### PR TITLE
chore: label stack pods with creation timestamp

### DIFF
--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 
@@ -106,7 +107,8 @@ func configureInstanceEnvironment(accessToken string, instance *model.Instance, 
 	instanceHostnameEnv := fmt.Sprintf("%s=%s", "INSTANCE_HOSTNAME", group.Hostname)
 	imTokenEnv := fmt.Sprintf("%s=%s", "IM_ACCESS_TOKEN", accessToken)
 	homeEnv := fmt.Sprintf("%s=%s", "HOME", "/tmp")
-	cmd.Env = append(cmd.Env, instanceNameEnv, instanceNamespaceEnv, instanceIdEnv, instanceHostnameEnv, homeEnv, imTokenEnv)
+	imCreationTimestamp := fmt.Sprintf("%s=%d", "INSTANCE_CREATION_TIMESTAMP", time.Now().Unix())
+	cmd.Env = append(cmd.Env, instanceNameEnv, instanceNamespaceEnv, instanceIdEnv, instanceHostnameEnv, imTokenEnv, homeEnv, imCreationTimestamp)
 
 	cmd.Env = injectEnv(cmd.Env, "AWS_ACCESS_KEY_ID")
 	cmd.Env = injectEnv(cmd.Env, "AWS_SECRET_ACCESS_KEY")

--- a/pkg/stack/loader.go
+++ b/pkg/stack/loader.go
@@ -205,7 +205,7 @@ func inSlice(str string, strings []string) bool {
 }
 
 func getSystemParameters() []string {
-	parameters := []string{"INSTANCE_ID", "INSTANCE_NAME", "INSTANCE_HOSTNAME", "INSTANCE_NAMESPACE", "IM_ACCESS_TOKEN"}
+	parameters := []string{"INSTANCE_ID", "INSTANCE_NAME", "INSTANCE_HOSTNAME", "INSTANCE_NAMESPACE", "IM_ACCESS_TOKEN", "INSTANCE_CREATION_TIMESTAMP"}
 	sort.Strings(parameters)
 	return parameters
 }

--- a/scripts/deploy-whoami-ttl.sh
+++ b/scripts/deploy-whoami-ttl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./auth.sh
+
+STACK=whoami-go
+
+GROUP=$1
+NAME=$2
+TTL=${3:-""}
+CHART_VERSION=${CHART_VERSION:-0.9.0}
+IMAGE_TAG=${IMAGE_TAG:-0.6.0}
+
+echo "{
+  \"name\": \"$NAME\",
+  \"groupName\": \"$GROUP\",
+  \"stackName\": \"$STACK\",
+  \"optionalParameters\": [
+    {
+      \"name\": \"CHART_VERSION\",
+      \"value\": \"$CHART_VERSION\"
+    },
+    {
+      \"name\": \"IMAGE_TAG\",
+      \"value\": \"$IMAGE_TAG\"
+    },
+    {
+      \"name\": \"INSTANCE_TTL\",
+      \"value\": \"$TTL\"
+    }
+  ]
+}" | $HTTP post "$INSTANCE_HOST/instances" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/deploy-whoami-ttl.sh
+++ b/scripts/deploy-whoami-ttl.sh
@@ -8,7 +8,7 @@ STACK=whoami-go
 
 GROUP=$1
 NAME=$2
-TTL=${3:-""}
+TTL=${3:-300}
 CHART_VERSION=${CHART_VERSION:-0.9.0}
 IMAGE_TAG=${IMAGE_TAG:-0.6.0}
 

--- a/stacks/dhis2-core/helmfile.yaml
+++ b/stacks/dhis2-core/helmfile.yaml
@@ -35,6 +35,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "dhis2"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/stacks/dhis2-core/helmfile.yaml
+++ b/stacks/dhis2-core/helmfile.yaml
@@ -35,7 +35,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "dhis2"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/stacks/dhis2-db/helmfile.yaml
+++ b/stacks/dhis2-db/helmfile.yaml
@@ -12,6 +12,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "db"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
       - primary:

--- a/stacks/dhis2-db/helmfile.yaml
+++ b/stacks/dhis2-db/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "db"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
       - primary:

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -33,7 +33,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "dhis2"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/stacks/dhis2/helmfile.yaml
+++ b/stacks/dhis2/helmfile.yaml
@@ -33,6 +33,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "dhis2"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - dhisConfig: |
           connection.dialect = org.hibernate.dialect.PostgreSQLDialect

--- a/stacks/im-job-runner/helmfile.yaml
+++ b/stacks/im-job-runner/helmfile.yaml
@@ -11,6 +11,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "job"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - command: "{{ requiredEnv "COMMAND" }}"
       - payload: "{{ env "PAYLOAD" | default "-" }}"

--- a/stacks/im-job-runner/helmfile.yaml
+++ b/stacks/im-job-runner/helmfile.yaml
@@ -11,7 +11,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "job"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
       - command: "{{ requiredEnv "COMMAND" }}"
       - payload: "{{ env "PAYLOAD" | default "-" }}"

--- a/stacks/pgadmin/helmfile.yaml
+++ b/stacks/pgadmin/helmfile.yaml
@@ -11,7 +11,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "pgadmin"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
       - ingress:

--- a/stacks/pgadmin/helmfile.yaml
+++ b/stacks/pgadmin/helmfile.yaml
@@ -11,6 +11,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "pgadmin"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
       - ingress:

--- a/stacks/whoami-go/helmfile.yaml
+++ b/stacks/whoami-go/helmfile.yaml
@@ -19,6 +19,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "whoami"
+          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
 repositories:

--- a/stacks/whoami-go/helmfile.yaml
+++ b/stacks/whoami-go/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
           im-default: "true"
           im-id: "{{ requiredEnv "INSTANCE_ID" }}"
           im-type: "whoami"
-          im-creationTimestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
+          im-creation-timestamp: "{{ env "INSTANCE_CREATION_TIMESTAMP" | default "" }}"
           im-ttl: "{{ env "INSTANCE_TTL" | default "" }}"
 
 repositories:


### PR DESCRIPTION
This PR adds a creation timestamp label to each of our stack pods

The actual label is add in helmfile.go

In the loader it's marked as a system parameter

The helmfile.yaml in each stack is updated to include the label

And finally a new user script is added so this can easily be tried