### PR TITLE
chore: remove redundant operations in restart

### DIFF
--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -286,7 +286,7 @@ func (h Handler) Restart(c *gin.Context) {
 		return
 	}
 
-	err = h.instanceService.Restart(token, instance.ID)
+	err = h.instanceService.Restart(token, instance)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -21,7 +21,7 @@ import (
 
 type Service interface {
 	ConsumeParameters(source, destination *model.Instance) error
-	Restart(token string, id uint) error
+	Restart(token string, instance *model.Instance) error
 	Save(instance *model.Instance) (*model.Instance, error)
 	Deploy(token string, instance *model.Instance) error
 	FindById(id uint) (*model.Instance, error)
@@ -146,12 +146,7 @@ func (s service) findParameterValue(parameter string, sourceInstance *model.Inst
 	return "", fmt.Errorf("unable to find value for parameter: %s", parameter)
 }
 
-func (s service) Restart(token string, id uint) error {
-	instance, err := s.FindById(id)
-	if err != nil {
-		return err
-	}
-
+func (s service) Restart(token string, instance *model.Instance) error {
 	group, err := s.userClient.FindGroupByName(token, instance.GroupName)
 	if err != nil {
 		return err

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -173,27 +173,22 @@ func (s service) Restart(token string, instance *model.Instance) error {
 		name := items[0].Name
 
 		// Scale down
-		deployment, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
+		scale, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		replicas := deployment.Spec.Replicas
-		deployment.Spec.Replicas = 0
+		replicas := scale.Spec.Replicas
+		scale.Spec.Replicas = 0
 
-		_, err = deployments.UpdateScale(context.TODO(), name, deployment, metav1.UpdateOptions{})
+		updatedScale, err := deployments.UpdateScale(context.TODO(), name, scale, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
 
 		// Scale up
-		updatedDeployment, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-
-		updatedDeployment.Spec.Replicas = replicas
-		_, err = deployments.UpdateScale(context.TODO(), name, updatedDeployment, metav1.UpdateOptions{})
+		updatedScale.Spec.Replicas = replicas
+		_, err = deployments.UpdateScale(context.TODO(), name, updatedScale, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/instance/ttlDestroyConsumer_test.go
+++ b/pkg/instance/ttlDestroyConsumer_test.go
@@ -72,7 +72,7 @@ func (is *instanceService) Link(source, destination *model.Instance) error {
 	return nil
 }
 
-func (is *instanceService) Restart(token string, id uint) error {
+func (is *instanceService) Restart(token string, instance *model.Instance) error {
 	return nil
 }
 


### PR DESCRIPTION
* we already have the instance so no need to `s.FindById(id)` again in the instance service
* updating the scale object already returns it so we do not need to get it again
