### PR TITLE
fix: remove "required" binding from Deployable bool field

### DIFF
--- a/pkg/group/docs.go
+++ b/pkg/group/docs.go
@@ -2,7 +2,7 @@ package group
 
 // swagger:parameters groupCreate
 type _ struct {
-	// Refresh token request body parameter
+	// Create group request body parameter
 	// in: body
 	// required: true
 	Body CreateGroupRequest

--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -33,7 +33,7 @@ type groupService interface {
 type CreateGroupRequest struct {
 	Name       string `json:"name" binding:"required"`
 	Hostname   string `json:"hostname" binding:"required"`
-	Deployable bool   `json:"deployable" binding:"required"`
+	Deployable bool   `json:"deployable"`
 }
 
 // Create group

--- a/pkg/group/repository.go
+++ b/pkg/group/repository.go
@@ -83,7 +83,13 @@ func findAllFromUser(user *model.User, deployable bool) []model.Group {
 }
 
 func (r repository) create(group *model.Group) error {
-	return r.db.Create(&group).Error
+	err := r.db.Create(&group).Error
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		// TODO how to check if name or hostname is duplicated?
+		return errdef.NewDuplicated("group name/hostname already exists: %s", err)
+	}
+
+	return err
 }
 
 func (r repository) findOrCreate(group *model.Group) (*model.Group, error) {

--- a/scripts/users/createGroup.sh
+++ b/scripts/users/createGroup.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 GROUP=$1
 HOSTNAME=$2
+DEPLOYABLE=${3:-false}
 
 echo "{
   \"name\": \"$GROUP\",
-  \"hostname\": \"$HOSTNAME\"
+  \"hostname\": \"$HOSTNAME\",
+  \"deployable\": $DEPLOYABLE
 }" | $HTTP post "$IM_HOST/groups" "Authorization: Bearer $ACCESS_TOKEN"

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -2106,7 +2106,7 @@ paths:
             description: Create a group...
             operationId: groupCreate
             parameters:
-                - description: Refresh token request body parameter
+                - description: Create group request body parameter
                   in: body
                   name: Body
                   required: true


### PR DESCRIPTION
Turns out that if the Deployable bool field is `false`, the validation from the "required" tag will fail
```
Error #01: Key: 'CreateGroupRequest.Deployable' Error:Field validation for 'Deployable' failed on the 'required' tag
```
as it's considered the zero-value for bools. In our case both `true` and `false` are valid, so there's no need to use the "required" tag.

I've also handled the duplicated key error when creating a `group`, but I'm not sure how to distinguish between duplicated `Hostname` and `Name`. Any ideas?