### PR TITLE
fix: allow im service restarts within skaffold deadline

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta25
+apiVersion: skaffold/v4beta2
 kind: Config
 metadata:
   name: im-manager
@@ -9,6 +9,7 @@ build:
     inputDigest: { }
 deploy:
   statusCheckDeadlineSeconds: 240
+  tolerateFailuresUntilDeadline: true
   helm:
     releases:
       - name: im-rabbitmq-{{ .ENVIRONMENT }}
@@ -36,10 +37,8 @@ deploy:
         namespace: instance-manager-{{ .ENVIRONMENT }}
         createNamespace: true
         chartPath: helm/chart
-        artifactOverrides:
-          image: dhis2/im-manager
-        imageStrategy:
-          helm: { }
+        setValueTemplates:
+          image.repository: dhis2/im-manager
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .ENVIRONMENT }}/values.yaml


### PR DESCRIPTION
When a DB is not yet ready while a service is, the service exits with a non zero exit code. This causes 'skaffold dev' to exit and cleanup resources. [Configure skaffold](https://skaffold.dev/docs/references/yaml/#deploy-tolerateFailuresUntilDeadline) to allow restarts within the `statusCheckDeadlineSeconds` as this is a normal occurrence, which is fixed by restarts.

`tolerateFailuresUntilDeadline` is only available in a later config version where helm `artifactOverrides` and `imageStrategy` don't exist any longer https://skaffold.dev/docs/deployers/helm/#configuring-your-helm-project-with-skaffold

The downside is that it will take longer to exit from an unrecoverable error. Namely `statusCheckDeadlineSeconds` or however long it is that a dev sees this and terminates skaffold.
