### PR TITLE
chore: let gin log using slog DEVOPS-170

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -176,7 +176,7 @@ func run() error {
 		return err
 	}
 
-	r := server.GetEngine(cfg.BasePath)
+	r := server.GetEngine(logger, cfg.BasePath)
 
 	group.Routes(r, authentication, authorization, groupHandler)
 	user.Routes(r, authentication, authorization, userHandler)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/orlangure/gnomock v0.30.0
 	github.com/rabbitmq/amqp091-go v1.9.0
+	github.com/samber/slog-gin v1.12.1
 	github.com/stretchr/testify v1.9.0
 	go.mozilla.org/sops/v3 v3.7.3
 	golang.org/x/crypto v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -716,6 +716,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/samber/slog-gin v1.12.1 h1:cVNbmf/vEktrJkTJzyfnlDDE8MUVSzgrFpnzqqUcTLo=
+github.com/samber/slog-gin v1.12.1/go.mod h1:i6SkTHMmyiy2lBYBaVrJIktLl5lLOyW84ts1PKpC+SQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -1,6 +1,10 @@
 package server
 
 import (
+	"log/slog"
+
+	sloggin "github.com/samber/slog-gin"
+
 	"github.com/dhis2-sre/im-manager/internal/middleware"
 	"github.com/dhis2-sre/im-manager/pkg/health"
 	"github.com/gin-contrib/cors"
@@ -8,8 +12,10 @@ import (
 	redocMiddleware "github.com/go-openapi/runtime/middleware"
 )
 
-func GetEngine(basePath string) *gin.Engine {
-	r := gin.Default()
+func GetEngine(logger *slog.Logger, basePath string) *gin.Engine {
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(sloggin.New(logger.WithGroup("http")))
 
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowAllOrigins = true

--- a/pkg/inttest/http.go
+++ b/pkg/inttest/http.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/dhis2-sre/im-manager/internal/handler"
@@ -26,7 +28,8 @@ func SetupHTTPServer(t *testing.T, f func(engine *gin.Engine)) *HTTPClient {
 	require.NoError(t, err, "failed to register validation")
 	gin.SetMode(gin.TestMode)
 
-	engine := server.GetEngine("")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	engine := server.GetEngine(logger, "")
 	f(engine)
 
 	//goland:noinspection GoImportUsedAsName


### PR DESCRIPTION
Use middleware https://github.com/samber/slog-gin to let Gin log using slog. This means we replaced the default

https://github.com/gin-gonic/gin/blob/4ea0e648e38a63d6caff14100f5eab5c50912bcd/gin.go#L216-L221

by creating a new router and only adding the `Recovery` middleware and the slog middleware.

So instead of a log line like

```
[GIN] 2024/04/29 - 14:33:01 | 200 |     105.956µs |    10.0.103.193 | GET      "/health"
```

We now log

```
time=2024-04-29T14:33:01.009Z level=INFO msg="Incoming request" http.request.time=2024-04-29T14:33:01.008Z http.request.method=GET http.request.host=10.0.101.202:8080 http.request.path=/health http.request.query="" http.request.params=map[] http.request.route=/health http.request.ip=10.0.103.193 http.request.referer="" http.request.length=0 http.response.time=2024-04-29T14:33:01.008Z http.response.latency=22.97µs http.response.status=200 http.response.length=15 http.id=da6aaa76-8114-4d34-bd68-3004ce413cdc
```

# Next

* Replace using https://pkg.go.dev/log with https://pkg.go.dev/log/slog in im-manager code.
* Configure Loki to extract and index some of the key/value pairs in our log lines. I am hoping that https://grafana.com/docs/loki/latest/send-data/promtail/stages/logfmt works since the TextHandler emits space separated `key=val` pairs. Extract at least `http.id` which is the request/trace id generated by the slog middleware at the start of a request.