### PR TITLE
chore: consistently label all stack resources

### DIFF
--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -44,6 +44,7 @@ type _ struct {
 	// in: query
 	// required: false
 	// type: string
+	// description: stream logs of a specific pod labeled with im-type=<selector>
 	Selector string `json:"selector"`
 }
 

--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -32,6 +32,13 @@ type _ struct {
 	// in: path
 	// required: true
 	ID uint `json:"id"`
+
+	// selector
+	// in: query
+	// required: false
+	// type: string
+	// description: restart a specific deployment labeled with im-type=<selector>
+	Selector string `json:"selector"`
 }
 
 // swagger:parameters instanceLogs

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -342,7 +342,8 @@ func (h Handler) Restart(c *gin.Context) {
 		return
 	}
 
-	err = h.instanceService.Restart(token, instance)
+	selector := c.Query("selector")
+	err = h.instanceService.Restart(token, instance, selector)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -526,14 +526,6 @@ func (h Handler) Logs(c *gin.Context) {
 		return
 	}
 
-	selector := c.Query("selector")
-	// We currently only support streaming of logs from DHIS2 and the database. And we want to make sure logs from any other pods are off limit
-	if selector != "" && selector != "data" {
-		badRequest := apperror.NewBadRequest("selector can only be empty or \"data\"")
-		_ = c.Error(badRequest)
-		return
-	}
-
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
 		_ = c.Error(err)
@@ -565,6 +557,7 @@ func (h Handler) Logs(c *gin.Context) {
 		_ = c.Error(err)
 	}
 
