### PR TITLE
chore: declare all stacks DEVOPS-223

### DIFF
--- a/pkg/stack/loader.go
+++ b/pkg/stack/loader.go
@@ -25,6 +25,16 @@ const (
 // Perhaps upsert using... https://gorm.io/docs/advanced_query.html#FirstOrCreate
 
 func LoadStacks(dir string, stackService Service) error {
+	stacks, _ := New(
+		DHIS2DB,
+		DHIS2Core,
+		DHIS2,
+		PgAdmin,
+		WhoamiGo,
+		IMJobRunner,
+	)
+	_ = stacks
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("failed to read stack folder: %s", err)

--- a/pkg/stack/loader_test.go
+++ b/pkg/stack/loader_test.go
@@ -52,11 +52,11 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 		"im-job-runner": IMJobRunner.Parameters,
 	}
 
-	for n, p := range helmfileParameters {
-		staticParameters, ok := stackDefinitions[n]
-		require.Truef(t, ok, "stack %q has a helmfile but no static stack definition", n)
-		assert.Equalf(t, p, staticParameters, "parameters for stack %q don't match", n)
-		delete(stackDefinitions, n)
+	for name, parameter := range helmfileParameters {
+		staticParameters, ok := stackDefinitions[name]
+		require.Truef(t, ok, "stack %q has a helmfile but no static stack definition", name)
+		assert.Equalf(t, parameter, staticParameters, "parameters for stack %q don't match", name)
+		delete(stackDefinitions, name)
 	}
 
 	assert.Empty(t, stackDefinitions, "all stack definitions should have a helmfile, these don't")

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -1,3 +1,9 @@
+// Package stack contains stacks that can be deployed with the instance manager. Stacks have
+// parameters as their input which are used to render helmfile templates. Stacks might depend
+// on other stacks to provide a parameter (consumed parameter). Stack parameters declared here are
+// kept in sync with the helmfile template. No cycle is allowed within our stacks as this would lead
+// to undeployable stacks. No two stacks are allowed to provide the same parameter for another stack
+// as this is an ambiguity that cannot be automatically resolved.
 package stack
 
 import (
@@ -5,6 +11,18 @@ import (
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
+
+// Stacks represents all deployable stacks.
+type Stacks map[string]model.Stack
+
+// New creates stacks ensuring consumed parameters are provided by required stacks.
+func New(stacks ...model.Stack) (Stacks, error) {
+	result := make(Stacks, len(stacks))
+	for _, s := range stacks {
+		result[s.Name] = s
+	}
+	return result, nil
+}
 
 const ifNotPresent = "IfNotPresent"
 


### PR DESCRIPTION
to prepare using them in the loader and validating that
* all stacks consumed parameters are provided
* we do not have a cycle in our stack definition