### PR TITLE
chore: add tests and make the KubernetesService testable

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -56,7 +56,8 @@ func run() error {
 	instanceRepo := instance.NewRepository(db, cfg)
 	uc := userClient.New(cfg.UserService.Host, cfg.UserService.BasePath)
 	helmfileSvc := instance.NewHelmfileService(stackSvc, cfg)
-	instanceSvc := instance.NewService(cfg, instanceRepo, uc, stackSvc, helmfileSvc)
+	kubernetesService := instance.NewKubernetesService()
+	instanceSvc := instance.NewService(cfg, instanceRepo, uc, stackSvc, helmfileSvc, kubernetesService)
 
 	dockerHubClient := integration.NewDockerHubClient(cfg.DockerHub.Username, cfg.DockerHub.Password)
 


### PR DESCRIPTION
The KubernetesService required a Kubernetes server being available. This PR changes that by loading the configuration on demand and add some tests.