### PR TITLE
Fix/missing stack parameters

### DIFF
--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -78,7 +78,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (stackP
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return stackParameters{}, err
+			return stackParameters{}, nil
 		}
 		return nil, err
 	}

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -78,7 +78,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (stackP
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return stackParameters{}, nil
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -69,9 +69,9 @@ func (h helmfileService) executeHelmfileCommand(accessToken string, instance *mo
 	return cmd, nil
 }
 
-type StackParameters map[string]string
+type stackParameters map[string]string
 
-func (h helmfileService) loadStackParameters(folder string, name string) (StackParameters, error) {
+func (h helmfileService) loadStackParameters(folder string, name string) (stackParameters, error) {
 	environment := h.config.Environment
 	path := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", folder, name, environment)
 	data, err := os.ReadFile(path)
@@ -84,7 +84,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (StackP
 		return nil, err
 	}
 
-	var params StackParameters
+	var params stackParameters
 	err = yaml.Unmarshal(b, &params)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (StackP
 	return params, nil
 }
 
-func configureInstanceEnvironment(accessToken string, instance *model.Instance, group *models.Group, stackParameters StackParameters, cmd *exec.Cmd) {
+func configureInstanceEnvironment(accessToken string, instance *model.Instance, group *models.Group, stackParameters stackParameters, cmd *exec.Cmd) {
 	// TODO: We should only inject what the stack require, currently we just blindly inject IM_ACCESS_TOKEN and others which may not be required by the stack
 	// We could probably list the required system parameters in the stacks helmfile and parse those as well as other parameters
 	instanceNameEnv := fmt.Sprintf("%s=%s", "INSTANCE_NAME", instance.Name)

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -3,7 +3,6 @@ package instance
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -78,8 +77,7 @@ func (h helmfileService) loadStackParameters(folder string, name string) (stackP
 	path := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", folder, name, environment)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		var e *fs.PathError
-		if errors.As(err, &e) {
+		if errors.Is(err, os.ErrNotExist) {
 			return stackParameters{}, err
 		}
 		return nil, err

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -1,7 +1,9 @@
 package instance
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -76,6 +78,10 @@ func (h helmfileService) loadStackParameters(folder string, name string) (stackP
 	path := fmt.Sprintf("%s/%s/parameters/%s/parameters.yaml", folder, name, environment)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		var e *fs.PathError
+		if errors.As(err, &e) {
+			return stackParameters{}, err
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
I noticed we could unexport StackParameters and included it here but the main focus should be [this](https://github.com/dhis2-sre/im-manager/compare/fix/missing-stack-parameters?expand=1#diff-136f6c444b77ece1ba158828d1f341f38c90c4097dae5da04ed558e3fd695ef8R81).
