### PR TITLE
chore: add image pull policy integration

### DIFF
--- a/pkg/integration/handler.go
+++ b/pkg/integration/handler.go
@@ -116,6 +116,13 @@ func (h Handler) Integrations(c *gin.Context) {
 		return
 	}
 
+	if request.Key == "IMAGE_PULL_POLICY" {
+		policies := []string{"Always", "IfNotPresent", "Never"}
+
+		c.JSON(http.StatusOK, policies)
+		return
+	}
+
 	if request.Key == "DATABASE_ID" {
 		token, err := handler.GetTokenFromHttpAuthHeader(c)
 		if err != nil {


### PR DESCRIPTION
Add `IMAGE_PULL_POLICY` option to integrations endpoint. As described in [DEVOPS-261](https://dhis2.atlassian.net/browse/DEVOPS-261) the whole integrations logic should be refactored and moved out of the handler, but in a separate PR.