### PR TITLE
feat: Add optional Redis release to dhis2 stack

### DIFF
--- a/scripts/deploy-dhis2.sh
+++ b/scripts/deploy-dhis2.sh
@@ -17,7 +17,7 @@ IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-core}
 IMAGE_TAG=${IMAGE_TAG:-2.39.0}
 IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
 DATABASE_SIZE=${DATABASE_SIZE:-30Gi}
-PGADMIN_INSTALL=${PGADMIN_INSTALL:-false}
+INSTALL_PGADMIN=${INSTALL_PGADMIN:-false}
 INSTALL_REDIS=${INSTALL_REDIS:-false}
 DATABASE_ID=${DATABASE_ID:-1}
 INSTANCE_TTL=${INSTANCE_TTL:-""}
@@ -52,8 +52,8 @@ echo "{
       \"value\": \"$DATABASE_SIZE\"
     },
     {
-      \"name\": \"PGADMIN_INSTALL\",
-      \"value\": \"$PGADMIN_INSTALL\"
+      \"name\": \"INSTALL_PGADMIN\",
+      \"value\": \"$INSTALL_PGADMIN\"
     },
     {
       \"name\": \"INSTALL_REDIS\",

--- a/scripts/deploy-dhis2.sh
+++ b/scripts/deploy-dhis2.sh
@@ -18,6 +18,7 @@ IMAGE_TAG=${IMAGE_TAG:-2.39.0}
 IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
 DATABASE_SIZE=${DATABASE_SIZE:-30Gi}
 PGADMIN_INSTALL=${PGADMIN_INSTALL:-false}
+INSTALL_REDIS=${INSTALL_REDIS:-false}
 DATABASE_ID=${DATABASE_ID:-1}
 INSTANCE_TTL=${INSTANCE_TTL:-""}
 
@@ -53,6 +54,10 @@ echo "{
     {
       \"name\": \"PGADMIN_INSTALL\",
       \"value\": \"$PGADMIN_INSTALL\"
+    },
+    {
+      \"name\": \"INSTALL_REDIS\",
+      \"value\": \"$INSTALL_REDIS\"
     },
     {
        \"name\": \"INSTANCE_TTL\",

--- a/scripts/update-dhis2.sh
+++ b/scripts/update-dhis2.sh
@@ -17,7 +17,7 @@ IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-core}
 IMAGE_TAG=${IMAGE_TAG:-2.39.0}
 IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
 DATABASE_SIZE=${DATABASE_SIZE:-30Gi}
-PGADMIN_INSTALL=${PGADMIN_INSTALL:-false}
+INSTALL_PGADMIN=${INSTALL_PGADMIN:-false}
 INSTALL_REDIS=${INSTALL_REDIS:-false}
 DATABASE_ID=${DATABASE_ID:-1}
 INSTANCE_TTL=${INSTANCE_TTL:-""}
@@ -51,8 +51,8 @@ echo "{
       \"value\": \"$DATABASE_SIZE\"
     },
     {
-      \"name\": \"PGADMIN_INSTALL\",
-      \"value\": \"$PGADMIN_INSTALL\"
+      \"name\": \"INSTALL_PGADMIN\",
+      \"value\": \"$INSTALL_PGADMIN\"
     },
     {
       \"name\": \"INSTALL_REDIS\",

--- a/scripts/update-dhis2.sh
+++ b/scripts/update-dhis2.sh
@@ -18,6 +18,7 @@ IMAGE_TAG=${IMAGE_TAG:-2.39.0}
 IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
 DATABASE_SIZE=${DATABASE_SIZE:-30Gi}
 PGADMIN_INSTALL=${PGADMIN_INSTALL:-false}
+INSTALL_REDIS=${INSTALL_REDIS:-false}
 DATABASE_ID=${DATABASE_ID:-1}
 INSTANCE_TTL=${INSTANCE_TTL:-""}
 
@@ -52,6 +53,10 @@ echo "{
     {
       \"name\": \"PGADMIN_INSTALL\",
       \"value\": \"$PGADMIN_INSTALL\"
+    },
+    {
+      \"name\": \"INSTALL_REDIS\",
+      \"value\": \"$INSTALL_REDIS\"
     },
     {
        \"name\": \"INSTANCE_TTL\",

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -102,7 +102,7 @@ releases:
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
     chart: runix/pgadmin4
     version: "{{ env "PGADMIN_CHART_VERSION" | default "1.9.10" }}"
-    installed: {{ env "PGADMIN_INSTALL" | default "false" }}
+    installed: {{ env "INSTALL_PGADMIN" | default "false" }}
     values:
       - podLabels:
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -45,6 +45,11 @@ releases:
           server.base.url = https://{{ requiredEnv "INSTANCE_HOSTNAME" }}/{{ requiredEnv "INSTANCE_NAME" }}
           flyway.migrate_out_of_order = {{ env "FLYWAY_MIGRATE_OUT_OF_ORDER" | default false }}
           flyway.repair_before_migration = {{ env "FLYWAY_REPAIR_BEFORE_MIGRATION" | default false }}
+          {{- if eq (env "INSTALL_REDIS" | default "false") "true" }}
+          redis.enabled = on
+          redis.host = {{ requiredEnv "INSTANCE_NAME" }}-redis-master.{{ requiredEnv "INSTANCE_NAMESPACE" }}.svc
+          redis.port = 6379
+          {{ end }}
       - googleAuth:
           projectId: "{{ env "GOOGLE_AUTH_PROJECT_ID" | default "" }}"
           privateKeyId: "{{ env "GOOGLE_AUTH_PRIVATE_KEY_ID" | default "" }}"
@@ -132,6 +137,17 @@ releases:
               Host: {{ requiredEnv "INSTANCE_NAME" }}-database-postgresql.{{ requiredEnv "INSTANCE_NAMESPACE" }}.svc
               SSLMode: prefer
               MaintenanceDB: {{ env "DATABASE_NAME" | default "dhis2" }}
+
+  - name: {{ requiredEnv "INSTANCE_NAME" }}-redis
+    namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
+    chart: bitnami/redis
+    version: 17.3.11
+    verify: false
+    installed: {{ env "INSTALL_REDIS" | default "false" }}
+    values:
+      - architecture: standalone
+      - auth:
+          enabled: false
 
 repositories:
   - name: bitnami


### PR DESCRIPTION
Adding an option to install Redis in the monolith `dhis2` stack, so that it can be used as a [data store](https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-master/installation.html#install_cluster_configuration_redis) for system tasks (and other things like user sessions, system settings, etc) instead of storing them in-memory.


And substituting `PGADMIN_INSTALL` for `INSTALL_PGADMIN`.