### PR TITLE
chore: validate stack config has no cycles DEVOPS-223

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,10 @@ require (
 	k8s.io/client-go v0.27.5
 )
 
-require github.com/go-mail/mail v2.3.1+incompatible
+require (
+	github.com/dominikbraun/graph v0.23.0
+	github.com/go-mail/mail v2.3.1+incompatible
+)
 
 require (
 	cloud.google.com/go/compute v1.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,6 +368,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dominikbraun/graph v0.23.0 h1:TdZB4pPqCLFxYhdyMFb1TBdFxp8XLcJfTTBQucVPgCo=
+github.com/dominikbraun/graph v0.23.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=


### PR DESCRIPTION
Cycles in our stack configs we would lead to users sending us linked instances that contain cycles. Such deployments have no order in which they can successfully be deployed.

I picked https://github.com/dominikbraun/graph as it
* does what we need (prevent cycles in our stacks config, topological sort for finding a deployment order of linked instances)
* has no dependencies
* has an easy to use API
* is well tested

Its API might change as its pre 1.0. Some Go projects never reach 1.0 even if they are feature complete. Some due to reluctance to go into a v1/v2/... API versioning 😅 

We could look into implementing this ourselves if we prefer.