### PR TITLE
chore: Update dhis2 chart repo for dhis2* stacks

### DIFF
--- a/stacks/dhis2-core/helmfile.yaml
+++ b/stacks/dhis2-core/helmfile.yaml
@@ -1,8 +1,8 @@
 releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
-    chart: tons/dhis2-core
-    version: "{{ env "CHART_VERSION" | default "0.7.0" }}"
+    chart: dhis2/core
+    version: "{{ env "CHART_VERSION" | default "0.10.0" }}"
     values:
       - image:
           repository: dhis2/{{ env "IMAGE_REPOSITORY" | default "core" }}
@@ -44,5 +44,5 @@ releases:
           clientId: "{{ env "GOOGLE_AUTH_CLIENT_ID" | default "" }}"
 
 repositories:
-  - name: tons
-    url: https://helm-charts.fitfit.dk
+  - name: dhis2
+    url: https://dhis2-sre.github.io/dhis2-core-helm

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -2,8 +2,8 @@
 releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
-    chart: tons/dhis2-core
-    version: "{{ env "CHART_VERSION" | default "0.7.0" }}"
+    chart: dhis2/core
+    version: "{{ env "CHART_VERSION" | default "0.10.0" }}"
     values:
       - image:
           repository: dhis2/{{ env "IMAGE_REPOSITORY" | default "core" }}
@@ -124,7 +124,7 @@ releases:
 repositories:
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
-  - name: tons
-    url: https://helm-charts.fitfit.dk
+  - name: dhis2
+    url: https://dhis2-sre.github.io/dhis2-core-helm
   - name: runix
     url: https://helm.runix.net


### PR DESCRIPTION
Changing default `dhis2*` stacks chart repo to https://dhis2-sre.github.io/dhis2-core-helm/