### PR TITLE
chore: move kubernetes domain into kube service

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -57,9 +57,8 @@ func run() error {
 
 	instanceRepo := instance.NewRepository(db, cfg)
 	uc := userClient.New(cfg.UserService.Host, cfg.UserService.BasePath)
-	kubernetesSvc := instance.NewKubernetesService()
 	helmfileSvc := instance.NewHelmfileService(stackSvc, cfg)
-	instanceSvc := instance.NewService(cfg, instanceRepo, uc, stackSvc, kubernetesSvc, helmfileSvc)
+	instanceSvc := instance.NewService(cfg, instanceRepo, uc, stackSvc, helmfileSvc)
 
 	err = stack.LoadStacks("./stacks", stackSvc)
 	if err != nil {

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -2,25 +2,37 @@ package instance
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-user/swagger/sdk/models"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-type kubernetesService struct{}
-
-func NewKubernetesService() *kubernetesService {
-	return &kubernetesService{}
+type kubernetesService struct {
+	client *kubernetes.Clientset
 }
 
-func (k kubernetesService) commandExecutor(cmd *exec.Cmd, configuration *models.ClusterConfiguration) (stdout []byte, stderr []byte, err error) {
+func NewKubernetesService(config *models.ClusterConfiguration) (*kubernetesService, error) {
+	client, err := newClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating kube client: %v", err)
+	}
+
+	return &kubernetesService{client: client}, nil
+}
+
+func commandExecutor(cmd *exec.Cmd, configuration *models.ClusterConfiguration) (stdout []byte, stderr []byte, err error) {
 	if len(configuration.KubernetesConfiguration) == 0 {
 		return runCommand(cmd)
 	}
@@ -111,10 +123,83 @@ func newClient(configuration *models.ClusterConfiguration) (*kubernetes.Clientse
 	return client, nil
 }
 
-func (k kubernetesService) executor(configuration *models.ClusterConfiguration, fn func(client *kubernetes.Clientset) error) error {
-	client, err := newClient(configuration)
+func (ks kubernetesService) getLogs(instance *model.Instance, selector string) (io.ReadCloser, error) {
+	pod, err := ks.getPod(instance, selector)
 	if err != nil {
-		return fmt.Errorf("error creating kube client: %v", err)
+		return nil, err
 	}
-	return fn(client)
+
+	podLogOptions := v1.PodLogOptions{
+		Follow: true,
+	}
+
+	return ks.client.
+		CoreV1().
+		Pods(pod.Namespace).
+		GetLogs(pod.Name, &podLogOptions).
+		Stream(context.TODO())
+}
+
+func (ks kubernetesService) getPod(instance *model.Instance, selector string) (v1.Pod, error) {
+	var labelSelector string
+	if selector == "" {
+		labelSelector = fmt.Sprintf("im-id=%d", instance.ID)
+	} else {
+		labelSelector = fmt.Sprintf("im-%s-id=%d", selector, instance.ID)
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	podList, err := ks.client.CoreV1().Pods("").List(context.TODO(), listOptions)
+	if err != nil {
+		return v1.Pod{}, fmt.Errorf("error getting pod for instance %d and selector %q: %v", instance.ID, selector, err)
+	}
+
+	if len(podList.Items) > 1 {
+		return v1.Pod{}, fmt.Errorf("multiple pods found using the selector: %q", labelSelector)
+	}
+
+	return podList.Items[0], nil
+}
+
+func (ks kubernetesService) restart(instance *model.Instance) error {
+	deployments := ks.client.AppsV1().Deployments(instance.GroupName)
+	labelSelector := fmt.Sprintf("app.kubernetes.io/instance=%s", instance.Name)
+	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
+	deploymentList, err := deployments.List(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+
+	items := deploymentList.Items
+	if len(items) > 1 {
+		return fmt.Errorf("multiple deployments found using the selector: %q", labelSelector)
+	}
+	if len(items) < 1 {
+		return fmt.Errorf("no deployment found using the selector: %q", labelSelector)
+	}
+
+	name := items[0].Name
+
+	// Scale down
+	scale, err := deployments.GetScale(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	replicas := scale.Spec.Replicas
+	scale.Spec.Replicas = 0
+
+	updatedScale, err := deployments.UpdateScale(context.TODO(), name, scale, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Scale up
+	updatedScale.Spec.Replicas = replicas
+	_, err = deployments.UpdateScale(context.TODO(), name, updatedScale, metav1.UpdateOptions{})
+
+	return err
 }


### PR DESCRIPTION
The instance service is doing too many low level kubernetes things IMHO 😄 The kubernetes service can be our higher level client to kubernetes APIs we use. Practically this means that I would try to have only kubernetes.go depend on `k8s.io` things.

Separating these changes from the pausing feature will make those changes easier to read.