### PR TITLE
chore: create map of parameter names to parameters DEVOPS-223

### DIFF
--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -545,11 +545,10 @@ func findParameter(parameter string, instance *model.Instance, stack *model.Stac
 		}
 	}
 
-	for _, p := range stack.Parameters {
-		if p.Name == parameter {
-			return *p.DefaultValue, nil
-		}
+	p, ok := stack.Parameters[parameter]
+	if !ok {
+		return "", errors.New("parameter not found: " + parameter)
 	}
 
-	return "", errors.New("parameter not found: " + parameter)
+	return *p.DefaultValue, nil
 }

--- a/pkg/stack/loader.go
+++ b/pkg/stack/loader.go
@@ -59,11 +59,11 @@ func LoadStacks(dir string, stackService Service) error {
 			Name:             name,
 			HostnamePattern:  stackTemplate.hostnamePattern,
 			HostnameVariable: stackTemplate.hostnameVariable,
+			Parameters:       make(map[string]model.StackParameter),
 		}
 		for name, v := range stackTemplate.parameters {
 			isConsumed := isConsumedParameter(name, stackTemplate.consumedParameters)
-			parameter := &model.StackParameter{Name: name, StackName: stack.Name, Consumed: isConsumed, DefaultValue: v}
-			stack.Parameters = append(stack.Parameters, *parameter)
+			stack.Parameters[name] = model.StackParameter{Consumed: isConsumed, DefaultValue: v}
 		}
 
 		err = stackService.Create(stack)

