### PR TITLE
use im-group

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -44,3 +44,66 @@ deploy:
         valuesFiles:
           - helm/data/secrets/{{ .ENVIRONMENT }}/values.yaml
           - helm/data/values/{{ .ENVIRONMENT }}/values.yaml
+
+profiles:
+  - name: dev
+    deploy:
+      helm:
+        releases:
+          - name: im-group-whoami
+            namespace: whoami
+            createNamespace: true
+            remoteChart: im-group
+            repo: https://dhis2-sre.github.io/im-group
+            version: 0.2.0
+            setValues:
+              serviceAccount:
+                name: im-manager-dev
+                namespace: instance-manager-dev
+  - name: prod
+    deploy:
+      helm:
+        releases:
+          - name: im-group-dev
+            namespace: dev
+            createNamespace: true
+            remoteChart: im-group
+            repo: https://dhis2-sre.github.io/im-group
+            version: 0.2.0
+            setValues:
+              serviceAccount:
+                name: im-manager-prod
+                namespace: instance-manager-prod
+
+          - name: im-group-play
+            namespace: play
+            createNamespace: true
+            remoteChart: im-group
+            repo: https://dhis2-sre.github.io/im-group
+            version: 0.2.0
+            setValues:
+              serviceAccount:
+                name: im-manager-prod
+                namespace: instance-manager-prod
+
+          - name: im-group-qa
+            namespace: qa
+            createNamespace: true
+            remoteChart: im-group
+            repo: https://dhis2-sre.github.io/im-group
+            version: 0.2.0
+            setValues:
+              serviceAccount:
+                name: im-manager-prod
+                namespace: instance-manager-prod
+
+          - name: im-group-meta-packages
+            namespace: meta-packages
+            createNamespace: true
+            remoteChart: im-group
+            repo: https://dhis2-sre.github.io/im-group
+            version: 0.2.0
+            setValues:
+              serviceAccount:
+                name: im-manager-prod
+                namespace: instance-manager-prod


### PR DESCRIPTION
Previously we've been installing the roles, required by IM to deploy instances into namespaces, when installing IM itself. It was done within the chart deploying IM itself. This ins't ideal because by doing so we can't easily create or remove namespaces.

This PR only updates the skaffold file by created two profiles, dev and prod, which will be used to deploy im-group into the various namespaces used for production and none production. It doesn't actually use the new profiles.

In the future the we'll delete the [role file](https://github.com/dhis2-sre/im-manager/blob/master/helm/chart/templates/role.yaml) but for now I'll leave it in there since I'm not entirely sure how we'll go about this in the pipeline.
Deploying with a profile is done by running `skaffold dev -p name-of-the-profile`. However, unless a valid profile name is passed to -p skaffold will fail which is a problem because our workflow is used with multiple project, some of which doesn't have profiles.
One solution would be to update our pipeline so it'll deploy using `skaffold -p name-of-the-profile run || skaffold run` but that's a bit ugly.

The im-group chart can be found [here](https://github.com/dhis2-sre/im-group).