### PR TITLE
chore: set gin to run in release mode in production

### DIFF
--- a/helm/data/values/prod/values.yaml
+++ b/helm/data/values/prod/values.yaml
@@ -8,6 +8,8 @@ serviceAccount:
 environment:
   ENVIRONMENT: prod
 
+  GIN_MODE: release
+
   USER_SERVICE_HOST: im-user-prod.instance-manager-prod.svc:8080
   USER_SERVICE_BASE_PATH: /
 


### PR DESCRIPTION
mainly influences logging right now. Usually such configurations can
also have performance implications if the framework authors also use
different middleware in debug than release modes.

is what you currently see after im-manager starts up
```
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
- using env: export GIN_MODE=release
- using code: gin.SetMode(gin.ReleaseMode)
```

https://github.com/gin-gonic/gin/blob/f2182de38c8d19d35d4b4191749216f12512f59c/mode.go#L16-L25
https://github.com/gin-gonic/gin/issues/2984