### PR TITLE
draft: review of kubernetes.go

### DIFF
--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -28,13 +28,11 @@ func NewKubernetesService() *kubernetesService {
 
 func (k kubernetesService) CommandExecutor(cmd *exec.Cmd, configuration *models.ClusterConfiguration) ([]byte, []byte, error) {
 	if len(configuration.KubernetesConfiguration) > 0 {
-		// Decrypt
 		kubernetesConfigurationInCleartext, err := k.decrypt(configuration.KubernetesConfiguration, "yaml")
 		if err != nil {
 			return nil, nil, err
 		}
 
-		// Create tmp file
 		file, err := ioutil.TempFile("", "kubectl")
 		if err != nil {
 			return nil, nil, err
@@ -47,7 +45,6 @@ func (k kubernetesService) CommandExecutor(cmd *exec.Cmd, configuration *models.
 			}
 		}(file.Name())
 
-		// Write configuration to file
 		_, err = file.Write(kubernetesConfigurationInCleartext)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
### Code suggestions

suggestions we already discussed, just for completeness
* declare interfaces where they are consumed
* shorter variable names https://go.dev/doc/effective_go#names

other suggestions
* declare vars as close to their usage as possible
* used named return to capture and return error in defer https://go.dev/blog/defer-panic-and-recover
* only use a method if the receiver is actually used. The receiver is syntactic sugar. Think of it as the first parameter.

  For example https://github.com/dhis2-sre/im-manager/blob/56ac69c890e58dc458fe827dd7e77d08d1086a09/pkg/instance/kubernetes.go#L118

CommandExecutor should thus also just be a function IMHO

### Discussion of behavior

* [Cmd.Run](https://pkg.go.dev/os/exec#Cmd.Run) _Run starts the specified command and waits for it to complete._ In case a helmfile sync/destroy command blocks, the request will be blocked. We might want to use [exec.CommandContext](https://pkg.go.dev/os/exec#CommandContext) instead.
* helm `--cleanup-on-fail` seems to be false by default https://helmfile.readthedocs.io/en/latest/#configuration Should we set it to true so resources are cleaned up if sync (upgrade) fails? See https://github.com/helm/helm/issues/7811 as the docs are not super clear