### PR TITLE
chore: validate consumed parameters are provided by required stacks DEVOPS-223

### DIFF
--- a/pkg/stack/loader.go
+++ b/pkg/stack/loader.go
@@ -25,7 +25,7 @@ const (
 // Perhaps upsert using... https://gorm.io/docs/advanced_query.html#FirstOrCreate
 
 func LoadStacks(dir string, stackService Service) error {
-	stacks, _ := New(
+	stacks, err := New(
 		DHIS2DB,
 		DHIS2Core,
 		DHIS2,
@@ -33,6 +33,9 @@ func LoadStacks(dir string, stackService Service) error {
 		WhoamiGo,
 		IMJobRunner,
 	)
+	if err != nil {
+		return fmt.Errorf("error in stack config: %v", err)
+	}
 	_ = stacks
 
 	entries, err := os.ReadDir(dir)

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -55,17 +55,20 @@ func validateConsumedParams(stacks []model.Stack) error {
 
 		// generate frequency map of provided parameters
 		for _, requiredStack := range stack.Requires {
-			for name := range requiredStack.Parameters {
-				_, ok := consumedParameterProviders[name]
+			for parameterName, parameter := range requiredStack.Parameters {
+				if parameter.Consumed { // consumed parameters cannot be provided
+					continue
+				}
+				_, ok := consumedParameterProviders[parameterName]
 				if ok {
-					consumedParameterProviders[name]++
+					consumedParameterProviders[parameterName]++
 					requiredStacks[requiredStack.Name]++
 				}
 			}
-			for name := range requiredStack.Providers {
-				_, ok := consumedParameterProviders[name]
+			for parameterName := range requiredStack.Providers {
+				_, ok := consumedParameterProviders[parameterName]
 				if ok {
-					consumedParameterProviders[name]++
+					consumedParameterProviders[parameterName]++
 					requiredStacks[requiredStack.Name]++
 				}
 			}

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -1,0 +1,227 @@
+package stack_test
+
+import (
+	"testing"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	provider := model.ProviderFunc(func(instance model.Instance) (string, error) {
+		return "1", nil
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"b_param": {},
+			},
+			Providers: model.Providers{
+				"b_param_provided": provider,
+			},
+		}
+		c := model.Stack{
+			Name: "c",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+				"b_param_provided": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a, b},
+		}
+
+		stacks, err := stack.New(a, b, c)
+		require.NoError(t, err)
+
+		for _, stackName := range []string{"a", "b", "c"} {
+			assert.Contains(t, stacks, stackName, "stack should be part of stacks")
+		}
+	})
+
+	t.Run("FailGivenStackIfConsumedParameterIsNotProvidedByRequiredStack", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Providers: model.Providers{
+				"a_param_provided": provider,
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+				"a_param_provided": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a},
+		}
+
+		_, err := stack.New(a, b)
+
+		require.ErrorContains(t, err, `stack "b" parameter "a_param"`)
+	})
+
+	t.Run("FailGivenStackIfConsumedParameterIsNotProvidedByProvider", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+				"a_param_provided": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a},
+		}
+
+		_, err := stack.New(a, b)
+
+		require.ErrorContains(t, err, `no provider for stack "b" parameter "a_param_provided"`)
+	})
+
+	t.Run("FailGivenStackIfThereAreMultipleStacksProvidingTheSameConsumedParameter", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Providers: model.Providers{
+				"a_param_provided": provider,
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Providers: model.Providers{
+				"a_param_provided": provider,
+			},
+		}
+		c := model.Stack{
+			Name: "c",
+			Parameters: model.StackParameters{
+				"a_param_provided": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a, b},
+		}
+
+		_, err := stack.New(a, b, c)
+
+		require.ErrorContains(t, err, `stack "c" parameter "a_param_provided"`)
+	})
+
+	t.Run("FailGivenStackIfThereAreMultipleProvidersForOneConsumedParameter", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		c := model.Stack{
+			Name: "c",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a, b},
+		}
+
+		_, err := stack.New(a, b, c)
+
+		require.ErrorContains(t, err, `stack "c" parameter "a_param"`)
+	})
+
+	t.Run("FailGivenStackIfARequiredStackProvidesTheSameConsumedParameterTwice", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+			Providers: model.Providers{
+				"a_param": provider,
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a},
+		}
+
+		_, err := stack.New(a, b)
+
+		require.ErrorContains(t, err, `stack "b" parameter "a_param"`)
+	})
+
+	t.Run("FailGivenStackIfItContainsDuplicateRequiredStacks", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{a, a},
+		}
+
+		_, err := stack.New(a, b)
+
+		require.ErrorContains(t, err, `stack "b" requires "a" more than once`)
+	})
+
+	t.Run("FailGivenStackIfARequiredStackDoesNotProvideAnyOfItsConsumedParameters", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"b_param_1": {},
+				"b_param_2": {},
+			},
+			Requires: []model.Stack{a},
+		}
+
+		_, err := stack.New(a, b)
+
+		require.ErrorContains(t, err, `stack "b" requires "a" but does not consume from "a"`)
+	})
+}

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -101,6 +101,33 @@ func TestNew(t *testing.T) {
 		require.ErrorContains(t, err, `no provider for stack "b" parameter "a_param_provided"`)
 	})
 
+	t.Run("FailGivenStackIfConsumedParameterIsPointingToAnAlreadyConsumedParameter", func(t *testing.T) {
+		a := model.Stack{
+			Name: "a",
+			Parameters: model.StackParameters{
+				"a_param": {},
+			},
+		}
+		b := model.Stack{
+			Name: "b",
+			Parameters: model.StackParameters{
+				"a_param": {Consumed: true},
+			},
+			Requires: []model.Stack{a},
+		}
+		c := model.Stack{
+			Name: "c",
+			Parameters: model.StackParameters{
+				"a_param": {Consumed: true},
+			},
+			Requires: []model.Stack{b},
+		}
+
+		_, err := stack.New(a, c, b)
+
+		require.ErrorContains(t, err, `stack "c" parameter "a_param"`)
+	})
+
 	t.Run("FailGivenStackIfThereAreMultipleStacksProvidingTheSameConsumedParameter", func(t *testing.T) {
 		a := model.Stack{
 			Name: "a",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1235,7 +1235,7 @@ definitions:
             parameters:
                 description: |-
                     GormParameters are only used by Gorm to persist parameters as it cannot persist a
-                    map[string]StackParameter. Only use GormParameters within the repository. Otherwise use
+                    StackParameters. Only use GormParameters within the repository. Otherwise use
                     Parameters.
                 items:
                     $ref: '#/definitions/StackParameter'


### PR DESCRIPTION
validate
* all consumed parameters have exactly one provider
* a stack requires every stack only once
* every required stack actually provides at least one consumed parameter
* a consumed parameter cannot be provided

# Next

* validate stacks have no cycle