### PR TITLE
refactor: support S3 folder/path structure with an optional db prefix

### DIFF
--- a/pkg/database/docs.go
+++ b/pkg/database/docs.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"mime/multipart"
-
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
@@ -61,15 +59,10 @@ type _ struct {
 
 // swagger:parameters uploadDatabase
 type _ struct {
-	// Upload database request body parameter
-	// in: formData
+	// Update database request body parameter
+	// in: body
 	// required: true
-	Group string
-	// Upload database request body parameter
-	// in: formData
-	// required: true
-	// swagger:file
-	File multipart.File
+	Body uploadDatabaseRequest
 }
 
 // swagger:parameters updateDatabaseById

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"mime/multipart"

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"mime/multipart"
@@ -65,7 +64,7 @@ type stackService interface {
 type uploadDatabaseRequest struct {
 	Database *multipart.FileHeader `form:"database"`
 	Group    string                `form:"group"`
-	Prefix   string                `form:"prefix,omitempty"`
+	Name     string                `form:"name"`
 }
 
 // Upload database
@@ -100,10 +99,7 @@ func (h Handler) Upload(c *gin.Context) {
 		return
 	}
 
-	databaseName := file.Filename
-	if request.Prefix != "" {
-		databaseName = fmt.Sprintf("%s/%s", strings.Trim(request.Prefix, "/"), file.Filename)
-	}
+	databaseName := strings.Trim(request.Name, "/")
 
 	d := &model.Database{
 		Name:      databaseName,

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"mime/multipart"

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -117,6 +117,8 @@ func TestInstanceHandler(t *testing.T) {
 		w := multipart.NewWriter(&b)
 		err := w.WriteField("group", "group-name")
 		require.NoError(t, err, "failed to write form field")
+		err = w.WriteField("name", "path/name.extension")
+		require.NoError(t, err, "failed to write form field")
 		f, err := w.CreateFormFile("database", "mydb")
 		require.NoError(t, err, "failed to create form file")
 		_, err = io.WriteString(f, "select now();")
@@ -128,7 +130,7 @@ func TestInstanceHandler(t *testing.T) {
 		var actualDB model.Database
 		err = json.Unmarshal(body, &actualDB)
 		require.NoError(t, err, "POST /databases: failed to unmarshal HTTP response body")
-		require.Equal(t, "mydb", actualDB.Name)
+		require.Equal(t, "path/name.extension", actualDB.Name)
 		require.Equal(t, "group-name", actualDB.GroupName)
 
 		databaseID = strconv.FormatUint(uint64(actualDB.ID), 10)

--- a/scripts/databases/seed.sh
+++ b/scripts/databases/seed.sh
@@ -7,22 +7,22 @@ shift
 VERSIONS=$*
 
 DHIS2_RELEASES_URL="https://releases.dhis2.org/v1/versions/stable.json"
-DB_DUMP_FORMAT='.sql.gz'
+FORMAT='.sql.gz'
 
 function createDatabase() {
-  local db_name=${1}${DB_DUMP_FORMAT}
+  local name=${1}${FORMAT}
 
-  echo "Downloading database $db_name ..."
+  echo "Downloading database $name ..."
 
   mkdir -p "$HOME/Downloads"
-  curl -C - "$2" -o "$HOME/Downloads/$db_name"
+  curl -C - "$2" -o "$HOME/Downloads/$name"
 
   echo "Login ..."
   rm .access_token_cache # to make sure we're not using an expired token if we're seeding a lot of databases
   source ./auth.sh
 
-  echo "Uploading database $db_name ..."
-  ./upload.sh "$GROUP" "sierra-leone/$db_name" "$HOME/Downloads/$db_name"
+  echo "Uploading database $name ..."
+  ./upload.sh "$GROUP" "sierra-leone/$name" "$HOME/Downloads/$name"
   echo # empty line to improve output readability
 }
 

--- a/scripts/databases/seed.sh
+++ b/scripts/databases/seed.sh
@@ -7,19 +7,22 @@ shift
 VERSIONS=$*
 
 DHIS2_RELEASES_URL="https://releases.dhis2.org/v1/versions/stable.json"
+DB_DUMP_FORMAT='.sql.gz'
 
 function createDatabase() {
-  echo "Downloading database $1 ..."
+  local db_name=${1}${DB_DUMP_FORMAT}
+
+  echo "Downloading database $db_name ..."
 
   mkdir -p "$HOME/Downloads"
-  curl -C - "$2" -o "$HOME/Downloads/$1.sql.gz"
+  curl -C - "$2" -o "$HOME/Downloads/$db_name"
 
   echo "Login ..."
   rm .access_token_cache # to make sure we're not using an expired token if we're seeding a lot of databases
   source ./auth.sh
 
-  echo "Uploading database $1 ..."
-  ./upload.sh "$GROUP" "$HOME/Downloads/$1.sql.gz" sierra-leone
+  echo "Uploading database $db_name ..."
+  ./upload.sh "$GROUP" "sierra-leone/$db_name" "$HOME/Downloads/$db_name"
   echo # empty line to improve output readability
 }
 
@@ -35,7 +38,7 @@ if [[ -z "$*" ]]; then
 fi
 
 # shellcheck disable=SC2145
-echo "Seeding the following databases: ${VERSIONS[@]}"
+echo "Seeding the following database versions: ${VERSIONS[@]}"
 
 for VERSION in "${VERSIONS[@]}"; do
   createDatabase "$VERSION" "https://databases.dhis2.org/sierra-leone/$VERSION/dhis2-db-sierra-leone.sql.gz"

--- a/scripts/databases/seed.sh
+++ b/scripts/databases/seed.sh
@@ -19,7 +19,7 @@ function createDatabase() {
   source ./auth.sh
 
   echo "Uploading database $1 ..."
-  ./upload.sh "$GROUP" "$HOME/Downloads/$1.sql.gz"
+  ./upload.sh "$GROUP" "$HOME/Downloads/$1.sql.gz" sierra-leone
   echo # empty line to improve output readability
 }
 
@@ -38,5 +38,5 @@ fi
 echo "Seeding the following databases: ${VERSIONS[@]}"
 
 for VERSION in "${VERSIONS[@]}"; do
-  createDatabase "Sierra Leone - $VERSION" "https://databases.dhis2.org/sierra-leone/$VERSION/dhis2-db-sierra-leone.sql.gz"
+  createDatabase "$VERSION" "https://databases.dhis2.org/sierra-leone/$VERSION/dhis2-db-sierra-leone.sql.gz"
 done

--- a/scripts/databases/upload.sh
+++ b/scripts/databases/upload.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 source ./auth.sh
 
 GROUP=$1
-FILE=$2
-PREFIX=${3:-""}
+NAME=$2
+FILE=$3
 
 #$HTTP --ignore-stdin --form post "$IM_HOST/databases" "group=$GROUP" "database@$FILE" "Authorization: Bearer $ACCESS_TOKEN"
-curl --fail --progress-bar -H "Authorization: $ACCESS_TOKEN" -F "group=$GROUP" -F "prefix=$PREFIX" -F "database=@$FILE" -L "$IM_HOST/databases" | cat
+curl --fail --progress-bar -H "Authorization: $ACCESS_TOKEN" -F "group=$GROUP" -F "name=$NAME" -F "database=@$FILE" -L "$IM_HOST/databases" | cat

--- a/scripts/databases/upload.sh
+++ b/scripts/databases/upload.sh
@@ -6,6 +6,7 @@ source ./auth.sh
 
 GROUP=$1
 FILE=$2
+PREFIX=${3:-""}
 
 #$HTTP --ignore-stdin --form post "$IM_HOST/databases" "group=$GROUP" "database@$FILE" "Authorization: Bearer $ACCESS_TOKEN"
-curl --fail --progress-bar -H "Authorization: $ACCESS_TOKEN" -F "group=$GROUP" -F "database=@$FILE" -L "$IM_HOST/databases" | cat
+curl --fail --progress-bar -H "Authorization: $ACCESS_TOKEN" -F "group=$GROUP" -F "prefix=$PREFIX" -F "database=@$FILE" -L "$IM_HOST/databases" | cat

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -601,7 +601,7 @@ definitions:
                 $ref: '#/definitions/FileHeader'
             Group:
                 type: string
-            Prefix:
+            Name:
                 type: string
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/database

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -235,6 +235,18 @@ definitions:
                 x-go-name: UUID
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+    FileHeader:
+        properties:
+            Filename:
+                type: string
+            Header:
+                $ref: '#/definitions/MIMEHeader'
+            Size:
+                format: int64
+                type: integer
+        title: A FileHeader describes a file part of a multipart request.
+        type: object
+        x-go-package: mime/multipart
     Group:
         description: Group domain object defining a group
         properties:
@@ -392,6 +404,16 @@ definitions:
                 x-go-name: InstanceId
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/database
+    MIMEHeader:
+        additionalProperties:
+            items:
+                type: string
+            type: array
+        description: |-
+            A MIMEHeader represents a MIME-style header mapping
+            keys to sets of values.
+        type: object
+        x-go-package: net/textproto
     RefreshTokenRequest:
         properties:
             refreshToken:
@@ -573,6 +595,16 @@ definitions:
                 x-go-name: Password
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/user
+    uploadDatabaseRequest:
+        properties:
+            Database:
+                $ref: '#/definitions/FileHeader'
+            Group:
+                type: string
+            Prefix:
+                type: string
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/database
     validateEmailRequest:
         properties:
             token:
@@ -610,16 +642,12 @@ paths:
             description: Upload database...
             operationId: uploadDatabase
             parameters:
-                - description: Upload database request body parameter
-                  in: formData
-                  name: Group
+                - description: Update database request body parameter
+                  in: body
+                  name: Body
                   required: true
-                  type: string
-                - description: Upload database request body parameter
-                  in: formData
-                  name: File
-                  required: true
-                  type: file
+                  schema:
+                    $ref: '#/definitions/uploadDatabaseRequest'
             responses:
                 "201":
                     $ref: '#/responses/Database'


### PR DESCRIPTION
Implements an S3 folder-like structure with a `name` field that supports forward slashes. 

Can be tested at - https://radnov.im.dhis2.org


Note that leading and trailing `/` is trimmed from the prefix, so that users can't create paths like `this/one//file.sql.gz`, where the double forward slash `//` would result in an extra directory in S3 named `/`.
```
$ ./upload.sh whoami /path/with/leading/and/trailing/slash/ ~/Downloads/dhis2-dbs/dev.sql.gz | jq
######################################################################################################################################################################################## 100.0%
{
  "id": 29,
  "createdAt": "2023-10-12T10:17:25.607254559Z",
  "updatedAt": "2023-10-12T10:17:25.607254559Z",
  "name": "path/with/leading/and/trailing/slash",
  "groupName": "whoami",
  "url": "s3://im-databases-feature/whoami/path/with/leading/and/trailing/slash",
  "externalDownloads": null,
  "lock": null,
  "slug": "whoami-path-with-leading-and-trailing-slash"
```

And here is [that database in S3](https://s3.console.aws.amazon.com/s3/object/im-databases-feature?region=eu-west-1&prefix=whoami/path/with/leading/and/trailing/slash/dev.sql.gz).