### PR TITLE
chore: adopt more go idioms in helmfile

### DIFF
--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -80,9 +80,8 @@ func (h helmfileService) loadStackParameters(stacksFolder string, stackName stri
 	environment := h.config.Environment
 	stackParametersPath := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", stacksFolder, stackName, environment)
 	data, err := os.ReadFile(stackParametersPath)
-	// TODO: Maybe not just return an empty struct on any given error
 	if err != nil {
-		return &StackParameters{}, nil
+		return nil, err
 	}
 
 	bytes, err := decryptYaml(data)

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -62,15 +62,15 @@ func (h helmfileService) executeHelmfileCommand(accessToken string, instance *mo
 		return nil, err
 	}
 
-	cmd := exec.Command("/usr/bin/helmfile", "--helm-binary", "/usr/bin/helm", "-f", stackPath, operation)
-	log.Printf("Command: %s\n", cmd.String())
-
 	stackParameters, err := h.loadStackParameters(stacksFolder, stack.Name)
 	if err != nil {
 		return nil, err
 	}
 
+	cmd := exec.Command("/usr/bin/helmfile", "--helm-binary", "/usr/bin/helm", "-f", stackPath, operation)
+	log.Printf("Command: %s\n", cmd.String())
 	h.configureInstanceEnvironment(accessToken, instance, group, stackParameters, cmd)
+
 	return cmd, nil
 }
 

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -76,26 +76,26 @@ func (h helmfileService) executeHelmfileCommand(accessToken string, instance *mo
 
 type StackParameters map[string]string
 
-func (h helmfileService) loadStackParameters(stacksFolder string, stackName string) (*StackParameters, error) {
+func (h helmfileService) loadStackParameters(folder string, name string) (*StackParameters, error) {
 	environment := h.config.Environment
-	stackParametersPath := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", stacksFolder, stackName, environment)
-	data, err := os.ReadFile(stackParametersPath)
+	path := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", folder, name, environment)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	bytes, err := decryptYaml(data)
+	b, err := decryptYaml(data)
 	if err != nil {
 		return nil, err
 	}
 
-	stackParameters := &StackParameters{}
-	err = yaml.Unmarshal(bytes, stackParameters)
+	params := &StackParameters{}
+	err = yaml.Unmarshal(b, params)
 	if err != nil {
 		return nil, err
 	}
 
-	return stackParameters, nil
+	return params, nil
 }
 
 func (h helmfileService) configureInstanceEnvironment(accessToken string, instance *model.Instance, group *models.Group, stackParameters *StackParameters, cmd *exec.Cmd) {

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -94,6 +94,7 @@ func (h helmfileService) loadStackParameters(stacksFolder string, stackName stri
 	if err != nil {
 		return nil, err
 	}
+
 	return stackParameters, nil
 }
 

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -69,14 +69,14 @@ func (h helmfileService) executeHelmfileCommand(accessToken string, instance *mo
 
 	cmd := exec.Command("/usr/bin/helmfile", "--helm-binary", "/usr/bin/helm", "-f", stackPath, operation)
 	log.Printf("Command: %s\n", cmd.String())
-	h.configureInstanceEnvironment(accessToken, instance, group, stackParameters, cmd)
+	configureInstanceEnvironment(accessToken, instance, group, stackParameters, cmd)
 
 	return cmd, nil
 }
 
 type StackParameters map[string]string
 
-func (h helmfileService) loadStackParameters(folder string, name string) (*StackParameters, error) {
+func (h helmfileService) loadStackParameters(folder string, name string) (StackParameters, error) {
 	environment := h.config.Environment
 	path := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", folder, name, environment)
 	data, err := os.ReadFile(path)
@@ -89,8 +89,8 @@ func (h helmfileService) loadStackParameters(folder string, name string) (*Stack
 		return nil, err
 	}
 
-	params := &StackParameters{}
-	err = yaml.Unmarshal(b, params)
+	var params StackParameters
+	err = yaml.Unmarshal(b, &params)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (*Stack
 	return params, nil
 }
 
-func (h helmfileService) configureInstanceEnvironment(accessToken string, instance *model.Instance, group *models.Group, stackParameters *StackParameters, cmd *exec.Cmd) {
+func configureInstanceEnvironment(accessToken string, instance *model.Instance, group *models.Group, stackParameters StackParameters, cmd *exec.Cmd) {
 	// TODO: We should only inject what the stack require, currently we just blindly inject IM_ACCESS_TOKEN and others which may not be required by the stack
 	// We could probably list the required system parameters in the stacks helmfile and parse those as well as other parameters
 	instanceNameEnv := fmt.Sprintf("%s=%s", "INSTANCE_NAME", instance.Name)
@@ -109,21 +109,21 @@ func (h helmfileService) configureInstanceEnvironment(accessToken string, instan
 	homeEnv := fmt.Sprintf("%s=%s", "HOME", "/tmp")
 	cmd.Env = append(cmd.Env, instanceNameEnv, instanceNamespaceEnv, instanceIdEnv, instanceHostnameEnv, homeEnv, imTokenEnv)
 
-	h.injectEnv("AWS_ACCESS_KEY_ID", &cmd.Env)
-	h.injectEnv("AWS_SECRET_ACCESS_KEY", &cmd.Env)
-	h.injectEnv("AWS_DEFAULT_REGION", &cmd.Env)
-	h.injectEnv("AWS_REGION", &cmd.Env)
-	h.injectEnv("AWS_ROLE_ARN", &cmd.Env)
-	h.injectEnv("AWS_WEB_IDENTITY_TOKEN_FILE", &cmd.Env)
+	cmd.Env = injectEnv(cmd.Env, "AWS_ACCESS_KEY_ID")
+	cmd.Env = injectEnv(cmd.Env, "AWS_SECRET_ACCESS_KEY")
+	cmd.Env = injectEnv(cmd.Env, "AWS_DEFAULT_REGION")
+	cmd.Env = injectEnv(cmd.Env, "AWS_REGION")
+	cmd.Env = injectEnv(cmd.Env, "AWS_ROLE_ARN")
+	cmd.Env = injectEnv(cmd.Env, "AWS_WEB_IDENTITY_TOKEN_FILE")
 
-	h.injectEnv("KUBERNETES_SERVICE_PORT", &cmd.Env)
-	h.injectEnv("KUBERNETES_PORT", &cmd.Env)
-	h.injectEnv("KUBERNETES_PORT_443_TCP_ADDR", &cmd.Env)
-	h.injectEnv("KUBERNETES_PORT_443_TCP_PORT", &cmd.Env)
-	h.injectEnv("KUBERNETES_PORT_443_TCP_PROTO", &cmd.Env)
-	h.injectEnv("KUBERNETES_PORT_443_TCP", &cmd.Env)
-	h.injectEnv("KUBERNETES_SERVICE_PORT_HTTPS", &cmd.Env)
-	h.injectEnv("KUBERNETES_SERVICE_HOST", &cmd.Env)
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_SERVICE_PORT")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_PORT")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_PORT_443_TCP_ADDR")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_PORT_443_TCP_PORT")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_PORT_443_TCP_PROTO")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_PORT_443_TCP")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_SERVICE_PORT_HTTPS")
+	cmd.Env = injectEnv(cmd.Env, "KUBERNETES_SERVICE_HOST")
 
 	for _, parameter := range instance.RequiredParameters {
 		instanceEnv := fmt.Sprintf("%s=%s", parameter.StackRequiredParameter.Name, parameter.Value)
@@ -135,17 +135,19 @@ func (h helmfileService) configureInstanceEnvironment(accessToken string, instan
 		cmd.Env = append(cmd.Env, instanceEnv)
 	}
 
-	for parameter, value := range *stackParameters {
+	for parameter, value := range stackParameters {
 		instanceEnv := fmt.Sprintf("%s=%s", parameter, value)
 		cmd.Env = append(cmd.Env, instanceEnv)
 	}
 }
 
-func (h helmfileService) injectEnv(env string, envs *[]string) {
+func injectEnv(envs []string, env string) []string {
 	if value, exists := os.LookupEnv(env); exists {
 		cmdEnv := fmt.Sprintf("%s=%s", env, value)
-		*envs = append(*envs, cmdEnv)
+		envs = append(envs, cmdEnv)
 	} else {
 		log.Println("WARNING!!! Env not found:", env)
 	}
+
+	return envs
 }


### PR DESCRIPTION
* shorter variable names https://go.dev/doc/effective_go#names
* only export what is used outside of the declaring package for example `StackParameters`
* declare vars as close to their usage as possible for example `cmd`. Improves readability and potentially saves work in case of an errors between declaration and use.
* only use a method if the receiver is actually used. The receiver is syntactic sugar. Think of it as the first parameter.
* fix loadStackParameters as it did not return an error in case of an error in `os.ReadFile(path)`
* return nil for pointers in case of error like

```go
if err != nil {
    return nil, err
}
```
* slices and maps are already using pointer semantics meaning the underlying array/map is shared. We should not use `*[]string` or `*map[string]string`. Example

https://github.com/dhis2-sre/im-manager/blob/56ac69c890e58dc458fe827dd7e77d08d1086a09/pkg/instance/helmfile.go#L79-L81