### PR TITLE
fix: save

### DIFF
--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -368,6 +368,13 @@ func (s service) SaveAs(database *model.Database, instance *model.Instance, stac
 			return
 		}
 
+		// This is added due to the following issue - https://github.com/aws/aws-sdk-go/issues/1962
+		_, err = file.Seek(0, 0)
+		if err != nil {
+			logError(err)
+			return
+		}
+
 		_, err = s.Upload(newDatabase, group, file, stat.Size())
 		if err != nil {
 			logError(err)


### PR DESCRIPTION
The "Save as" function for database has been failing for some time. I assume it's due to an update applied by dependabot but haven't bothered investigating.

This PR fixes the issue but it's worth nothing that the code dealing with saving of databases could be improved. More details can be found [here](https://github.com/aws/aws-sdk-go/issues/1962).