### PR TITLE
refactor: deduplicate index names

### DIFF
--- a/pkg/model/database.go
+++ b/pkg/model/database.go
@@ -11,8 +11,8 @@ type Database struct {
 	ID                uint               `json:"id" gorm:"primarykey"`
 	CreatedAt         time.Time          `json:"createdAt"`
 	UpdatedAt         time.Time          `json:"updatedAt"`
-	Name              string             `json:"name" gorm:"index:idx_name_and_group,unique"`
-	GroupName         string             `json:"groupName" gorm:"index:idx_name_and_group,unique"`
+	Name              string             `json:"name" gorm:"index:database_name_group_idx,unique"`
+	GroupName         string             `json:"groupName" gorm:"index:database_name_group_idx,unique"`
 	Url               string             `json:"url"` // s3... Path?
 	ExternalDownloads []ExternalDownload `json:"externalDownloads" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Lock              *Lock              `json:"lock" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`

--- a/pkg/model/instance.go
+++ b/pkg/model/instance.go
@@ -34,11 +34,11 @@ type DeploymentInstance struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 
 	// TODO: FK to name of Deployment?
-	Name      string `json:"name" gorm:"index:idx_name_and_group,unique"`
+	Name      string `json:"name" gorm:"index:idx_name_and_group_stack,unique"`
 	Group     *Group `json:"group,omitempty"`
-	GroupName string `json:"groupName" gorm:"index:idx_name_and_group,unique; references:Name"`
+	GroupName string `json:"groupName" gorm:"index:idx_name_and_group_stack,unique; references:Name"`
 	//	Stack     *Stack `json:"stack,omitempty"`
-	StackName string `json:"stackName" gorm:"index:idx_name_and_group,unique"`
+	StackName string `json:"stackName" gorm:"index:idx_name_and_group_stack,unique"`
 
 	DeploymentID uint        `json:"deploymentId"`
 	Deployment   *Deployment `json:"deployment,omitempty"`

--- a/pkg/model/instance.go
+++ b/pkg/model/instance.go
@@ -15,9 +15,9 @@ type Deployment struct {
 	UserID uint  `json:"userId"`
 	User   *User `json:"user,omitempty"`
 
-	Name        string `json:"name" gorm:"index:idx_name_and_group,unique"`
+	Name        string `json:"name" gorm:"index:deployment_name_group_idx,unique"`
 	Description string `json:"description"`
-	GroupName   string `json:"groupName" gorm:"index:idx_name_and_group,unique; references:Name"`
+	GroupName   string `json:"groupName" gorm:"index:deployment_name_group_idx,unique; references:Name"`
 	Group       *Group `json:"group,omitempty"`
 
 	Public bool `json:"public"`
@@ -34,11 +34,11 @@ type DeploymentInstance struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 
 	// TODO: FK to name of Deployment?
-	Name      string `json:"name" gorm:"index:idx_name_and_group_stack,unique"`
+	Name      string `json:"name" gorm:"index:deployment_instance_name_group_stack_idx,unique"`
 	Group     *Group `json:"group,omitempty"`
-	GroupName string `json:"groupName" gorm:"index:idx_name_and_group_stack,unique; references:Name"`
+	GroupName string `json:"groupName" gorm:"index:deployment_instance_name_group_stack_idx,unique; references:Name"`
 	//	Stack     *Stack `json:"stack,omitempty"`
-	StackName string `json:"stackName" gorm:"index:idx_name_and_group_stack,unique"`
+	StackName string `json:"stackName" gorm:"index:deployment_instance_name_group_stack_idx,unique"`
 
 	DeploymentID uint        `json:"deploymentId"`
 	Deployment   *Deployment `json:"deployment,omitempty"`
@@ -80,9 +80,9 @@ type Instance struct {
 	ID          uint                `json:"id" gorm:"primarykey"`
 	User        User                `json:"user"`
 	UserID      uint                `json:"userId"`
-	Name        string              `json:"name" gorm:"index:idx_name_and_group,unique"`
+	Name        string              `json:"name" gorm:"index:instance_name_group_idx,unique"`
 	Group       Group               `json:"group"`
-	GroupName   string              `json:"groupName" gorm:"index:idx_name_and_group,unique"`
+	GroupName   string              `json:"groupName" gorm:"index:instance_name_group_idx,unique"`
 	Description string              `json:"description"`
 	StackName   string              `json:"stackName"`
 	TTL         uint                `json:"ttl"`


### PR DESCRIPTION
Gorm doesn't error or warn about indices of different tables that have the same name and only creates one of them.

The renamed indices are using the [format suggested here](https://stackoverflow.com/questions/4107915/postgresql-default-constraint-names/4108266#4108266) - `{tablename}_{columnname(s)}_{suffix}`.

Note that the rest of the indices will be renamed in a separate PR (https://dhis2.atlassian.net/browse/DEVOPS-378).