### PR TITLE
chore: document update user request and unexport it

### DIFF
--- a/pkg/user/docs.go
+++ b/pkg/user/docs.go
@@ -40,3 +40,11 @@ type _ struct {
 	//in: body
 	_ *[]model.User
 }
+
+// swagger:parameters updateUser
+type _ struct {
+	// Update user request
+	// in: body
+	// required: true
+	Body updateUserRequest
+}

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -319,7 +319,7 @@ func (h Handler) Delete(c *gin.Context) {
 	c.Status(http.StatusAccepted)
 }
 
-type UpdateUserRequest struct {
+type updateUserRequest struct {
 	Email    string `json:"email" binding:"omitempty,email"`
 	Password string `json:"password" binding:"omitempty,gte=16,lte=128"`
 }
@@ -346,7 +346,7 @@ func (h *Handler) Update(c *gin.Context) {
 		return
 	}
 
-	var request UpdateUserRequest
+	var request updateUserRequest
 	if err := handler.DataBinder(c, &request); err != nil {
 		_ = c.Error(err)
 		return

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -466,6 +466,16 @@ definitions:
                 x-go-name: Name
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/database
+    updateUserRequest:
+        properties:
+            email:
+                type: string
+                x-go-name: Email
+            password:
+                type: string
+                x-go-name: Password
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/user
 info:
     contact:
         email: info@dhis2.org
@@ -1540,6 +1550,12 @@ paths:
                   required: true
                   type: integer
                   x-go-name: ID
+                - description: Update user request
+                  in: body
+                  name: Body
+                  required: true
+                  schema:
+                    $ref: '#/definitions/updateUserRequest'
             responses:
                 "200":
                     description: User


### PR DESCRIPTION
While working on the front end I wanted to see what kind of payload is used when updating a user. Therefor I went to https://api.im.dev.test.c.dhis2.org/docs#operation/updateUser only to find that it was documented.

I also unexported the request struct since there's currently no need to export it.