### PR TITLE
chore: return an empty array rather than null

### DIFF
--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -133,6 +133,10 @@ func (r repository) FindByGroups(groups []*models.Group, presets bool) ([]GroupW
 		return nil, err
 	}
 
+	if len(instances) < 1 {
+		return []GroupWithInstances{}, nil
+	}
+
 	instancesByGroup := mapInstancesByGroup(groupNames, instances)
 
 	return groupWithInstances(instancesByGroup, groupsByName), nil


### PR DESCRIPTION
If a user don't have access to any instances the endpoint /instances simply returns null which IMHO isn't very pretty. This PR will ensure an empty array is returned instead.