### PR TITLE
chore: make instance handler testable

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -104,9 +104,9 @@ func run() error {
 
 	stackService := stack.NewService(stacks)
 
-	instanceRepo := instance.NewRepository(db, cfg)
-	helmfileService := instance.NewHelmfileService(stackService, cfg)
-	instanceService := instance.NewService(cfg, instanceRepo, groupService, stackService, helmfileService)
+	instanceRepository := instance.NewRepository(db, cfg.InstanceParameterEncryptionKey)
+	helmfileService := instance.NewHelmfileService("./stacks", stackService, cfg.Classification)
+	instanceService := instance.NewService(instanceRepository, groupService, stackService, helmfileService)
 
 	dockerHubClient := integration.NewDockerHubClient(cfg.DockerHub.Username, cfg.DockerHub.Password)
 
@@ -126,7 +126,7 @@ func run() error {
 	}
 
 	stackHandler := stack.NewHandler(stackService)
-	instanceHandler := instance.NewHandler(userService, groupService, instanceService, stackService, cfg.DefaultTTL)
+	instanceHandler := instance.NewHandler(groupService, instanceService, cfg.DefaultTTL)
 
 	s3Endpoint := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...any) (aws.Endpoint, error) {
 		if cfg.S3Endpoint != "" {
@@ -173,7 +173,7 @@ func run() error {
 	stack.Routes(r, authentication.TokenAuthentication, stackHandler)
 	integration.Routes(r, authentication, integrationHandler)
 	database.Routes(r, authentication.TokenAuthentication, databaseHandler)
-	instance.Routes(r, authentication, instanceHandler)
+	instance.Routes(r, authentication.TokenAuthentication, instanceHandler)
 
 	return r.Run()
 }
@@ -205,7 +205,6 @@ func newS3Config(region string, endpoint aws.EndpointResolverWithOptionsFunc) (a
 		s3config.WithRegion(region),
 		s3config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptions(endpoint)),
 	)
-
 	if err != nil {
 		return aws.Config{}, err
 	}

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -9,51 +9,23 @@ import (
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 
-	"github.com/dhis2-sre/im-manager/pkg/stack"
-
 	"github.com/dhis2-sre/im-manager/internal/handler"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/gin-gonic/gin"
 )
 
-func NewHandler(userService userServiceHandler, groupService groupServiceHandler, instanceService Service, stackService stack.Service, defaultTTL uint) Handler {
+func NewHandler(groupService groupServiceHandler, instanceService *service, defaultTTL uint) Handler {
 	return Handler{
-		userService,
 		groupService,
 		instanceService,
-		stackService,
 		defaultTTL,
 	}
 }
 
-type Service interface {
-	ConsumeParameters(source, destination *model.Instance) error
-	Pause(instance *model.Instance) error
-	Resume(instance *model.Instance) error
-	Restart(instance *model.Instance, typeSelector string) error
-	Reset(token string, instance *model.Instance) error
-	Save(instance *model.Instance) error
-	Deploy(token string, instance *model.Instance) error
-	FindById(id uint) (*model.Instance, error)
-	FindByIdDecrypted(id uint) (*model.Instance, error)
-	FindByNameAndGroup(instance string, group string) (*model.Instance, error)
-	FindPublicInstances() ([]GroupsWithInstances, error)
-	Delete(id uint) error
-	Logs(instance *model.Instance, group *model.Group, typeSelector string) (io.ReadCloser, error)
-	FindInstances(user *model.User, presets bool) ([]GroupsWithInstances, error)
-	Link(source, destination *model.Instance) error
-}
-
 type Handler struct {
-	userService     userServiceHandler
 	groupService    groupServiceHandler
-	instanceService Service
-	stackService    stack.Service
+	instanceService *service
 	defaultTTL      uint
-}
-
-type userServiceHandler interface {
-	FindById(id uint) (*model.User, error)
 }
 
 type groupServiceHandler interface {

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
-	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -13,13 +12,13 @@ import (
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func NewRepository(db *gorm.DB, config config.Config) *repository {
-	return &repository{db, config}
+func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) *repository {
+	return &repository{db: db, instanceParameterEncryptionKey: instanceParameterEncryptionKey}
 }
 
 type repository struct {
-	db     *gorm.DB
-	config config.Config
+	db                             *gorm.DB
+	instanceParameterEncryptionKey string
 }
 
 func (r repository) FindByIdDecrypted(id uint) (*model.Instance, error) {
@@ -28,7 +27,7 @@ func (r repository) FindByIdDecrypted(id uint) (*model.Instance, error) {
 		return nil, err
 	}
 
-	err = decryptParameters(r.config.InstanceParameterEncryptionKey, instance)
+	err = decryptParameters(r.instanceParameterEncryptionKey, instance)
 
 	return instance, err
 }
@@ -71,7 +70,7 @@ func (r repository) Unlink(instance *model.Instance) error {
 }
 
 func (r repository) Save(instance *model.Instance) error {
-	key := r.config.InstanceParameterEncryptionKey
+	key := r.instanceParameterEncryptionKey
 
 	populateParameterRelations(instance)
 

--- a/pkg/instance/router.go
+++ b/pkg/instance/router.go
@@ -1,15 +1,14 @@
 package instance
 
 import (
-	"github.com/dhis2-sre/im-manager/internal/middleware"
 	"github.com/gin-gonic/gin"
 )
 
-func Routes(r *gin.Engine, authenticationMiddleware middleware.AuthenticationMiddleware, handler Handler) {
+func Routes(r *gin.Engine, authenticator gin.HandlerFunc, handler Handler) {
 	r.GET("/public/instances", handler.ListPublicInstances)
 
 	tokenAuthenticationRouter := r.Group("")
-	tokenAuthenticationRouter.Use(authenticationMiddleware.TokenAuthentication)
+	tokenAuthenticationRouter.Use(authenticator)
 
 	tokenAuthenticationRouter.POST("/instances", handler.Deploy)
 	tokenAuthenticationRouter.GET("/instances", handler.ListInstances)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -11,20 +11,17 @@ import (
 
 	"github.com/dhis2-sre/im-manager/pkg/stack"
 
-	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
 func NewService(
-	config config.Config,
 	instanceRepository Repository,
 	groupService groupService,
 	stackService stack.Service,
 	helmfileService helmfile,
 ) *service {
 	return &service{
-		config,
 		instanceRepository,
 		groupService,
 		stackService,
@@ -47,7 +44,6 @@ type Repository interface {
 
 type groupService interface {
 	Find(name string) (*model.Group, error)
-	FindAll(user *model.User, deployable bool) ([]model.Group, error)
 }
 
 type helmfile interface {
@@ -56,7 +52,6 @@ type helmfile interface {
 }
 
 type service struct {
-	config             config.Config
 	instanceRepository Repository
 	groupService       groupService
 	stackService       stack.Service

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -1,25 +1,26 @@
 package model
 
+// swagger:model Stack
 type Stack struct {
-	Name             string
-	Parameters       StackParameters
-	Instances        []Instance
-	HostnamePattern  string
-	HostnameVariable string
+	Name             string          `json:"name"`
+	Parameters       StackParameters `json:"parameters"`
+	Instances        []Instance      `json:"instances"`
+	HostnamePattern  string          `json:"hostnamePattern"`
+	HostnameVariable string          `json:"hostnameVariable"`
 	// ParameterProviders provide parameters to other stacks.
-	ParameterProviders ParameterProviders
+	ParameterProviders ParameterProviders `json:"-"`
 	// Requires these stacks to deploy an instance of this stack.
-	Requires []Stack
+	Requires []Stack `json:"-"`
 }
 
 type StackParameters map[string]StackParameter
 
 type StackParameter struct {
-	DefaultValue *string
+	DefaultValue *string `json:"defaultValue,omitempty"`
 	// Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
-	Consumed bool
+	Consumed bool `json:"consumed"`
 	// Validator ensures that the actual stack parameters are valid according to its rules.
-	Validator func(value string) error
+	Validator func(value string) error `json:"-"`
 }
 
 type ParameterProviders map[string]ParameterProvider

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -1,6 +1,6 @@
 package model
 
-// swagger:model Stack
+// swagger:model StackDetail
 type Stack struct {
 	Name             string          `json:"name"`
 	Parameters       StackParameters `json:"parameters"`
@@ -13,8 +13,10 @@ type Stack struct {
 	Requires []Stack `json:"-"`
 }
 
+// swagger:model StackDetailParameters
 type StackParameters map[string]StackParameter
 
+// swagger:model StackDetailParameter
 type StackParameter struct {
 	DefaultValue *string `json:"defaultValue,omitempty"`
 	// Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -1,26 +1,25 @@
 package model
 
-// swagger:model Stack
 type Stack struct {
-	Name             string          `json:"name"`
-	Parameters       StackParameters `json:"parameters"`
-	Instances        []Instance      `json:"instances"`
-	HostnamePattern  string          `json:"hostnamePattern"`
-	HostnameVariable string          `json:"hostnameVariable"`
+	Name             string
+	Parameters       StackParameters
+	Instances        []Instance
+	HostnamePattern  string
+	HostnameVariable string
 	// ParameterProviders provide parameters to other stacks.
-	ParameterProviders ParameterProviders `json:"-"`
+	ParameterProviders ParameterProviders
 	// Requires these stacks to deploy an instance of this stack.
-	Requires []Stack `json:"-"`
+	Requires []Stack
 }
 
 type StackParameters map[string]StackParameter
 
 type StackParameter struct {
-	DefaultValue *string `json:"defaultValue,omitempty"`
+	DefaultValue *string
 	// Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
-	Consumed bool `json:"consumed"`
+	Consumed bool
 	// Validator ensures that the actual stack parameters are valid according to its rules.
-	Validator func(value string) error `json:"-"`
+	Validator func(value string) error
 }
 
 type ParameterProviders map[string]ParameterProvider

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -87,7 +87,7 @@ deploy:
             RABBITMQ_PORT: "5672"
             S3_BUCKET: im-databases-{{ .CLASSIFICATION }}
             S3_REGION: eu-west-1
-            DEFAULT_TTL: "172800"
+            DEFAULT_TTL: "172800" # 48 hours
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/values.yaml

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1217,13 +1217,34 @@ definitions:
                 type: string
                 x-go-name: Name
             parameters:
-                $ref: '#/definitions/StackParameters'
                 items:
                     $ref: '#/definitions/StackParameter'
                 type: array
+                x-go-name: Parameters
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
-    StackParameter:
+    StackDetail:
+        properties:
+            hostnamePattern:
+                type: string
+                x-go-name: HostnamePattern
+            hostnameVariable:
+                type: string
+                x-go-name: HostnameVariable
+            instances:
+                items:
+                    $ref: '#/definitions/Instance'
+                type: array
+                x-go-name: Instances
+            name:
+                type: string
+                x-go-name: Name
+            parameters:
+                $ref: '#/definitions/StackDetailParameters'
+        type: object
+        x-go-name: Stack
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+    StackDetailParameter:
         properties:
             consumed:
                 description: Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
@@ -1233,12 +1254,27 @@ definitions:
                 type: string
                 x-go-name: DefaultValue
         type: object
+        x-go-name: StackParameter
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
-    StackParameters:
+    StackDetailParameters:
         additionalProperties:
-            $ref: '#/definitions/StackParameter'
+            $ref: '#/definitions/StackDetailParameter'
         type: object
+        x-go-name: StackParameters
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+    StackParameter:
+        properties:
+            consumed:
+                type: boolean
+                x-go-name: Consumed
+            defaultValue:
+                type: string
+                x-go-name: DefaultValue
+            name:
+                type: string
+                x-go-name: Name
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     Tokens:
         description: Tokens domain object defining user tokens
         properties:
@@ -2905,12 +2941,12 @@ responses:
     StackResponse:
         description: ""
         schema:
-            $ref: '#/definitions/Stack'
+            $ref: '#/definitions/StackDetail'
     StacksResponse:
         description: ""
         schema:
             items:
-                $ref: '#/definitions/Stack'
+                $ref: '#/definitions/StackDetail'
             type: array
     Tokens:
         description: ""

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1217,28 +1217,25 @@ definitions:
                 type: string
                 x-go-name: Name
             parameters:
-                $ref: '#/definitions/StackParameters'
                 items:
                     $ref: '#/definitions/StackParameter'
                 type: array
+                x-go-name: Parameters
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     StackParameter:
         properties:
             consumed:
-                description: Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
                 type: boolean
                 x-go-name: Consumed
             defaultValue:
                 type: string
                 x-go-name: DefaultValue
+            name:
+                type: string
+                x-go-name: Name
         type: object
-        x-go-package: github.com/dhis2-sre/im-manager/pkg/model
-    StackParameters:
-        additionalProperties:
-            $ref: '#/definitions/StackParameter'
-        type: object
-        x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     Tokens:
         description: Tokens domain object defining user tokens
         properties:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1217,25 +1217,28 @@ definitions:
                 type: string
                 x-go-name: Name
             parameters:
+                $ref: '#/definitions/StackParameters'
                 items:
                     $ref: '#/definitions/StackParameter'
                 type: array
-                x-go-name: Parameters
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     StackParameter:
         properties:
             consumed:
+                description: Consumed signals that this parameter is provided by another stack i.e. one of the stacks required stacks.
                 type: boolean
                 x-go-name: Consumed
             defaultValue:
                 type: string
                 x-go-name: DefaultValue
-            name:
-                type: string
-                x-go-name: Name
         type: object
-        x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+    StackParameters:
+        additionalProperties:
+            $ref: '#/definitions/StackParameter'
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/model
     Tokens:
         description: Tokens domain object defining user tokens
         properties:


### PR DESCRIPTION
* remove unused dependencies/fields
* remove instance service interface in the instance handler as we do not benefit from it. We do not test the handler in isolation, nor do we have multiple instance service implementations. Its also not 3rd party code we want to isolate our code from. Only add an interface for any of the above reasons.
* only pass in the needed config instead of the entire config struct