### PR TITLE
chore: cleanup any lingering instances

### DIFF
--- a/scripts/stack_tests.sh
+++ b/scripts/stack_tests.sh
@@ -16,8 +16,7 @@ function cleanup_handler {
   exit
 }
 
-trap cleanup_handler INT
-trap cleanup_handler EXIT
+trap cleanup_handler INT EXIT
 
 # Whoami
 INSTANCE_NAME="$INSTANCE_PREFIX-whoami-$INSTANCE_POSTFIX"

--- a/scripts/stack_tests.sh
+++ b/scripts/stack_tests.sh
@@ -7,6 +7,18 @@ GROUP=whoami
 INSTANCE_PREFIX=im-e2e
 INSTANCE_POSTFIX=$(tr -dc '[:lower:]' </dev/urandom | head -c 5; echo '')
 
+function cleanup_handler {
+  # shellcheck disable=SC2046
+  ./destroy.sh whoami $(./list.sh | jq -r '.[].Instances[]?.Name' | grep $INSTANCE_PREFIX | grep "$INSTANCE_POSTFIX")
+  # shellcheck disable=SC2046
+  ./destroy.sh whoami $(./listPresets.sh | jq -r '.[].Instances[]?.Name' | grep $INSTANCE_PREFIX | grep "$INSTANCE_POSTFIX")
+  trap - EXIT
+  exit
+}
+
+trap cleanup_handler INT
+trap cleanup_handler EXIT
+
 # Whoami
 INSTANCE_NAME="$INSTANCE_PREFIX-whoami-$INSTANCE_POSTFIX"
 ./deploy-whoami.sh $GROUP "$INSTANCE_NAME"


### PR DESCRIPTION
@radnov and I have discussed the need for some automatic removal of leftover instances in regards to failing stack tests.

Ideally the tests shouldn't fail but we need more experience to adjust the thresholds so they don't.

The downside of this PR is that we might remove the evidence but on the other hand, if the problem persists, the tests could be ran again locally.