### PR TITLE
chore: temporary disable dependabot merge workflow

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,6 +1,7 @@
 name: Dependabot auto-merge
 
-on: pull_request
+#on: pull_request
+on: workflow_dispatch
 
 jobs:
   dependabot:


### PR DESCRIPTION
As described in #285, recent dependency updates are causing problems with linting and building the app. This PR temporary disables the workflow that merges dependabot PRs by commenting out the `on: pull_request` trigger and changing it to manual trigger.