### PR TITLE
fix: deploy both core and pgAdmin

### DIFF
--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -29,21 +29,17 @@ func TestResolveParameters(t *testing.T) {
 		}
 		stackService := stack.NewService(stacks)
 		service := NewService(nil, nil, stackService, nil)
-		deployment := &model.Deployment{
-			Instances: []*model.DeploymentInstance{
-				{
-					StackName: "stack",
-					Parameters: map[string]model.DeploymentInstanceParameter{
-						"parameter": {
-							ParameterName: "parameter",
-							Value:         "user overwrite",
-						},
-					},
+		instance := &model.DeploymentInstance{
+			StackName: "stack",
+			Parameters: map[string]model.DeploymentInstanceParameter{
+				"parameter": {
+					ParameterName: "parameter",
+					Value:         "user overwrite",
 				},
 			},
 		}
 
-		err := service.resolveParameters(deployment)
+		err := service.SaveInstance(instance)
 
 		require.ErrorContains(t, err, "consumed parameters can't be supplied by the user: parameter")
 	})

--- a/stacks/pgadmin/helmfile.yaml
+++ b/stacks/pgadmin/helmfile.yaml
@@ -1,7 +1,7 @@
 # consumedParameters: DATABASE_USERNAME, DATABASE_NAME, DATABASE_HOSTNAME
 # hostnameVariable: DATABASE_HOSTNAME
 releases:
-  - name: {{ requiredEnv "INSTANCE_NAME" }}
+  - name: {{ requiredEnv "INSTANCE_NAME" }}-pgadmin
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
     chart: runix/pgadmin4
     version: "{{ env "CHART_VERSION" | default "1.11.0" }}"
@@ -19,7 +19,7 @@ releases:
           hosts:
             - host: {{ requiredEnv "INSTANCE_HOSTNAME" }}
               paths:
-                - path: /{{ requiredEnv "INSTANCE_NAME" }}
+                - path: /{{ requiredEnv "INSTANCE_NAME" }}-pgadmin
                   pathType: Prefix
           annotations:
             cert-manager.io/cluster-issuer: cert-issuer-prod


### PR DESCRIPTION
The goal of this PR is to...
* reject user submitted consumed parameters before resolving parameters from required instances
* avoid overlapping ingress paths