### PR TITLE
chore: add parameter validation mechanism DEVOPS-223

### DIFF
--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -1,0 +1,122 @@
+package instance
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateParameters(t *testing.T) {
+	defaultPort := "8000"
+	stack := &model.Stack{
+		Name: "server",
+		Parameters: model.StackParameters{
+			"HOST": model.StackParameter{
+				Validator: func(value string) error {
+					if strings.TrimSpace(value) == "" {
+						return errors.New("empty hostname")
+					}
+
+					return nil
+				},
+			},
+			"PORT": model.StackParameter{
+				DefaultValue: &defaultPort,
+				Validator: func(value string) error {
+					_, err := strconv.Atoi(value)
+					if err != nil {
+						return errors.New("not a number")
+					}
+
+					return nil
+				},
+			},
+		},
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		instance := &model.Instance{
+			StackName: stack.Name,
+			Parameters: []model.InstanceParameter{
+				{
+					Name:  "HOST",
+					Value: "myhost",
+				},
+			},
+		}
+
+		err := validateParameters(stack, instance)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("FailsIfGivenParameterIsNotInStack", func(t *testing.T) {
+		instance := &model.Instance{
+			StackName: stack.Name,
+			Parameters: []model.InstanceParameter{
+				{
+					Name:  "HOST",
+					Value: "myhost",
+				},
+				{
+					Name:  "ADDITIONAL",
+					Value: "some",
+				},
+			},
+		}
+
+		err := validateParameters(stack, instance)
+
+		assert.True(t, errdef.IsBadRequest(err), "should be a bad request error")
+		assert.ErrorContains(t, err, `parameter "ADDITIONAL": is not a stack parameter`)
+	})
+
+	t.Run("FailsIfGivenRequiredParameterHasNoValue", func(t *testing.T) {
+		// this is to show that right now the parameter Validator needs to decide whether an empty
+		// string is a valid value for a required parameter because Value is of type string not
+		// *string
+		instance := &model.Instance{
+			StackName: stack.Name,
+			Parameters: []model.InstanceParameter{
+				{
+					Name: "HOST",
+				},
+			},
+		}
+
+		err := validateParameters(stack, instance)
+
+		assert.True(t, errdef.IsBadRequest(err), "should be a bad request error")
+		assert.ErrorContains(t, err, "invalid parameter(s)")
+		assert.ErrorContains(t, err, `parameter "HOST": empty hostname`)
+	})
+
+	t.Run("FailsIfGivenParameterIsNotValid", func(t *testing.T) {
+		instance := &model.Instance{
+			StackName: stack.Name,
+			Parameters: []model.InstanceParameter{
+				{
+					Name:  "HOST",
+					Value: "   ",
+				},
+				{
+					Name:  "PORT",
+					Value: "not an integer",
+				},
+			},
+		}
+
+		err := validateParameters(stack, instance)
+
+		assert.True(t, errdef.IsBadRequest(err), "should be a bad request error")
+		assert.ErrorContains(t, err, "invalid parameter(s)")
+		assert.ErrorContains(t, err, `parameter "HOST": empty hostname`)
+		assert.ErrorContains(t, err, `parameter "PORT": not a number`)
+	})
+}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -1,9 +1,5 @@
 package model
 
-import (
-	"fmt"
-)
-
 // swagger:model Stack
 type Stack struct {
 	Name             string          `json:"name"`
@@ -17,10 +13,6 @@ type Stack struct {
 	Requires []Stack `json:"-"`
 }
 
-func (s *Stack) GetHostname(name, namespace string) string {
-	return fmt.Sprintf(s.HostnamePattern, name, namespace)
-}
-
 type StackParameters map[string]StackParameter
 
 type StackParameter struct {
@@ -28,6 +20,8 @@ type StackParameter struct {
 	DefaultValue *string `json:"defaultValue,omitempty"`
 	// Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
 	Consumed bool `json:"consumed"`
+	// Validator ensures that the actual stack parameters are valid according to its rules.
+	Validator func(value string) error `json:"-"`
 }
 
 type Providers map[string]Provider

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -9,8 +9,12 @@ package stack
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"golang.org/x/exp/slices"
+	k8s "k8s.io/api/core/v1"
 )
 
 // Stacks represents all deployable stacks.
@@ -146,7 +150,7 @@ var DHIS2Core = model.Stack{
 		"DHIS2_HOME":                      {DefaultValue: &dhis2CoreDefaults.dhis2Home},
 		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
 		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"IMAGE_REPOSITORY":                {DefaultValue: &dhis2CoreDefaults.imageRepository},
 		"IMAGE_TAG":                       {DefaultValue: &dhis2CoreDefaults.imageTag},
 		"JAVA_OPTS":                       {DefaultValue: &dhis2CoreDefaults.javaOpts},
@@ -212,7 +216,7 @@ var DHIS2 = model.Stack{
 		"DHIS2_HOME":                      {DefaultValue: &dhis2CoreDefaults.dhis2Home},
 		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
 		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy},
+		"IMAGE_PULL_POLICY":               {DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"IMAGE_REPOSITORY":                {DefaultValue: &dhis2CoreDefaults.imageRepository},
 		"IMAGE_TAG":                       {DefaultValue: &dhis2CoreDefaults.imageTag},
 		"INSTALL_REDIS":                   {DefaultValue: &dhis2Defaults.installRedis},
@@ -260,7 +264,7 @@ var WhoamiGo = model.Stack{
 	Name: "whoami-go",
 	Parameters: model.StackParameters{
 		"CHART_VERSION":     {DefaultValue: &whoamiGoDefaults.chartVersion},
-		"IMAGE_PULL_POLICY": {DefaultValue: &whoamiGoDefaults.imagePullPolicy},
+		"IMAGE_PULL_POLICY": {DefaultValue: &whoamiGoDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"IMAGE_REPOSITORY":  {DefaultValue: &whoamiGoDefaults.imageRepository},
 		"IMAGE_TAG":         {DefaultValue: &whoamiGoDefaults.imageTag},
 		"REPLICA_COUNT":     {DefaultValue: &whoamiGoDefaults.replicaCount},
@@ -315,3 +319,32 @@ var imJobRunnerDefaults = struct {
 var postgresHostnameProvider = model.ProviderFunc(func(instance model.Instance) (string, error) {
 	return fmt.Sprintf("%s-database-postgresql.%s.svc", instance.Name, instance.GroupName), nil
 })
+
+// imagePullPolicy validates a value is a valid Kubernetes image pull policy.
+var imagePullPolicy = OneOf(string(k8s.PullAlways), string(k8s.PullNever), string(k8s.PullIfNotPresent))
+
+// OneOf creates a function returning an error when called with a value that is not any of the given
+// validValues.
+func OneOf(validValues ...string) func(value string) error {
+	fmtErrorArg := quoteStrings(validValues)
+
+	return func(value string) error {
+		if slices.Contains(validValues, value) {
+			return nil
+		}
+
+		return fmt.Errorf("%q is not valid, only %s are allowed", value, fmtErrorArg)
+	}
+}
+
+// qotesStrings quotes values and comma separates them into a joint string.
+func quoteStrings(values []string) string {
+	var result strings.Builder
+	for i, validValue := range values {
+		result.WriteString(strconv.Quote(validValue))
+		if i+1 < len(values) {
+			result.WriteString(", ")
+		}
+	}
+	return result.String()
+}

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -252,3 +252,11 @@ func TestNew(t *testing.T) {
 		require.ErrorContains(t, err, `stack "b" requires "a" but does not consume from "a"`)
 	})
 }
+
+func TestValidatorOneOf(t *testing.T) {
+	validator := stack.OneOf("ok", "not_ok")
+
+	assert.NoError(t, validator("ok"))
+	assert.NoError(t, validator("not_ok"))
+	assert.ErrorContains(t, validator("maybe"), `"maybe" is not valid, only "ok", "not_ok" are allowed`)
+}


### PR DESCRIPTION
* stack parameters can define a `Validator` which is a `func (value string) error`. I am not adding an interface like for `Provider`. I don't anticipate us needing any `struct` holding state like a `AWS` client or so that should satisfy this interface. Validators IMHO will mostly be functions. Functions cannot implement an interface in Go which leads to the pattern like the [http/HandlerFunc](https://pkg.go.dev/net/http#HandlerFunc) which makes things more complex. We can go there if needed.
* adapted the minimum parameter validation we had in instance service. New algorithm: collect as many errors as possible by iterating over all instance parameters
  * add error if parameter is not part of the instance's stack
  * add error if there is a Validator to run that returns an error
  * join all errors in a `BadRequest` error

Using higher-order functions we can create reusable validators like OneOf. If we benefit from adding multiple Validators to one parameter we can do so at a later point. Being able to return multiple errors in a structured way like JSON instead of a plain string might help with the presentation in the UI.

## Example Request
 
`./deploy-whoami.sh whoami foo`

with the following added invalid parameters 

```json
    {
      "name": "IMAGE_PULL_POLICY",
      "value": "nonsense"
    },
    {
      "name": "UNKNOWN",
      "value": "some"
    }
```

Parameter `IMAGE_PULL_POLICY` is invalid according to `Validator: ImagePullPolicy`. The other one is not part of the whoami stack.

Leads to HTTP 400 Bad Request with message

`invalid parameter(s): parameter "IMAGE_PULL_POLICY": "nonsense" is not valid, only "Always", "Never", "IfNotPresent" are allowed
parameter "UNKNOWN": not a stack parameter`

## Next steps for validation

* add more Validators for each stack parameter
* validatiors are run in the `instanceService.Save` which is used in the instance deploy and update handler. Are there other handlers that take in instance parameters that need to be validated?
* think of how to improve the error representation in the UI. Should we move to a structured error response like JSON where we return a list of errors maybe associated with each parameter?