### PR TITLE
refactor: return conflict if multiple pods are found

### DIFF
--- a/internal/errdef/errdef.go
+++ b/internal/errdef/errdef.go
@@ -61,3 +61,16 @@ func IsNotFound(err error) bool {
 	var e notFound
 	return errors.As(err, &e)
 }
+
+// NewConflict creates an error representing a conflicting state.
+func NewConflict(format string, a ...any) error {
+	return conflict{fmt.Errorf(format, a...)}
+}
+
+type conflict struct{ error }
+
+// IsConflict returns true if err is an error representing a conflict and false otherwise.
+func IsConflict(err error) bool {
+	var e conflict
+	return errors.As(err, &e)
+}

--- a/internal/middleware/errorHandler.go
+++ b/internal/middleware/errorHandler.go
@@ -34,6 +34,8 @@ func ErrorHandler() gin.HandlerFunc {
 			c.String(http.StatusNotFound, err.Error())
 		} else if errdef.IsUnauthorized(err) {
 			c.String(http.StatusUnauthorized, err.Error())
+		} else if errdef.IsConflict(err) {
+			c.String(http.StatusConflict, err.Error())
 		} else {
 			id := uuid.New()
 			log.Printf("unhandled error: %q, log id: %s\n", err, id)

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -1216,6 +1216,7 @@ func (h Handler) Status(c *gin.Context) {
 	//	401: Error
 	//	403: Error
 	//	404: Error
+	//	409: Error
 	//	415: Error
 	id, ok := handler.GetPathParameter(c, "id")
 	if !ok {

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -163,7 +163,7 @@ func (ks kubernetesService) getPod(instance *model.Instance, typeSelector string
 		return v1.Pod{}, errdef.NewNotFound("failed to find pod using the selector: %q", selector)
 	}
 	if len(pods.Items) > 1 {
-		return v1.Pod{}, fmt.Errorf("multiple pods found using the selector: %q", selector)
+		return v1.Pod{}, errdef.NewConflict("multiple pods found using the selector: %q", selector)
 	}
 
 	return pods.Items[0], nil

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1699,6 +1699,8 @@ paths:
                     $ref: '#/responses/Error'
                 "404":
                     $ref: '#/responses/Error'
+                "409":
+                    $ref: '#/responses/Error'
                 "415":
                     $ref: '#/responses/Error'
             security:


### PR DESCRIPTION
The goal of this PR is to avoid returning 500 when multiple pods are found during an instance status request