### PR TITLE
chore: separate parsing from CRUD

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -61,7 +61,7 @@ func run() error {
 	helmfileSvc := instance.NewHelmfileService(stackSvc, cfg)
 	instanceSvc := instance.NewService(cfg, instanceRepo, uc, stackSvc, kubernetesSvc, helmfileSvc)
 
-	err = stack.LoadStacks(stackSvc)
+	err = stack.LoadStacks("./stacks", stackSvc)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
stack templates can have many configurations/permutations that we should test. parsing stack templates is easier to test in isolation by
separating it from the CRUD operations.

This change highlights that we can merge the 2 DB transactions Create/Save into a single one. We might even be able to only use 1 DB transaction to create a stack with its required/optional parameters. This prevents stacks from potentially being in an illegal state in case any of the current 4 transactions fails.

Parsing the stacks before any crud operation also lets us fail
starting the instance manager early. So no stack with a template that
cannot be parsed will even be created.