### PR TITLE
feat: restart without downtime

### DIFF
--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -212,10 +212,8 @@ func (ks kubernetesService) restart(instance *model.Instance, typeSelector strin
 		return fmt.Errorf("multiple deployments found using the selector: %q", selector)
 	}
 
-	name := items[0].Name
-
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = deployments.Patch(context.TODO(), name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	_, err = deployments.Patch(context.TODO(), items[0].Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
 	return err
 }
 

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -213,9 +213,10 @@ func (ks kubernetesService) restart(instance *model.Instance, typeSelector strin
 		return fmt.Errorf("multiple deployments found using the selector: %q", selector)
 	}
 
+	deployment := items[0]
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = deployments.Patch(context.TODO(), items[0].Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
-	return err
+	_, err = deployments.Patch(context.TODO(), deployment.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	return fmt.Errorf("error restarting %q: %v", deployment.Name, err)
 }
 
 func (ks kubernetesService) pause(instance *model.Instance) error {

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-user/swagger/sdk/models"


### PR DESCRIPTION
Previously we were restarting instances by scaling them to 0 and then back to whatever number of replicas they had before. The drawback of this method is that it comes with a significant amount of downtime.

This PR updates the "kubectl.kubernetes.io/restartedAt" annotation with the current time and thereby triggers an update in the same way as it would be done using `kubectl rollout restart`.