### PR TITLE
feat: implement deleting users by their id

### DIFF
--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -637,6 +637,7 @@ func (h Handler) Update(c *gin.Context) {
 func (h Handler) canAccess(c *gin.Context, d *model.Database) error {
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
+		_ = c.Error(err)
 		return err
 	}
 

--- a/pkg/user/docs.go
+++ b/pkg/user/docs.go
@@ -18,7 +18,7 @@ type _ struct {
 	Body RefreshTokenRequest
 }
 
-// swagger:parameters findUserById
+// swagger:parameters findUserById deleteUser
 type _ struct {
 	// in: path
 	// required: true

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -294,6 +294,7 @@ func (h Handler) Delete(c *gin.Context) {
 
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
+		_ = c.Error(err)
 		return
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -92,6 +92,7 @@ func (h *Handler) SignIn(c *gin.Context) {
 	//   415: Error
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
+		_ = c.Error(err)
 		return
 	}
 
@@ -170,6 +171,7 @@ func (h Handler) Me(c *gin.Context) {
 	//   415: Error
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
+		_ = c.Error(err)
 		return
 	}
 
@@ -199,6 +201,7 @@ func (h Handler) SignOut(c *gin.Context) {
 	//	415: Error
 	user, err := handler.GetUserFromContext(c)
 	if err != nil {
+		_ = c.Error(err)
 		return
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -6,8 +6,8 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
-
 	"github.com/dhis2-sre/im-manager/internal/handler"
+
 	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/token"
 	"github.com/gin-gonic/gin"
@@ -32,6 +32,7 @@ type userService interface {
 	SignIn(email string, password string) (*model.User, error)
 	FindById(id uint) (*model.User, error)
 	FindAll() ([]*model.User, error)
+	Delete(id uint) error
 }
 
 type tokenService interface {
@@ -264,4 +265,51 @@ func (h Handler) FindAll(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, users)
+}
+
+// Delete user
+func (h Handler) Delete(c *gin.Context) {
+	// swagger:route DELETE /users/{id} deleteUser
+	//
+	// Delete user
+	//
+	// Delete user by id
+	//
+	// Security:
+	//	oauth2:
+	//
+	// Responses:
+	//	202:
+	//	401: Error
+	//	403: Error
+	//	404: Error
+	//	415: Error
+	id, ok := handler.GetPathParameter(c, "id")
+	if !ok {
+		return
+	}
+
+	user, err := handler.GetUserFromContext(c)
+	if err != nil {
+		return
+	}
+
+	_, err = h.userService.FindById(id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	if user.ID == id {
+		_ = c.Error(errdef.NewBadRequest("cannot delete the current user"))
+		return
+	}
+
+	err = h.userService.Delete(id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusAccepted)
 }

--- a/pkg/user/repository.go
+++ b/pkg/user/repository.go
@@ -75,3 +75,14 @@ func (r repository) findById(id uint) (*model.User, error) {
 	}
 	return u, err
 }
+
+func (r repository) delete(id uint) error {
+	db := r.db.Unscoped().Delete(&model.User{}, id)
+	if db.Error != nil {
+		return fmt.Errorf("failed to delete user with id %d: %v", id, db.Error)
+	} else if db.RowsAffected < 1 {
+		return errdef.NewNotFound("failed to find user with id %d", id)
+	}
+
+	return nil
+}

--- a/pkg/user/router.go
+++ b/pkg/user/router.go
@@ -23,4 +23,5 @@ func Routes(r *gin.Engine, authenticationMiddleware handler.AuthenticationMiddle
 	administratorRestrictedRouter := tokenAuthenticationRouter.Group("")
 	administratorRestrictedRouter.Use(authorizationMiddleware.RequireAdministrator)
 	administratorRestrictedRouter.GET("/users", handler.FindAll)
+	administratorRestrictedRouter.DELETE("/users/:id", handler.Delete)
 }

--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -22,6 +22,7 @@ type userRepository interface {
 	findById(id uint) (*model.User, error)
 	findOrCreate(email *model.User) (*model.User, error)
 	findAll() ([]*model.User, error)
+	delete(id uint) error
 }
 
 type service struct {
@@ -128,4 +129,8 @@ func (s service) FindOrCreate(email string, password string) (*model.User, error
 	}
 
 	return s.repository.findOrCreate(user)
+}
+
+func (s service) Delete(id uint) error {
+	return s.repository.delete(id)
 }

--- a/scripts/users/delete.sh
+++ b/scripts/users/delete.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+$HTTP delete "$IM_HOST/users/$1" "Authorization: Bearer $ACCESS_TOKEN"

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1437,6 +1437,30 @@ paths:
                     $ref: '#/responses/Error'
             summary: SignUp user
     /users/{id}:
+        delete:
+            description: Delete user by id
+            operationId: deleteUser
+            parameters:
+                - format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "202":
+                    description: ""
+                "401":
+                    $ref: '#/responses/Error'
+                "403":
+                    $ref: '#/responses/Error'
+                "404":
+                    $ref: '#/responses/Error'
+                "415":
+                    $ref: '#/responses/Error'
+            security:
+                - oauth2: []
+            summary: Delete user
         get:
             description: Find a user by its id
             operationId: findUserById


### PR DESCRIPTION
This PR adds an admin user endpoint `DELETE /users/{id}` for deleting users by their id.



I've added an [extra check to not allow the user to delete themself](https://github.com/dhis2-sre/im-manager/pull/257/files#diff-ca91d4575c0561bc512e314d455708400a1e715c5c98a109cd79960b29ee8a3aR307-R311), which I did by mistake while testing and thought it might be nice to have. Not completely sure if it's okay to have it in the handler, though. Let me know what you think. 👍 

