### PR TITLE
feat: restart instances

### DIFF
--- a/helm/chart/templates/role.yaml
+++ b/helm/chart/templates/role.yaml
@@ -60,6 +60,15 @@ rules:
       - patch
       - delete
 
+# Restart an instance
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/scale
+    verbs:
+      - get
+      - update
+
 # PgAdmin
   - apiGroups:
       - networking.k8s.io

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -30,6 +30,7 @@ func GetEngine(basePath string, stackHandler stack.Handler, instanceHandler inst
 
 	tokenAuthenticationRouter.POST("/instances", instanceHandler.Create)
 	tokenAuthenticationRouter.POST("/instances/:id/deploy", instanceHandler.Deploy)
+	tokenAuthenticationRouter.POST("/instances/:id/restart", instanceHandler.Restart)
 	tokenAuthenticationRouter.GET("/instances/:id/parameters", instanceHandler.FindByIdWithDecryptedParameters)
 	tokenAuthenticationRouter.GET("/instances", instanceHandler.List)
 	tokenAuthenticationRouter.DELETE("/instances/:id", instanceHandler.Delete)

--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -20,6 +20,13 @@ type _ struct {
 	_ DeployInstanceRequest
 }
 
+// swagger:parameters restartInstance
+type _ struct {
+	// in: path
+	// required: true
+	ID uint `json:"id"`
+}
+
 // swagger:parameters instanceLogs
 type _ struct {
 	// in: path

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -124,8 +124,7 @@ func (h Handler) Restart(c *gin.Context) {
 	idParam := c.Param("id")
 	id, err := strconv.ParseUint(idParam, 10, 64)
 	if err != nil {
-		badRequest := apperror.NewBadRequest("error parsing id")
-		_ = c.Error(badRequest)
+		_ = c.AbortWithError(http.StatusBadRequest, fmt.Errorf("failed to parse id: %s", err))
 		return
 	}
 

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -106,6 +106,44 @@ func (h Handler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, savedInstance)
 }
 
+// Restart instance
+// swagger:route POST /instances/{id}/restart restartInstance
+//
+// Restart instance
+//
+// Security:
+//  oauth2:
+//
+// responses:
+//   202:
+//   401: Error
+//   403: Error
+//   404: Error
+//   415: Error
+func (h Handler) Restart(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.ParseUint(idParam, 10, 64)
+	if err != nil {
+		badRequest := apperror.NewBadRequest("error parsing id")
+		_ = c.Error(badRequest)
+		return
+	}
+
+	token, err := handler.GetTokenFromHttpAuthHeader(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	err = h.instanceService.Restart(token, uint(id))
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusAccepted)
+}
+
 type ParameterRequest struct {
 	StackParameter string `json:"stackParameter" binding:"required"`
 	Value          string `json:"value" binding:"required"`

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -43,6 +43,7 @@ func (k kubernetesService) CommandExecutor(cmd *exec.Cmd, configuration *models.
 		defer func(name string) {
 			err := os.Remove(name)
 			if err != nil {
+				// TODO ... What to do?
 			}
 		}(file.Name())
 

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -67,12 +67,10 @@ func (s service) Restart(token string, id uint) error {
 	}
 
 	err = s.kubernetesService.Executor(group.ClusterConfiguration, func(client *kubernetes.Clientset) error {
-		labelSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", instance.Name)
-		listOptions := metav1.ListOptions{
-			LabelSelector: labelSelector,
-		}
-
 		deployments := client.AppsV1().Deployments(instance.GroupName)
+
+		labelSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", instance.Name)
+		listOptions := metav1.ListOptions{LabelSelector: labelSelector}
 		deploymentList, err := deployments.List(context.TODO(), listOptions)
 		if err != nil {
 			return err

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -78,11 +78,10 @@ func (s service) Restart(token string, id uint) error {
 
 		items := deploymentList.Items
 		if len(items) > 1 {
-			return fmt.Errorf("multiple deployments found using the selector: %s", labelSelector)
+			return fmt.Errorf("multiple deployments found using the selector: %q", labelSelector)
 		}
-
 		if len(items) < 1 {
-			return fmt.Errorf("no deployment found using the selector: %s", labelSelector)
+			return fmt.Errorf("no deployment found using the selector: %q", labelSelector)
 		}
 
 		name := items[0].Name

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Service interface {
+	Restart(token string, id uint) error
 	Create(instance *model.Instance) (*model.Instance, error)
 	Deploy(token string, instance *model.Instance, group *models.Group) error
 	FindById(id uint) (*model.Instance, error)
@@ -52,6 +53,72 @@ func NewService(
 
 type userClientService interface {
 	FindGroupByName(token string, name string) (*models.Group, error)
+}
+
+func (s service) Restart(token string, id uint) error {
+	instance, err := s.FindById(id)
+	if err != nil {
+		return err
+	}
+
+	group, err := s.userClient.FindGroupByName(token, instance.GroupName)
+	if err != nil {
+		return err
+	}
+
+	err = s.kubernetesService.Executor(group.ClusterConfiguration, func(client *kubernetes.Clientset) error {
+		labelSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", instance.Name)
+		listOptions := metav1.ListOptions{
+			LabelSelector: labelSelector,
+		}
+
+		deployments := client.AppsV1().Deployments(instance.GroupName)
+		deploymentList, err := deployments.List(context.TODO(), listOptions)
+		if err != nil {
+			return err
+		}
+
+		items := deploymentList.Items
+		if len(items) > 1 {
+			return fmt.Errorf("multiple deployments found using the selector: %s", labelSelector)
+		}
+
+		if len(items) < 1 {
+			return fmt.Errorf("no deployment found using the selector: %s", labelSelector)
+		}
+
+		name := items[0].Name
+
+		// Scale down
+		deployment, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		replicas := deployment.Spec.Replicas
+		deployment.Spec.Replicas = 0
+
+		_, err = deployments.UpdateScale(context.TODO(), name, deployment, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Scale up
+		updatedDeployment, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		updatedDeployment.Spec.Replicas = replicas
+		_, err = deployments.UpdateScale(context.TODO(), name, updatedDeployment, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return err
 }
 
 func (s service) Create(instance *model.Instance) (*model.Instance, error) {

--- a/pkg/instance/ttlDestroyConsumer_test.go
+++ b/pkg/instance/ttlDestroyConsumer_test.go
@@ -60,6 +60,10 @@ type instanceService struct {
 	mock.Mock
 }
 
+func (is *instanceService) Restart(token string, id uint) error {
+	return nil
+}
+
 func (is *instanceService) Delete(token string, id uint) error {
 	args := is.Called(token, id)
 	return args.Error(0)

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTANCE_NAME=$1
+GROUP_NAME=$2
+
+INSTANCE_ID=$($HTTP --check-status "$INSTANCE_HOST/instances-name-to-id/$GROUP_NAME/$INSTANCE_NAME" "Authorization: Bearer $ACCESS_TOKEN")
+
+$HTTP post "$INSTANCE_HOST/instances/$INSTANCE_ID/restart" "Authorization: Bearer $ACCESS_TOKEN"

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -398,6 +398,30 @@ paths:
           $ref: '#/responses/Error'
       security:
       - oauth2: []
+  /instances/{id}/restart:
+    post:
+      description: Restart instance
+      operationId: restartInstance
+      parameters:
+      - format: uint64
+        in: path
+        name: id
+        required: true
+        type: integer
+        x-go-name: ID
+      responses:
+        "202":
+          description: ""
+        "401":
+          $ref: '#/responses/Error'
+        "403":
+          $ref: '#/responses/Error'
+        "404":
+          $ref: '#/responses/Error'
+        "415":
+          $ref: '#/responses/Error'
+      security:
+      - oauth2: []
   /instances/{id}/save:
     post:
       description: Save instance database


### PR DESCRIPTION
This PR allows us to restart instances

The following limitations exists
* Restart only works for deployments, not statefulsets and others
* The deployment needs to have the "app.kubernetes.io/instance" label
* Currently we can only restart whoami-go and dhis2-core instances (not pgadmin or postgresql databases, one is lacking the required label and the other is controlled by a statefulset and not a deployment)