### PR TITLE
chore: dockerignore scripts, mardown, ...

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,12 @@
-helm/
+.env
+.env.example
+.envrc
+.git
+.github
+.gitignore
+.golangci.yml
+helm
+Makefile
+*.md
+.pre-commit-config.yaml
+scripts


### PR DESCRIPTION
which is honored by skaffold. So skaffold will not auto-redeploy if we
change for example a .env file in scripts to target a different
environment