### PR TITLE
fix: timeout might be due to dependency downloads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,2 @@
+run:
+  timeout: 4m


### PR DESCRIPTION
test PR to see if timeout is simply due to dependency download taking "too" long