### PR TITLE
test: add instance integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	filippo.io/age v1.0.0
 	github.com/dominikbraun/graph v0.23.0
 	github.com/go-mail/mail v2.3.1+incompatible
 )
@@ -44,7 +45,6 @@ require (
 require (
 	cloud.google.com/go/compute v1.15.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	filippo.io/age v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.28 // indirect
@@ -190,6 +190,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect
+	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1291,6 +1291,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -88,7 +88,7 @@ func (h helmfileService) loadStackParameters(stackName string) (stackParameters,
 
 	b, err := decryptYaml(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decrypt stack parameters: %v", err)
 	}
 
 	var params stackParameters

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -1,0 +1,178 @@
+package instance_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"filippo.io/age"
+	"go.mozilla.org/sops/v3"
+	"go.mozilla.org/sops/v3/aes"
+	"go.mozilla.org/sops/v3/cmd/sops/common"
+	"go.mozilla.org/sops/v3/keys"
+	"go.mozilla.org/sops/v3/keyservice"
+	"go.mozilla.org/sops/v3/stores/yaml"
+	"go.mozilla.org/sops/v3/version"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sops_age "go.mozilla.org/sops/v3/age"
+
+	"github.com/dhis2-sre/im-manager/pkg/instance"
+	"github.com/dhis2-sre/im-manager/pkg/inttest"
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceHandler(t *testing.T) {
+	k8sClient := inttest.SetupK8s(t)
+	db := inttest.SetupDB(t)
+
+	identity, err := age.GenerateX25519Identity()
+	require.NoError(t, err, "failed to generate age key pair")
+	t.Setenv("SOPS_KMS_ARN", "") // make sure not to use key stored in AWS
+	t.Setenv(sops_age.SopsAgeKeyEnv, identity.String())
+	k8sConfig := encryptUsingAge(t, identity, k8sClient.Config)
+
+	group := &model.Group{
+		Name:       "test",
+		Hostname:   "some",
+		Deployable: true,
+		ClusterConfiguration: &model.ClusterConfiguration{
+			GroupName:               "test",
+			KubernetesConfiguration: k8sConfig,
+		},
+	}
+	user := &model.User{
+		Email: "user1@dhis2.org",
+		Groups: []model.Group{
+			*group,
+		},
+	}
+	db.Create(user)
+
+	encryptionKey := strings.Repeat("a", 32)
+	instanceRepo := instance.NewRepository(db, encryptionKey)
+	groupService := groupService{group: group}
+	stacks := stack.Stacks{
+		"whoami-go": stack.WhoamiGo,
+	}
+	stackService := stack.NewService(stacks)
+	// classification 'test' does not actually exist, this is used to decrypt the stack parameters
+	helmfileService := instance.NewHelmfileService("../../stacks", stackService, "test")
+	instanceService := instance.NewService(instanceRepo, groupService, stackService, helmfileService)
+
+	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {
+		var twoDayTTL uint = 172800
+		instanceHandler := instance.NewHandler(groupService, instanceService, twoDayTTL)
+		instance.Routes(engine, func(ctx *gin.Context) {
+			ctx.Set("user", user)
+		}, instanceHandler)
+	})
+
+	t.Run("Deploy", func(t *testing.T) {
+		var instance model.Instance
+		client.PostJSON(t, "/instances", strings.NewReader(`{
+			"name": "test-whoami",
+			"groupName": "test",
+			"stackName": "whoami-go"
+		}`), &instance, inttest.WithAuthToken("sometoken"))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		watch, err := k8sClient.Client.CoreV1().Pods(group.Name).Watch(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/instance=" + instance.Name,
+		})
+		require.NoErrorf(t, err, "failed to find pod for instance %q", instance.Name)
+
+		timeout := 20 * time.Second
+		tm := time.NewTimer(timeout)
+		defer tm.Stop()
+		for {
+			select {
+			case <-tm.C:
+				assert.Fail(t, "timed out waiting on pod")
+				cancel()
+				return
+			case event := <-watch.ResultChan():
+				pod, ok := event.Object.(*v1.Pod)
+				if !ok {
+					assert.Failf(t, "failed to get pod event", "want pod event instead got %T", event.Object)
+					if !tm.Stop() {
+						<-tm.C
+					}
+					cancel()
+					return
+				}
+
+				t.Logf("watching pod conditions: %#v\n", pod.Status.Conditions)
+				for _, condition := range pod.Status.Conditions {
+					if condition.Type == v1.PodReady {
+						t.Logf("pod for instance %q is ready", instance.Name)
+						if !tm.Stop() {
+							<-tm.C
+						}
+						cancel()
+						return
+					}
+				}
+			}
+		}
+	})
+}
+
+func encryptUsingAge(t *testing.T, identity *age.X25519Identity, yamlData []byte) []byte {
+	inputStore := &yaml.Store{}
+	branches, err := inputStore.LoadPlainFile(yamlData)
+	require.NoError(t, err, "failed to load file")
+
+	ageKeys, err := sops_age.MasterKeysFromRecipients(identity.Recipient().String())
+	require.NoError(t, err, "failed to get master keys from age recipient")
+	var ageMasterKeys []keys.MasterKey
+	for _, k := range ageKeys {
+		ageMasterKeys = append(ageMasterKeys, k)
+	}
+	keyGroups := []sops.KeyGroup{ageMasterKeys}
+	keyServices := []keyservice.KeyServiceClient{keyservice.NewLocalClient()}
+
+	tree := sops.Tree{
+		Branches: branches,
+		Metadata: sops.Metadata{
+			KeyGroups:         keyGroups,
+			UnencryptedSuffix: "",
+			EncryptedSuffix:   "",
+			UnencryptedRegex:  "",
+			EncryptedRegex:    "",
+			Version:           version.Version,
+			ShamirThreshold:   0,
+		},
+		FilePath: "",
+	}
+	dataKey, errs := tree.GenerateDataKeyWithKeyServices(keyServices)
+	require.NoError(t, errors.Join(errs...), "failed to generate data key")
+
+	err = common.EncryptTree(common.EncryptTreeOpts{
+		DataKey: dataKey,
+		Tree:    &tree,
+		Cipher:  aes.NewCipher(),
+	})
+	require.NoError(t, err, "failed to encrypt")
+
+	outputStore := &yaml.Store{}
+	encryptedFile, err := outputStore.EmitEncryptedFile(tree)
+	require.NoError(t, err, "failed to emit encrypted yaml file")
+
+	return encryptedFile
+}
+
+type groupService struct {
+	group *model.Group
+}
+
+func (gs groupService) Find(name string) (*model.Group, error) {
+	return gs.group, nil
+}

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -42,7 +42,7 @@ func commandExecutor(cmd *exec.Cmd, configuration *model.ClusterConfiguration) (
 
 	kubeCfg, err := decryptYaml(configuration.KubernetesConfiguration)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to decrypt kubernetes config: %v", err)
 	}
 
 	file, err := os.CreateTemp("", "kubectl")

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -267,7 +267,7 @@ func (s service) Deploy(token string, instance *model.Instance) error {
 
 	syncCmd, err := s.helmfileService.sync(token, instance, group)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute helmfile sync: %v", err)
 	}
 
 	deployLog, deployErrorLog, err := commandExecutor(syncCmd, group.ClusterConfiguration)

--- a/pkg/inttest/k8s.go
+++ b/pkg/inttest/k8s.go
@@ -1,0 +1,48 @@
+package inttest
+
+import (
+	"testing"
+
+	"github.com/orlangure/gnomock/preset/k3s"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/orlangure/gnomock"
+	"github.com/stretchr/testify/require"
+)
+
+// SetupK8s creates an K8s container (using k3s).
+func SetupK8s(t *testing.T) *K8sClient {
+	t.Helper()
+
+	container, err := gnomock.Start(
+		k3s.Preset(
+			k3s.WithVersion("v1.26.7-k3s1"),
+			func(p *k3s.P) {
+				p.K3sServerFlags = []string{"--debug"} // TODO(ivo) remove this flag before merging?
+			},
+		),
+		gnomock.WithDebugMode(), // TODO(ivo) remove this config before merging?
+	)
+	require.NoError(t, err, "failed to start k3s")
+	t.Cleanup(func() { require.NoError(t, gnomock.Stop(container), "failed to stop k3s") })
+
+	k8sConfig, err := k3s.Config(container)
+	require.NoError(t, err, "failed to get k3s config from container")
+	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
+	require.NoError(t, err, "failed to create k8s client")
+
+	k3sConfigBytes, err := k3s.ConfigBytes(container)
+	require.NoError(t, err, "failed to get k3s config from container as bytes")
+
+	return &K8sClient{
+		Client: k8sClient,
+		Config: k3sConfigBytes,
+	}
+}
+
+// K8sClient allows making requests to K8s. It does so by wrapping a kubernetes.Clientset. Access
+// the actual Clientset for specific use cases where our defaults don't work.
+type K8sClient struct {
+	Client *kubernetes.Clientset
+	Config []byte
+}


### PR DESCRIPTION
The intention of the test is to see if we can deploy an instance of a stack. It also tests that a groups encrypted k8s config can be decrypted and is used to deploy into that k8s cluster. It establishes what we need in terms of the test setup (gnomock/k8s client and encrypted config). I took the simplest stack we have `whoami-go`.

* setup k8s via k3s
* encrypt k8s config using age https://github.com/getsops/sops#22encrypting-using-age
* set SOPS_AGE_KEY env in test with the private key used to encrypt. The encrypted k8s config will contain the age details (recipient/public key) needed to decrypt it. `decryptYaml(configuration.KubernetesConfiguration)` will rely the env var to find the private key
* deploy whoami-go and assert the pod is ready i.e. healthy. I am watching pod events using `LabelSelector: "app.kubernetes.io/instance=" + instance.Name`. I do not want to assert on/use too much knowledge of the specific stack. Kubernetes abstracts away what healthy is. Our stacks should have appropriate live/readiness probes defined. Stacks should also be tested individually. This test is not a test of stacks but of im-manager deploying an instance.  

NOTE: this test cannot be run in parallel right now because of our usage of https://pkg.go.dev/testing#T.Setenv. For the decryption to work we need to configure sops. Sops allows us to configure it via env vars like https://github.com/getsops/sops#22encrypting-using-age If we wanted to run the tests in parallel we would need to restructure our code. Maybe make the `decryptYaml` into a struct we pass into the instance service and
* mock in our tests
* or make it configurable. This might require us not using the sops decrypt helper which relies on env vars 🤷🏻 write code that looks more like the one in the encrypt function added in this test.


# Future

We could adjust our code slightly to deploy a test stack we come up with. These test stacks could live in `testdata` and we point the stack service to it. These test stacks could include all the features we use in our real stacks, while being so simple that they start up fast.

We could also try to deploy dhis2-db and dhis2-core.

I think there is still value in having at least one e2e test for the use case that most of our users use.