+	selector := c.Query("selector")
 	r, err := h.instanceService.Logs(instance, group, selector)
 	if err != nil {
 		conflict := apperror.NewConflict(err.Error())

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -18,7 +18,7 @@ import (
 type Service interface {
 	ConsumeParameters(source, destination *model.Instance) error
 	Pause(token string, instance *model.Instance) error
-	Restart(token string, instance *model.Instance) error
+	Restart(token string, instance *model.Instance, typeSelector string) error
 	Save(instance *model.Instance) (*model.Instance, error)
 	Deploy(token string, instance *model.Instance) error
 	FindById(id uint) (*model.Instance, error)
@@ -149,7 +149,7 @@ func (s service) Pause(token string, instance *model.Instance) error {
 	return ks.pause(instance)
 }
 
-func (s service) Restart(token string, instance *model.Instance) error {
+func (s service) Restart(token string, instance *model.Instance, typeSelector string) error {
 	group, err := s.userClient.FindGroupByName(token, instance.GroupName)
 	if err != nil {
 		return err
@@ -160,7 +160,7 @@ func (s service) Restart(token string, instance *model.Instance) error {
 		return err
 	}
 
-	return ks.restart(instance)
+	return ks.restart(instance, typeSelector)
 }
 
 func (s service) Link(source, destination *model.Instance) error {

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -25,7 +25,7 @@ type Service interface {
 	FindByIdDecrypted(id uint) (*model.Instance, error)
 	FindByNameAndGroup(instance string, group string) (*model.Instance, error)
 	Delete(token string, id uint) error
-	Logs(instance *model.Instance, group *models.Group, selector string) (io.ReadCloser, error)
+	Logs(instance *model.Instance, group *models.Group, typeSelector string) (io.ReadCloser, error)
 	FindInstances(groups []*models.Group) ([]*model.Instance, error)
 	Link(source, destination *model.Instance) error
 }
@@ -257,13 +257,13 @@ func (s service) Delete(token string, id uint) error {
 	return s.instanceRepository.Delete(id)
 }
 
-func (s service) Logs(instance *model.Instance, group *models.Group, selector string) (io.ReadCloser, error) {
+func (s service) Logs(instance *model.Instance, group *models.Group, typeSelector string) (io.ReadCloser, error) {
 	ks, err := NewKubernetesService(group.ClusterConfiguration)
 	if err != nil {
 		return nil, err
 	}
 
-	return ks.getLogs(instance, selector)
+	return ks.getLogs(instance, typeSelector)
 }
 
 func (s service) FindById(id uint) (*model.Instance, error) {

--- a/pkg/instance/ttlDestroyConsumer_test.go
+++ b/pkg/instance/ttlDestroyConsumer_test.go
@@ -76,7 +76,7 @@ func (is *instanceService) Pause(token string, instance *model.Instance) error {
 	return nil
 }
 
-func (is *instanceService) Restart(token string, instance *model.Instance) error {
+func (is *instanceService) Restart(token string, instance *model.Instance, typeSelector string) error {
 	return nil
 }
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -6,7 +6,8 @@ source ./auth.sh
 
 GROUP=$1
 NAME=$2
+SELECTOR=${3:-""}
 
 INSTANCE_ID=$($HTTP get "$INSTANCE_HOST/instances-name-to-id/$GROUP/$NAME" "Authorization: Bearer $ACCESS_TOKEN")
 
-$HTTP put "$INSTANCE_HOST/instances/$INSTANCE_ID/restart" "Authorization: Bearer $ACCESS_TOKEN"
+$HTTP put "$INSTANCE_HOST/instances/$INSTANCE_ID/restart?selector=$SELECTOR" "Authorization: Bearer $ACCESS_TOKEN"

--- a/stacks/dhis2-core/helmfile.yaml
+++ b/stacks/dhis2-core/helmfile.yaml
@@ -5,7 +5,7 @@ releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
     chart: dhis2/core
-    version: "{{ env "CHART_VERSION" | default "0.10.1" }}"
+    version: "{{ env "CHART_VERSION" | default "0.11.3" }}"
     values:
       - image:
           repository: dhis2/{{ env "IMAGE_REPOSITORY" | default "core" }}
@@ -25,9 +25,11 @@ releases:
           path: /{{ requiredEnv "INSTANCE_NAME" }}
       - readinessProbe:
           path: /{{ requiredEnv "INSTANCE_NAME" }}
-      - podLabels:
+      - commonLabels:
           im: "true"
+          im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "dhis2"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/stacks/dhis2-db/helmfile.yaml
+++ b/stacks/dhis2-db/helmfile.yaml
@@ -7,12 +7,14 @@ releases:
     version: "{{ env "CHART_VERSION" | default "11.0.4" }}"
     verify: false
     values:
-      - primary:
-          podLabels:
-            im: "true"
-            im-id: "{{ requiredEnv "INSTANCE_ID" }}"
-            im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
+      - commonLabels:
+          im: "true"
+          im-default: "true"
+          im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "db"
+          im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
+      - primary:
           extraEnvVars:
             - name: DATABASE_MANAGER_URL
               value: {{ requiredEnv "DATABASE_MANAGER_URL" }}

--- a/stacks/dhis2-db/helmfile.yaml
+++ b/stacks/dhis2-db/helmfile.yaml
@@ -1,4 +1,4 @@
-# hostnamePattern: %s-postgresql.%s.svc
+# hostnamePattern: %s-database-postgresql.%s.svc
 # stackParameters: DATABASE_MANAGER_URL
 releases:
   - name: {{ requiredEnv "INSTANCE_NAME" }}-database

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -3,7 +3,7 @@ releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
     chart: dhis2/core
-    version: "{{ env "CHART_VERSION" | default "0.10.1" }}"
+    version: "{{ env "CHART_VERSION" | default "0.11.3" }}"
     values:
       - image:
           repository: dhis2/{{ env "IMAGE_REPOSITORY" | default "core" }}
@@ -24,9 +24,11 @@ releases:
           path: /{{ requiredEnv "INSTANCE_NAME" }}
       - readinessProbe:
           path: /{{ requiredEnv "INSTANCE_NAME" }}
-      - podLabels:
+      - commonLabels:
           im: "true"
+          im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "dhis2"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect
@@ -53,10 +55,11 @@ releases:
     version: 11.0.4
     verify: false
     values:
-      - primary:
-          podLabels:
-            im-data-id: "{{ requiredEnv "INSTANCE_ID" }}"
+      - commonLabels:
+          im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "db"
 
+      - primary:
           extraEnvVars:
             - name: DATABASE_MANAGER_URL
               value: {{ requiredEnv "DATABASE_MANAGER_URL" }}
@@ -93,6 +96,9 @@ releases:
     version: "{{ env "PGADMIN_CHART_VERSION" | default "1.9.10" }}"
     installed: {{ env "PGADMIN_INSTALL" | default "false" }}
     values:
+      - podLabels:
+          im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "pgadmin"
       - ingress:
           enabled: true
           hosts:

--- a/stacks/im-job-runner/helmfile.yaml
+++ b/stacks/im-job-runner/helmfile.yaml
@@ -8,7 +8,9 @@ releases:
           pullPolicy: Always
       - podLabels:
           im: "true"
+          im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "job"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - command: "{{ requiredEnv "COMMAND" }}"
       - payload: "{{ env "PAYLOAD" | default "-" }}"

--- a/stacks/pgadmin/helmfile.yaml
+++ b/stacks/pgadmin/helmfile.yaml
@@ -8,7 +8,9 @@ releases:
     values:
       - podLabels:
           im: "true"
+          im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "pgadmin"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
       - ingress:

--- a/stacks/whoami-go/helmfile.yaml
+++ b/stacks/whoami-go/helmfile.yaml
@@ -12,7 +12,9 @@ releases:
           certIssuer: cert-issuer-prod
       - podLabels:
           im: "true"
+          im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "whoami"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
 repositories:

--- a/swagger/sdk/client/operations/restart_instance_parameters.go
+++ b/swagger/sdk/client/operations/restart_instance_parameters.go
@@ -65,6 +65,12 @@ type RestartInstanceParams struct {
 	// Format: uint64
 	ID uint64
 
+	/* Selector.
+
+	   selector
+	*/
+	Selector *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -129,6 +135,17 @@ func (o *RestartInstanceParams) SetID(id uint64) {
 	o.ID = id
 }
 
+// WithSelector adds the selector to the restart instance params
+func (o *RestartInstanceParams) WithSelector(selector *string) *RestartInstanceParams {
+	o.SetSelector(selector)
+	return o
+}
+
+// SetSelector adds the selector to the restart instance params
+func (o *RestartInstanceParams) SetSelector(selector *string) {
+	o.Selector = selector
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *RestartInstanceParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -140,6 +157,23 @@ func (o *RestartInstanceParams) WriteToRequest(r runtime.ClientRequest, reg strf
 	// path param id
 	if err := r.SetPathParam("id", swag.FormatUint64(o.ID)); err != nil {
 		return err
+	}
+
+	if o.Selector != nil {
+
+		// query param selector
+		var qrSelector string
+
+		if o.Selector != nil {
+			qrSelector = *o.Selector
+		}
+		qSelector := qrSelector
+		if qSelector != "" {
+
+			if err := r.SetQueryParam("selector", qSelector); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -473,6 +473,11 @@ paths:
                   required: true
                   type: integer
                   x-go-name: ID
+                - description: selector
+                  in: query
+                  name: selector
+                  type: string
+                  x-go-name: Selector
             responses:
                 "202":
                     description: ""


### PR DESCRIPTION
at least all the resources we have control over. the pgAdmin helm chart only allows us to label pods and not deployments for example.

* return an error when trying to stream logs using a type selector that does not exist in the instances stack. Example `no pod found using the selector: "im-id=52,im-type=dff"`