### PR TITLE
fix: nack TTL messages containing invalid JSON

### DIFF
--- a/pkg/instance/ttlDestroyConsumer.go
+++ b/pkg/instance/ttlDestroyConsumer.go
@@ -41,6 +41,11 @@ func (c *ttlDestroyConsumer) Consume() error {
 
 		if err := json.Unmarshal(d.Body, &payload); err != nil {
 			log.Printf("Error unmarshalling ttl-destroy message: %v\n", err)
+			err := d.Nack(false, false)
+			if err != nil {
+				log.Printf("Error negatively acknowledging ttl-destroy message: %v\n", err)
+				return
+			}
 			return
 		}
 


### PR DESCRIPTION
as re-consuming them will never be successful