### PR TITLE
chore: explicitly name Provider ParameterProvider

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -7,8 +7,8 @@ type Stack struct {
 	Instances        []Instance      `json:"instances"`
 	HostnamePattern  string          `json:"hostnamePattern"`
 	HostnameVariable string          `json:"hostnameVariable"`
-	// Providers provide parameters to other stacks.
-	Providers Providers `json:"-"`
+	// ParameterProviders provide parameters to other stacks.
+	ParameterProviders ParameterProviders `json:"-"`
 	// Requires these stacks to deploy an instance of this stack.
 	Requires []Stack `json:"-"`
 }
@@ -24,15 +24,15 @@ type StackParameter struct {
 	Validator func(value string) error `json:"-"`
 }
 
-type Providers map[string]Provider
+type ParameterProviders map[string]ParameterProvider
 
-// Provider provides a value that can be consumed by a stack as a stack parameter.
-type Provider interface {
+// ParameterProvider provides a value that can be consumed by a stack as a stack parameter.
+type ParameterProvider interface {
 	Provide(instance Instance) (value string, err error)
 }
 
-type ProviderFunc func(instance Instance) (string, error)
+type ParameterProviderFunc func(instance Instance) (string, error)
 
-func (p ProviderFunc) Provide(instance Instance) (string, error) {
+func (p ParameterProviderFunc) Provide(instance Instance) (string, error) {
 	return p(instance)
 }

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -69,7 +69,7 @@ func validateConsumedParams(stacks []model.Stack) error {
 					requiredStacks[requiredStack.Name]++
 				}
 			}
-			for parameterName := range requiredStack.Providers {
+			for parameterName := range requiredStack.ParameterProviders {
 				_, ok := consumedParameterProviders[parameterName]
 				if ok {
 					consumedParameterProviders[parameterName]++
@@ -112,7 +112,7 @@ var DHIS2DB = model.Stack{
 		"RESOURCES_REQUESTS_CPU":    {DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
 		"RESOURCES_REQUESTS_MEMORY": {DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
 	},
-	Providers: model.Providers{
+	ParameterProviders: model.ParameterProviders{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 }
@@ -226,7 +226,7 @@ var DHIS2 = model.Stack{
 		"STARTUP_PROBE_FAILURE_THRESHOLD": {DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
 		"STARTUP_PROBE_PERIOD_SECONDS":    {DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
 	},
-	Providers: model.Providers{
+	ParameterProviders: model.ParameterProviders{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 }
@@ -316,7 +316,7 @@ var imJobRunnerDefaults = struct {
 }
 
 // Provides the PostgreSQL hostname of an instance.
-var postgresHostnameProvider = model.ProviderFunc(func(instance model.Instance) (string, error) {
+var postgresHostnameProvider = model.ParameterProviderFunc(func(instance model.Instance) (string, error) {
 	return fmt.Sprintf("%s-database-postgresql.%s.svc", instance.Name, instance.GroupName), nil
 })
 

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	provider := model.ProviderFunc(func(instance model.Instance) (string, error) {
+	provider := model.ParameterProviderFunc(func(instance model.Instance) (string, error) {
 		return "1", nil
 	})
 
@@ -26,7 +26,7 @@ func TestNew(t *testing.T) {
 			Parameters: model.StackParameters{
 				"b_param": {},
 			},
-			Providers: model.Providers{
+			ParameterProviders: model.ParameterProviders{
 				"b_param_provided": provider,
 			},
 		}
@@ -54,7 +54,7 @@ func TestNew(t *testing.T) {
 	t.Run("FailGivenStackIfConsumedParameterIsNotProvidedByRequiredStack", func(t *testing.T) {
 		a := model.Stack{
 			Name: "a",
-			Providers: model.Providers{
+			ParameterProviders: model.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
@@ -131,13 +131,13 @@ func TestNew(t *testing.T) {
 	t.Run("FailGivenStackIfThereAreMultipleStacksProvidingTheSameConsumedParameter", func(t *testing.T) {
 		a := model.Stack{
 			Name: "a",
-			Providers: model.Providers{
+			ParameterProviders: model.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
 		b := model.Stack{
 			Name: "b",
-			Providers: model.Providers{
+			ParameterProviders: model.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
@@ -190,7 +190,7 @@ func TestNew(t *testing.T) {
 			Parameters: model.StackParameters{
 				"a_param": {},
 			},
-			Providers: model.Providers{
+			ParameterProviders: model.ParameterProviders{
 				"a_param": provider,
 			},
 		}


### PR DESCRIPTION
to make it clear what the Stack.Provider field is for.