--- a/pkg/stack/repository.go
+++ b/pkg/stack/repository.go
@@ -37,7 +37,7 @@ func (r repository) Delete(name string) error {
 func (r repository) Find(name string) (*model.Stack, error) {
 	var stack *model.Stack
 	err := r.db.
-		Preload("Parameters").
+		Preload("GormParameters").
 		First(&stack, "name = ?", name).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -11,16 +11,16 @@ const ifNotPresent = "IfNotPresent"
 // Stack representing ../../stacks/dhis2-db/helmfile.yaml
 var DHIS2DB = model.Stack{
 	Name: "dhis2-db",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &dhis2DBDefaults.chartVersion},
-		{Name: "DATABASE_ID"},
-		{Name: "DATABASE_NAME", DefaultValue: &dhis2DBDefaults.dbName},
-		{Name: "DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
-		{Name: "DATABASE_SIZE", DefaultValue: &dhis2DBDefaults.dbSize},
-		{Name: "DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
-		{Name: "DATABASE_VERSION", DefaultValue: &dhis2DBDefaults.dbVersion},
-		{Name: "RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
-		{Name: "RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":             {DefaultValue: &dhis2DBDefaults.chartVersion},
+		"DATABASE_ID":               {},
+		"DATABASE_NAME":             {DefaultValue: &dhis2DBDefaults.dbName},
+		"DATABASE_PASSWORD":         {DefaultValue: &dhis2DBDefaults.dbPassword},
+		"DATABASE_SIZE":             {DefaultValue: &dhis2DBDefaults.dbSize},
+		"DATABASE_USERNAME":         {DefaultValue: &dhis2DBDefaults.dbUsername},
+		"DATABASE_VERSION":          {DefaultValue: &dhis2DBDefaults.dbVersion},
+		"RESOURCES_REQUESTS_CPU":    {DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		"RESOURCES_REQUESTS_MEMORY": {DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
 	},
 	Providers: map[string]model.Provider{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
@@ -51,25 +51,25 @@ var dhis2DBDefaults = struct {
 // Stack representing ../../stacks/dhis2-core/helmfile.yaml
 var DHIS2Core = model.Stack{
 	Name: "dhis2-core",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &dhis2CoreDefaults.chartVersion},
-		{Name: "DATABASE_HOSTNAME", Consumed: true},
-		{Name: "DATABASE_NAME", Consumed: true},
-		{Name: "DATABASE_PASSWORD", Consumed: true},
-		{Name: "DATABASE_USERNAME", Consumed: true},
-		{Name: "DHIS2_HOME", DefaultValue: &dhis2CoreDefaults.dhis2Home},
-		{Name: "FLYWAY_MIGRATE_OUT_OF_ORDER", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
-		{Name: "FLYWAY_REPAIR_BEFORE_MIGRATION", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		{Name: "IMAGE_PULL_POLICY", DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
-		{Name: "IMAGE_REPOSITORY", DefaultValue: &dhis2CoreDefaults.imageRepository},
-		{Name: "IMAGE_TAG", DefaultValue: &dhis2CoreDefaults.imageTag},
-		{Name: "JAVA_OPTS", DefaultValue: &dhis2CoreDefaults.javaOpts},
-		{Name: "LIVENESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
-		{Name: "READINESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
-		{Name: "RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
-		{Name: "RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
-		{Name: "STARTUP_PROBE_FAILURE_THRESHOLD", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
-		{Name: "STARTUP_PROBE_PERIOD_SECONDS", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":                   {DefaultValue: &dhis2CoreDefaults.chartVersion},
+		"DATABASE_HOSTNAME":               {Consumed: true},
+		"DATABASE_NAME":                   {Consumed: true},
+		"DATABASE_PASSWORD":               {Consumed: true},
+		"DATABASE_USERNAME":               {Consumed: true},
+		"DHIS2_HOME":                      {DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		"IMAGE_REPOSITORY":                {DefaultValue: &dhis2CoreDefaults.imageRepository},
+		"IMAGE_TAG":                       {DefaultValue: &dhis2CoreDefaults.imageTag},
+		"JAVA_OPTS":                       {DefaultValue: &dhis2CoreDefaults.javaOpts},
+		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		"READINESS_PROBE_TIMEOUT_SECONDS": {DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		"RESOURCES_REQUESTS_CPU":          {DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		"RESOURCES_REQUESTS_MEMORY":       {DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		"STARTUP_PROBE_FAILURE_THRESHOLD": {DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		"STARTUP_PROBE_PERIOD_SECONDS":    {DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
 	},
 	Requires: []model.Stack{
 		DHIS2DB,
@@ -111,30 +111,30 @@ var dhis2CoreDefaults = struct {
 // Stack representing ../../stacks/dhis2/helmfile.yaml
 var DHIS2 = model.Stack{
 	Name: "dhis2",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &dhis2CoreDefaults.chartVersion},
-		{Name: "CORE_RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
-		{Name: "CORE_RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
-		{Name: "DATABASE_ID"},
-		{Name: "DATABASE_NAME", DefaultValue: &dhis2DBDefaults.dbName},
-		{Name: "DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
-		{Name: "DATABASE_SIZE", DefaultValue: &dhis2DBDefaults.dbSize},
-		{Name: "DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
-		{Name: "DATABASE_VERSION", DefaultValue: &dhis2DBDefaults.dbVersion},
-		{Name: "DB_RESOURCES_REQUESTS_CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
-		{Name: "DB_RESOURCES_REQUESTS_MEMORY", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
-		{Name: "DHIS2_HOME", DefaultValue: &dhis2CoreDefaults.dhis2Home},
-		{Name: "FLYWAY_MIGRATE_OUT_OF_ORDER", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
-		{Name: "FLYWAY_REPAIR_BEFORE_MIGRATION", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		{Name: "IMAGE_PULL_POLICY", DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
-		{Name: "IMAGE_REPOSITORY", DefaultValue: &dhis2CoreDefaults.imageRepository},
-		{Name: "IMAGE_TAG", DefaultValue: &dhis2CoreDefaults.imageTag},
-		{Name: "INSTALL_REDIS", DefaultValue: &dhis2Defaults.installRedis},
-		{Name: "JAVA_OPTS", DefaultValue: &dhis2CoreDefaults.javaOpts},
-		{Name: "LIVENESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
-		{Name: "READINESS_PROBE_TIMEOUT_SECONDS", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
-		{Name: "STARTUP_PROBE_FAILURE_THRESHOLD", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
-		{Name: "STARTUP_PROBE_PERIOD_SECONDS", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":                   {DefaultValue: &dhis2CoreDefaults.chartVersion},
+		"CORE_RESOURCES_REQUESTS_CPU":     {DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		"CORE_RESOURCES_REQUESTS_MEMORY":  {DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		"DATABASE_ID":                     {},
+		"DATABASE_NAME":                   {DefaultValue: &dhis2DBDefaults.dbName},
+		"DATABASE_PASSWORD":               {DefaultValue: &dhis2DBDefaults.dbPassword},
+		"DATABASE_SIZE":                   {DefaultValue: &dhis2DBDefaults.dbSize},
+		"DATABASE_USERNAME":               {DefaultValue: &dhis2DBDefaults.dbUsername},
+		"DATABASE_VERSION":                {DefaultValue: &dhis2DBDefaults.dbVersion},
+		"DB_RESOURCES_REQUESTS_CPU":       {DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		"DB_RESOURCES_REQUESTS_MEMORY":    {DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+		"DHIS2_HOME":                      {DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		"IMAGE_REPOSITORY":                {DefaultValue: &dhis2CoreDefaults.imageRepository},
+		"IMAGE_TAG":                       {DefaultValue: &dhis2CoreDefaults.imageTag},
+		"INSTALL_REDIS":                   {DefaultValue: &dhis2Defaults.installRedis},
+		"JAVA_OPTS":                       {DefaultValue: &dhis2CoreDefaults.javaOpts},
+		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		"READINESS_PROBE_TIMEOUT_SECONDS": {DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		"STARTUP_PROBE_FAILURE_THRESHOLD": {DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		"STARTUP_PROBE_PERIOD_SECONDS":    {DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
 	},
 	Providers: map[string]model.Provider{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
@@ -150,13 +150,13 @@ var dhis2Defaults = struct {
 // Stack representing ../../stacks/pgadmin/helmfile.yaml
 var PgAdmin = model.Stack{
 	Name: "pgadmin",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &pgAdminDefaults.chartVersion},
-		{Name: "DATABASE_HOSTNAME", Consumed: true},
-		{Name: "DATABASE_NAME", Consumed: true},
-		{Name: "DATABASE_USERNAME", Consumed: true},
-		{Name: "PGADMIN_PASSWORD"},
-		{Name: "PGADMIN_USERNAME"},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":     {DefaultValue: &pgAdminDefaults.chartVersion},
+		"DATABASE_HOSTNAME": {Consumed: true},
+		"DATABASE_NAME":     {Consumed: true},
+		"DATABASE_USERNAME": {Consumed: true},
+		"PGADMIN_PASSWORD":  {},
+		"PGADMIN_USERNAME":  {},
 	},
 	Requires: []model.Stack{
 		DHIS2DB,
@@ -172,12 +172,12 @@ var pgAdminDefaults = struct {
 // Stack representing ../../stacks/whoami-go/helmfile.yaml
 var WhoamiGo = model.Stack{
 	Name: "whoami-go",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &whoamiGoDefaults.chartVersion},
-		{Name: "IMAGE_PULL_POLICY", DefaultValue: &whoamiGoDefaults.imagePullPolicy},
-		{Name: "IMAGE_REPOSITORY", DefaultValue: &whoamiGoDefaults.imageRepository},
-		{Name: "IMAGE_TAG", DefaultValue: &whoamiGoDefaults.imageTag},
-		{Name: "REPLICA_COUNT", DefaultValue: &whoamiGoDefaults.replicaCount},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":     {DefaultValue: &whoamiGoDefaults.chartVersion},
+		"IMAGE_PULL_POLICY": {DefaultValue: &whoamiGoDefaults.imagePullPolicy},
+		"IMAGE_REPOSITORY":  {DefaultValue: &whoamiGoDefaults.imageRepository},
+		"IMAGE_TAG":         {DefaultValue: &whoamiGoDefaults.imageTag},
+		"REPLICA_COUNT":     {DefaultValue: &whoamiGoDefaults.replicaCount},
 	},
 }
 
@@ -198,16 +198,16 @@ var whoamiGoDefaults = struct {
 // Stack representing ../../stacks/im-job-runner/helmfile.yaml
 var IMJobRunner = model.Stack{
 	Name: "im-job-runner",
-	Parameters: []model.StackParameter{
-		{Name: "CHART_VERSION", DefaultValue: &imJobRunnerDefaults.chartVersion},
-		{Name: "COMMAND"},
-		{Name: "DHIS2_DATABASE_DATABASE", DefaultValue: &dhis2DBDefaults.dbName},
-		{Name: "DHIS2_DATABASE_HOSTNAME", DefaultValue: &imJobRunnerDefaults.dbHostname},
-		{Name: "DHIS2_DATABASE_PASSWORD", DefaultValue: &dhis2DBDefaults.dbPassword},
-		{Name: "DHIS2_DATABASE_PORT", DefaultValue: &imJobRunnerDefaults.dbPort},
-		{Name: "DHIS2_DATABASE_USERNAME", DefaultValue: &dhis2DBDefaults.dbUsername},
-		{Name: "DHIS2_HOSTNAME", DefaultValue: &imJobRunnerDefaults.dhis2Hostname},
-		{Name: "PAYLOAD", DefaultValue: &imJobRunnerDefaults.payload},
+	Parameters: map[string]model.StackParameter{
+		"CHART_VERSION":           {DefaultValue: &imJobRunnerDefaults.chartVersion},
+		"COMMAND":                 {},
+		"DHIS2_DATABASE_DATABASE": {DefaultValue: &dhis2DBDefaults.dbName},
+		"DHIS2_DATABASE_HOSTNAME": {DefaultValue: &imJobRunnerDefaults.dbHostname},
+		"DHIS2_DATABASE_PASSWORD": {DefaultValue: &dhis2DBDefaults.dbPassword},
+		"DHIS2_DATABASE_PORT":     {DefaultValue: &imJobRunnerDefaults.dbPort},
+		"DHIS2_DATABASE_USERNAME": {DefaultValue: &dhis2DBDefaults.dbUsername},
+		"DHIS2_HOSTNAME":          {DefaultValue: &imJobRunnerDefaults.dhis2Hostname},
+		"PAYLOAD":                 {DefaultValue: &imJobRunnerDefaults.payload},
 	},
 }
 

--- a/pkg/stack/stack_integration_test.go
+++ b/pkg/stack/stack_integration_test.go
@@ -45,3 +45,31 @@ func TestStackHandler(t *testing.T) {
 		assert.NotEmpty(t, stacks)
 	})
 }
+
+func TestStackModelHooksTransformParametersFromAndToMap(t *testing.T) {
+	t.Parallel()
+
+	db := inttest.SetupDB(t)
+	stackRepository := stack.NewRepository(db)
+
+	st := &model.Stack{
+		Name: "example",
+		Parameters: map[string]model.StackParameter{
+			"FIRST": {Consumed: true},
+		},
+	}
+
+	err := stackRepository.Create(st)
+	require.NoError(t, err)
+
+	assert.EqualValues(t,
+		[]model.StackParameter{{Name: "FIRST", StackName: "example", Consumed: true}},
+		st.GormParameters)
+
+	got, err := stackRepository.Find("example")
+	require.NoError(t, err)
+
+	assert.EqualValues(t,
+		map[string]model.StackParameter{"FIRST": {Name: "FIRST", StackName: "example", Consumed: true}},
+		got.Parameters)
+}

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1233,10 +1233,14 @@ definitions:
                 type: string
                 x-go-name: Name
             parameters:
+                description: |-
+                    GormParameters are only used by Gorm to persist parameters as it cannot persist a
+                    map[string]StackParameter. Only use GormParameters within the repository. Otherwise use
+                    Parameters.
                 items:
                     $ref: '#/definitions/StackParameter'
                 type: array
-                x-go-name: Parameters
+                x-go-name: GormParameters
             updatedAt:
                 format: date-time
                 type: string
@@ -1246,6 +1250,7 @@ definitions:
     StackParameter:
         properties:
             consumed:
+                description: Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
                 type: boolean
                 x-go-name: Consumed
             defaultValue:


### PR DESCRIPTION
create map of parameter names to parameters as in the end we need a map of name/value pairs to set the environment variables for the stack's helmfile. Use Gorm hooks to transform the map to a slice as it cannot persist the parameters otherwise.