### PR TITLE
refactor: improve databases seed script

### DIFF
--- a/scripts/databases/seed.sh
+++ b/scripts/databases/seed.sh
@@ -3,23 +3,43 @@
 set -euo pipefail
 
 GROUP=$1
+shift
+VERSIONS=$*
+
+DHIS2_RELEASES_URL="https://releases.dhis2.org/v1/versions/stable.json"
 
 function createDatabase() {
-  echo "Downloading database... $1"
-  curl -C - "$2" -o "$HOME/Downloads/$1.sql.gz"
-  #curl "$2" -o "$HOME/Downloads/$1.sql.gz"
+  echo "Downloading database $1 ..."
 
-  echo "Login..."
+  mkdir -p "$HOME/Downloads"
+  curl -C - "$2" -o "$HOME/Downloads/$1.sql.gz"
+
+  echo "Login ..."
+  rm .access_token_cache # to make sure we're not using an expired token if we're seeding a lot of databases
   source ./auth.sh
 
-  echo "Uploading database...$1"
+  echo "Uploading database $1 ..."
   ./upload.sh "$GROUP" "$HOME/Downloads/$1.sql.gz"
+  echo # empty line to improve output readability
 }
 
-## https://databases.dhis2.org/
-createDatabase "Sierra Leone - 2.39.0" https://databases.dhis2.org/sierra-leone/2.39.0/dhis2-db-sierra-leone.sql.gz
-createDatabase "Sierra Leone - 2.38.1" https://databases.dhis2.org/sierra-leone/2.38.1/dhis2-db-sierra-leone.sql.gz
-createDatabase "Sierra Leone - 2.37.7" https://databases.dhis2.org/sierra-leone/2.37.6/dhis2-db-sierra-leone.sql.gz
-createDatabase "Sierra Leone - 2.36.11" https://databases.dhis2.org/sierra-leone/2.36.0/dhis2-db-sierra-leone.sql.gz
+if [[ -z "$*" ]]; then
+  VERSIONS=("dev")
 
-./list.sh | jq '.[].Databases[]? | .ID, .Name, .Url'
+  # Filter out all supported versions - current + 2 previous, including patch versions (like 2.40, 2.40.0, 2.39, 2.39.0, etc)
+  DHIS2_RELEASES=$(curl -fsSL "$DHIS2_RELEASES_URL")
+  LATEST_RELEASE=$(echo "$DHIS2_RELEASES" | jq -r '.versions[] | select(.latest == true) | .version')
+  # shellcheck disable=SC2207
+  VERSIONS+=($(
+    echo "$DHIS2_RELEASES" | jq -r "[.versions[] |
+      select(.version == $LATEST_RELEASE or .version == ($LATEST_RELEASE - 1) or .version == ($LATEST_RELEASE - 2)) |
+      [.name] + [(.patchVersions[] | select(.hotfix != true) | .name)]] | flatten | .[]"
+  ))
+fi
+
+# shellcheck disable=SC2145
+echo "Seeding the following databases: ${VERSIONS[@]}"
+
+for VERSION in "${VERSIONS[@]}"; do
+  createDatabase "Sierra Leone - $VERSION" "https://databases.dhis2.org/sierra-leone/$VERSION/dhis2-db-sierra-leone.sql.gz"
+done


### PR DESCRIPTION
As we start to get users actually using the Instance Manager, we need to have the databases frequently seeded and kept in sync. This PR improves the databases `seed.sh` to allow for easier seeding of the most frequently used databases, as well as provide an option for specifying DB versions manually.

The seed script will now have two options for usage:
* With only a group name provided `./seed whoami` - this will default to seeding databases for all DHIS2 versions (taken from the [stable.json](https://releases.dhis2.org/v1/versions/stable.json) file) for the current and 2 previous versions, without hotfixes, as we don't publish specific database versions for hotfixes.
* With group name and explicit database versions provided `./seed whoami 2.40 2.39`.