### PR TITLE
chore: update reset.sh to target deployment instances

### DIFF
--- a/scripts/instances/reset.sh
+++ b/scripts/instances/reset.sh
@@ -4,9 +4,6 @@ set -euo pipefail
 
 source ./auth.sh
 
-GROUP=$1
-NAME=$2
-
-INSTANCE_ID=$($HTTP get "$IM_HOST/instances-name-to-id/$GROUP/$NAME" "Authorization: Bearer $ACCESS_TOKEN")
+INSTANCE_ID=$1
 
 $HTTP put "$IM_HOST/instances/$INSTANCE_ID/reset" "Authorization: Bearer $ACCESS_TOKEN"


### PR DESCRIPTION
The goal of this PR is to update the reset user script to target deployment instances.

It no longer accepts group and name but rather the id of the deployment instance.

It can be used in combination with the findByName.sh script as seen below
```
./reset.sh $(./findByName.sh group name | jq '.instances[] | select(.stackName=="dhis2-core") | .id')
```