### PR TITLE
chore: declare stacks in Go DEVOPS-223

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -14,6 +14,9 @@ type Stack struct {
 	Instances        []Instance       `json:"instances" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	HostnamePattern  string           `json:"hostnamePattern"`
 	HostnameVariable string           `json:"hostnameVariable"`
+	// Providers provide parameters to other stacks.
+	Providers map[string]Provider `json:"-" gorm:"-"`
+	Requires  []Stack             `json:"-" gorm:"-"`
 }
 
 func (s Stack) GetHostname(name, namespace string) string {
@@ -34,4 +37,15 @@ type StackParameter struct {
 	StackName    string  `json:"-" gorm:"primaryKey"`
 	DefaultValue *string `json:"defaultValue"`
 	Consumed     bool    `json:"consumed"`
+}
+
+// Provides a value that can be consumed by a stack as a stack parameter.
+type Provider interface {
+	Provide(instance Instance) (value string, err error)
+}
+
+type ProviderFunc func(instance Instance) (string, error)
+
+func (p ProviderFunc) Provide(instance Instance) (string, error) {
+	return p(instance)
 }

--- a/pkg/stack/loader_test.go
+++ b/pkg/stack/loader_test.go
@@ -1,10 +1,68 @@
 package stack
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
 )
+
+func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
+	// assert every stack defined in Go has a helmfile
+	// assert every stack helmfile has a stack definition in Go
+	// assert that the parameters their default value and whether they are consumed are in sync
+	dir := "../../stacks"
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	helmfileParameters := make(map[string][]model.StackParameter)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		t.Logf("parsing stack: %q", name)
+		st, err := parseStack(dir, name)
+		require.NoError(t, err, "failed to parse stack %q", name)
+
+		consumedParameter := make(map[string]struct{})
+		for _, p := range st.consumedParameters {
+			consumedParameter[p] = struct{}{}
+		}
+
+		t.Logf("stack %q: %#v", name, st)
+		var parameters []model.StackParameter
+		for name, value := range st.parameters {
+			_, consumed := consumedParameter[name]
+			parameter := model.StackParameter{Name: name, DefaultValue: value, Consumed: consumed}
+
+			parameters = append(parameters, parameter)
+		}
+		helmfileParameters[name] = parameters
+	}
+
+	stackDefinitions := map[string][]model.StackParameter{
+		"dhis2-db":      DHIS2DB.Parameters,
+		"dhis2-core":    DHIS2Core.Parameters,
+		"dhis2":         DHIS2.Parameters,
+		"pgadmin":       PgAdmin.Parameters,
+		"whoami-go":     WhoamiGo.Parameters,
+		"im-job-runner": IMJobRunner.Parameters,
+	}
+
+	for n, p := range helmfileParameters {
+		staticParameters, ok := stackDefinitions[n]
+		require.Truef(t, ok, "stack %q has a helmfile but no static stack definition", n)
+		assert.ElementsMatchf(t, p, staticParameters, "parameters for stack %q don't match", n)
+		delete(stackDefinitions, n)
+	}
+
+	assert.Empty(t, stackDefinitions, "all stack definitions should have a helmfile, these don't")
+}
 
 func TestIsSystemParameterPositive(t *testing.T) {
 	const instanceId = "INSTANCE_ID"

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -1,0 +1,231 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+)
+
+const ifNotPresent = "IfNotPresent"
+
+// Stack representing ../../stacks/dhis2-db/helmfile.yaml
+var DHIS2DB = model.Stack{
+	Name: "dhis2-db",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &dhis2DBDefaults.chartVersion},
+		{Name: "DATABASE_ID"},
+		{Name: "DATABASE_NAME", DefaultValue: &dhis2DBDefaults.dbName},
+		{Name: "DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
+		{Name: "DATABASE_SIZE", DefaultValue: &dhis2DBDefaults.dbSize},
+		{Name: "DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
+		{Name: "DATABASE_VERSION", DefaultValue: &dhis2DBDefaults.dbVersion},
+		{Name: "RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		{Name: "RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+	},
+	Providers: map[string]model.Provider{
+		"DATABASE_HOSTNAME": postgresHostnameProvider,
+	},
+}
+
+var dhis2DBDefaults = struct {
+	chartVersion            string
+	dbID                    string
+	dbName                  string
+	dbPassword              string
+	dbSize                  string
+	dbUsername              string
+	dbVersion               string
+	resourcesRequestsCPU    string
+	resourcesRequestsMemory string
+}{
+	chartVersion:            "12.6.2",
+	dbName:                  "dhis2",
+	dbPassword:              "dhis",
+	dbSize:                  "5Gi",
+	dbUsername:              "dhis",
+	dbVersion:               "13",
+	resourcesRequestsCPU:    "250m",
+	resourcesRequestsMemory: "256Mi",
+}
+
+// Stack representing ../../stacks/dhis2-core/helmfile.yaml
+var DHIS2Core = model.Stack{
+	Name: "dhis2-core",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &dhis2CoreDefaults.chartVersion},
+		{Name: "DATABASE_HOSTNAME", Consumed: true},
+		{Name: "DATABASE_NAME", Consumed: true},
+		{Name: "DATABASE_PASSWORD", Consumed: true},
+		{Name: "DATABASE_USERNAME", Consumed: true},
+		{Name: "DHIS2_HOME", DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		{Name: "FLYWAY_MIGRATE_OUT_OF_ORDER", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		{Name: "FLYWAY_REPAIR_BEFORE_MIGRATION", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		{Name: "IMAGE_PULL_POLICY", DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		{Name: "IMAGE_REPOSITORY", DefaultValue: &dhis2CoreDefaults.imageRepository},
+		{Name: "IMAGE_TAG", DefaultValue: &dhis2CoreDefaults.imageTag},
+		{Name: "JAVA_OPTS", DefaultValue: &dhis2CoreDefaults.javaOpts},
+		{Name: "LIVENESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		{Name: "READINESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		{Name: "RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		{Name: "RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		{Name: "STARTUP_PROBE_FAILURE_THRESHOLD", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		{Name: "STARTUP_PROBE_PERIOD_SECONDS", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+	},
+	Requires: []model.Stack{
+		DHIS2DB,
+	},
+}
+
+var dhis2CoreDefaults = struct {
+	chartVersion                 string
+	dhis2Home                    string
+	flywayMigrateOutOfOrder      string
+	flywayRepairBeforeMigration  string
+	imagePullPolicy              string
+	imageRepository              string
+	imageTag                     string
+	javaOpts                     string
+	livenessProbeTimeoutSeconds  string
+	readinessProbeTimeoutSeconds string
+	resourcesRequestsCPU         string
+	resourcesRequestsMemory      string
+	startupProbeFailureThreshold string
+	startupProbePeriodSeconds    string
+}{
+	chartVersion:                 "0.14.0",
+	dhis2Home:                    "/opt/dhis2",
+	flywayMigrateOutOfOrder:      "false",
+	flywayRepairBeforeMigration:  "false",
+	imagePullPolicy:              ifNotPresent,
+	imageRepository:              "core",
+	imageTag:                     "2.40.0",
+	javaOpts:                     "",
+	livenessProbeTimeoutSeconds:  "1",
+	readinessProbeTimeoutSeconds: "1",
+	resourcesRequestsCPU:         "250m",
+	resourcesRequestsMemory:      "256Mi",
+	startupProbeFailureThreshold: "26",
+	startupProbePeriodSeconds:    "5",
+}
+
+// Stack representing ../../stacks/dhis2/helmfile.yaml
+var DHIS2 = model.Stack{
+	Name: "dhis2",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &dhis2CoreDefaults.chartVersion},
+		{Name: "CORE_RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		{Name: "CORE_RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		{Name: "DATABASE_ID"},
+		{Name: "DATABASE_NAME", DefaultValue: &dhis2DBDefaults.dbName},
+		{Name: "DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
+		{Name: "DATABASE_SIZE", DefaultValue: &dhis2DBDefaults.dbSize},
+		{Name: "DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
+		{Name: "DATABASE_VERSION", DefaultValue: &dhis2DBDefaults.dbVersion},
+		{Name: "DB_RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		{Name: "DB_RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+		{Name: "DHIS2_HOME", DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		{Name: "FLYWAY_MIGRATE_OUT_OF_ORDER", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		{Name: "FLYWAY_REPAIR_BEFORE_MIGRATION", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		{Name: "IMAGE_PULL_POLICY", DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		{Name: "IMAGE_REPOSITORY", DefaultValue: &dhis2CoreDefaults.imageRepository},
+		{Name: "IMAGE_TAG", DefaultValue: &dhis2CoreDefaults.imageTag},
+		{Name: "INSTALL_REDIS", DefaultValue: &dhis2Defaults.installRedis},
+		{Name: "JAVA_OPTS", DefaultValue: &dhis2CoreDefaults.javaOpts},
+		{Name: "LIVENESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		{Name: "READINESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		{Name: "STARTUP_PROBE_FAILURE_THRESHOLD", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		{Name: "STARTUP_PROBE_PERIOD_SECONDS", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+	},
+	Providers: map[string]model.Provider{
+		"DATABASE_HOSTNAME": postgresHostnameProvider,
+	},
+}
+
+var dhis2Defaults = struct {
+	installRedis string
+}{
+	installRedis: "false",
+}
+
+// Stack representing ../../stacks/pgadmin/helmfile.yaml
+var PgAdmin = model.Stack{
+	Name: "pgadmin",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &pgAdminDefaults.chartVersion},
+		{Name: "DATABASE_HOSTNAME", Consumed: true},
+		{Name: "DATABASE_NAME", Consumed: true},
+		{Name: "DATABASE_USERNAME", Consumed: true},
+		{Name: "PGADMIN_PASSWORD"},
+		{Name: "PGADMIN_USERNAME"},
+	},
+	Requires: []model.Stack{
+		DHIS2DB,
+	},
+}
+
+var pgAdminDefaults = struct {
+	chartVersion string
+}{
+	chartVersion: "1.11.0",
+}
+
+// Stack representing ../../stacks/whoami-go/helmfile.yaml
+var WhoamiGo = model.Stack{
+	Name: "whoami-go",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &whoamiGoDefaults.chartVersion},
+		{Name: "IMAGE_PULL_POLICY", DefaultValue: &whoamiGoDefaults.imagePullPolicy},
+		{Name: "IMAGE_REPOSITORY", DefaultValue: &whoamiGoDefaults.imageRepository},
+		{Name: "IMAGE_TAG", DefaultValue: &whoamiGoDefaults.imageTag},
+		{Name: "REPLICA_COUNT", DefaultValue: &whoamiGoDefaults.replicaCount},
+	},
+}
+
+var whoamiGoDefaults = struct {
+	chartVersion    string
+	imagePullPolicy string
+	imageRepository string
+	imageTag        string
+	replicaCount    string
+}{
+	chartVersion:    "0.9.0",
+	imagePullPolicy: ifNotPresent,
+	imageRepository: "core",
+	imageTag:        "0.6.0",
+	replicaCount:    "1",
+}
+
+// Stack representing ../../stacks/im-job-runner/helmfile.yaml
+var IMJobRunner = model.Stack{
+	Name: "im-job-runner",
+	Parameters: []model.StackParameter{
+		{Name: "CHART_VERSION", DefaultValue: &imJobRunnerDefaults.chartVersion},
+		{Name: "COMMAND"},
+		{Name: "DHIS2_DATABASE_DATABASE", DefaultValue: &dhis2DBDefaults.dbName},
+		{Name: "DHIS2_DATABASE_HOSTNAME", DefaultValue: &imJobRunnerDefaults.dbHostname},
+		{Name: "DHIS2_DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
+		{Name: "DHIS2_DATABASE_PORT", DefaultValue: &imJobRunnerDefaults.dbPort},
+		{Name: "DHIS2_DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
+		{Name: "DHIS2_HOSTNAME", DefaultValue: &imJobRunnerDefaults.dhis2Hostname},
+		{Name: "PAYLOAD", DefaultValue: &imJobRunnerDefaults.payload},
+	},
+}
+
+var imJobRunnerDefaults = struct {
+	chartVersion  string
+	dbHostname    string
+	dbPort        string
+	dhis2Hostname string
+	payload       string
+}{
+	chartVersion:  "0.1.0",
+	dbHostname:    "-",
+	dbPort:        "5432",
+	dhis2Hostname: "-",
+	payload:       "-",
+}
+
+// Provides the PostgreSQL hostname of an instance.
+var postgresHostnameProvider = model.ProviderFunc(func(instance model.Instance) (string, error) {
+	return fmt.Sprintf("%s-database-postgresql.%s.svc", instance.Name, instance.GroupName), nil
+})

--- a/stacks/pgadmin/helmfile.yaml
+++ b/stacks/pgadmin/helmfile.yaml
@@ -1,4 +1,4 @@
-# consumedParameters: DATABASE_USERNAME, DATABASE_PASSWORD, DATABASE_NAME, DATABASE_HOSTNAME
+# consumedParameters: DATABASE_USERNAME, DATABASE_NAME, DATABASE_HOSTNAME
 # hostnameVariable: DATABASE_HOSTNAME
 releases:
   - name: {{ requiredEnv "INSTANCE_NAME" }}


### PR DESCRIPTION
* Declare the metadata of stacks in Go. That is the first step in transitioning the metadata we currently have as comments in a stack's helmfile.

We are not yet using the Go stack definitions only putting them in place. We test that the static information in Go matches the one we parse in the stack's helmfile to ensure they are in sync (parameters, values, consumed or not).

* remove unused parameter from stacks/pgadmin/helmfile.yaml `DATABASE_PASSWORD` was declared as consumed but was not actually consumed.

## Next

* make Stack.parameters a `map[string]StackParameter` (ignored by Gorm) while still keeping a `[]StackParameter` field to be persisted by Gorm. This is so that parameters match what we need in the end which is a map. This makes processing the parameters easier. The compiler will also reject duplicate keys in our stack configs 😄.
* add checks to stacks
  * every required stack actually provides at least one consumed parameter
  * all consumed parameters are uniquely provided by the required stacks
  * no cycles in the stack config as this leads to cycles in the stack chains which cannot be deployed.