### PR TITLE
chore: make instance handler testable

### DIFF
--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -9,51 +9,23 @@ import (
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 
-	"github.com/dhis2-sre/im-manager/pkg/stack"
-
 	"github.com/dhis2-sre/im-manager/internal/handler"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/gin-gonic/gin"
 )
 
-func NewHandler(userService userServiceHandler, groupService groupServiceHandler, instanceService Service, stackService stack.Service, defaultTTL uint) Handler {
+func NewHandler(groupService groupServiceHandler, instanceService *service, defaultTTL uint) Handler {
 	return Handler{
-		userService,
 		groupService,
 		instanceService,
-		stackService,
 		defaultTTL,
 	}
 }
 
-type Service interface {
-	ConsumeParameters(source, destination *model.Instance) error
-	Pause(instance *model.Instance) error
-	Resume(instance *model.Instance) error
-	Restart(instance *model.Instance, typeSelector string) error
-	Reset(token string, instance *model.Instance) error
-	Save(instance *model.Instance) error
-	Deploy(token string, instance *model.Instance) error
-	FindById(id uint) (*model.Instance, error)
-	FindByIdDecrypted(id uint) (*model.Instance, error)
-	FindByNameAndGroup(instance string, group string) (*model.Instance, error)
-	FindPublicInstances() ([]GroupsWithInstances, error)
-	Delete(id uint) error
-	Logs(instance *model.Instance, group *model.Group, typeSelector string) (io.ReadCloser, error)
-	FindInstances(user *model.User, presets bool) ([]GroupsWithInstances, error)
-	Link(source, destination *model.Instance) error
-}
-
 type Handler struct {
-	userService     userServiceHandler
 	groupService    groupServiceHandler
-	instanceService Service
-	stackService    stack.Service
+	instanceService *service
 	defaultTTL      uint
-}
-
-type userServiceHandler interface {
-	FindById(id uint) (*model.User, error)
 }
 
 type groupServiceHandler interface {

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
-	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -13,13 +12,13 @@ import (
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func NewRepository(db *gorm.DB, config config.Config) *repository {
-	return &repository{db, config}
+func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) *repository {
+	return &repository{db: db, instanceParameterEncryptionKey: instanceParameterEncryptionKey}
 }
 
 type repository struct {
-	db     *gorm.DB
-	config config.Config
+	db                             *gorm.DB
+	instanceParameterEncryptionKey string
 }
 
 func (r repository) FindByIdDecrypted(id uint) (*model.Instance, error) {
@@ -28,7 +27,7 @@ func (r repository) FindByIdDecrypted(id uint) (*model.Instance, error) {
 		return nil, err
 	}
 
-	err = decryptParameters(r.config.InstanceParameterEncryptionKey, instance)
+	err = decryptParameters(r.instanceParameterEncryptionKey, instance)
 
 	return instance, err
 }
@@ -71,7 +70,7 @@ func (r repository) Unlink(instance *model.Instance) error {
 }
 
 func (r repository) Save(instance *model.Instance) error {
-	key := r.config.InstanceParameterEncryptionKey
+	key := r.instanceParameterEncryptionKey
 
 	populateParameterRelations(instance)
 

--- a/pkg/instance/router.go
+++ b/pkg/instance/router.go
@@ -1,15 +1,14 @@
 package instance
 
 import (
-	"github.com/dhis2-sre/im-manager/internal/middleware"
 	"github.com/gin-gonic/gin"
 )
 
-func Routes(r *gin.Engine, authenticationMiddleware middleware.AuthenticationMiddleware, handler Handler) {
+func Routes(r *gin.Engine, authenticator gin.HandlerFunc, handler Handler) {
 	r.GET("/public/instances", handler.ListPublicInstances)
 
 	tokenAuthenticationRouter := r.Group("")
-	tokenAuthenticationRouter.Use(authenticationMiddleware.TokenAuthentication)
+	tokenAuthenticationRouter.Use(authenticator)
 
 	tokenAuthenticationRouter.POST("/instances", handler.Deploy)
 	tokenAuthenticationRouter.GET("/instances", handler.ListInstances)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -11,20 +11,17 @@ import (
 
 	"github.com/dhis2-sre/im-manager/pkg/stack"
 
-	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
 func NewService(
-	config config.Config,
 	instanceRepository Repository,
 	groupService groupService,
 	stackService stack.Service,
 	helmfileService helmfile,
 ) *service {
 	return &service{
-		config,
 		instanceRepository,
 		groupService,
 		stackService,
@@ -47,7 +44,6 @@ type Repository interface {
 
 type groupService interface {
 	Find(name string) (*model.Group, error)
-	FindAll(user *model.User, deployable bool) ([]model.Group, error)
 }
 
 type helmfile interface {
@@ -56,7 +52,6 @@ type helmfile interface {
 }
 
 type service struct {
-	config             config.Config
 	instanceRepository Repository
 	groupService       groupService
 	stackService       stack.Service

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -87,7 +87,7 @@ deploy:
             RABBITMQ_PORT: "5672"
             S3_BUCKET: im-databases-{{ .CLASSIFICATION }}
             S3_REGION: eu-west-1
-            DEFAULT_TTL: "172800"
+            DEFAULT_TTL: "172800" # 48 hours
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/values.yaml


### PR DESCRIPTION
These are changes we made to other parts of the code when we added an integration test.

* remove unused dependencies/fields from a handler, service, ...
* remove instance service interface in the instance handler as we do not benefit from it. We do not test the handler in isolation, nor do we have multiple instance service implementations. Its also not 3rd party code we want to isolate our code from. Only add an interface for any of
the above reasons.
* only pass in the needed config instead of the entire config struct