### PR TITLE
chore: log request id inside Gin context DEVOPS-170

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -67,10 +67,12 @@ func run() error {
 		return err
 	}
 
+	httpLoggerGroup := "http"
+	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil), httpLoggerGroup))
 	userRepository := user.NewRepository(db)
 	dailer := mail.NewDialer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password)
 	userService := user.NewService(cfg.UIURL, cfg.PasswordTokenTTL, userRepository, dailer)
-	authorization := middleware.NewAuthorization(userService)
+	authorization := middleware.NewAuthorization(logger, userService)
 	redis := storage.NewRedis(cfg)
 	tokenRepository := token.NewRepository(redis)
 	privateKey, err := cfg.Authentication.Keys.GetPrivateKey()
@@ -113,8 +115,6 @@ func run() error {
 
 	dockerHubClient := integration.NewDockerHubClient(cfg.DockerHub.Username, cfg.DockerHub.Password)
 
-	httpLoggerGroup := "http"
-	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil), httpLoggerGroup))
 	host := hostname()
 	consumer, err := rabbitmq.NewConsumer(
 		cfg.RabbitMqURL.GetUrl(),

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -169,7 +169,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	err = createGroups(cfg.Groups, logger, groupService)
+	err = createGroups(logger, groupService, cfg.Groups)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ type groupService interface {
 	AddUser(groupName string, userId uint) error
 }
 
-func createGroups(groups []config.Group, logger *slog.Logger, groupService groupService) error {
+func createGroups(logger *slog.Logger, groupService groupService, groups []config.Group) error {
 	logger.Info("Creating groups...")
 	for _, g := range groups {
 		newGroup, err := groupService.FindOrCreate(g.Name, g.Hostname, true)

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -30,9 +30,8 @@ basePath: ""
 #  key: value
 #  ...
 
-#environment:
-#  key: value
-#  ...
+environment:
+  GIN_MODE: release
 
 #groups:
 #  names: whoami

--- a/internal/log/hander_test.go
+++ b/internal/log/hander_test.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	sloggin "github.com/samber/slog-gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestIDHandler(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	gin.SetMode(gin.TestMode)
+
+	var b bytes.Buffer
+	var requestID string
+	r := gin.New()
+	logger := slog.New(RequestIDHandler{Handler: slog.NewJSONHandler(&b, nil)})
+	r.Use(sloggin.New(logger))
+
+	r.GET("/", func(ctx *gin.Context) {
+		requestID = sloggin.GetRequestID(ctx)
+
+		// samber/slog-gin and our call to InfoContext should add log lines with attribute
+		// id=<requestID>
+		logger.InfoContext(ctx, "info")
+		ctx.String(http.StatusOK, "success")
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/", nil)
+	require.NoError(err)
+	r.ServeHTTP(w, req)
+	require.Equal(http.StatusOK, w.Code)
+
+	sc := bufio.NewScanner(&b)
+	for sc.Scan() {
+		line := sc.Text()
+		got := make(map[string]any)
+
+		err = json.Unmarshal([]byte(line), &got)
+
+		assert.NoError(err)
+		t.Log("log line:", line)
+		v, ok := got["id"]
+		assert.True(ok, "want log line to have key `id`")
+		assert.Equal(requestID, v, "want log line to have request `id` set")
+	}
+}

--- a/internal/log/handler.go
+++ b/internal/log/handler.go
@@ -1,0 +1,35 @@
+// Package log provides slog handlers.
+package log
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/gin-gonic/gin"
+	sloggin "github.com/samber/slog-gin"
+)
+
+// RequestIDHandler adds the request ID to the slog.Record if present in the Gin context.
+type RequestIDHandler struct {
+	slog.Handler
+	group string
+}
+
+func New(handler slog.Handler, group string) RequestIDHandler {
+	return RequestIDHandler{
+		Handler: handler,
+		group:   group,
+	}
+}
+
+func (rh RequestIDHandler) Handle(ctx context.Context, r slog.Record) error {
+	if ginCtx, ok := ctx.(*gin.Context); ok {
+		// we are logging the request id under the same key used by the slog Gin middleware
+		// https://github.com/samber/slog-gin/blob/812b3ffb5d6c562fa79e00edaef5409cd053f4d0/middleware.go#L167-L169
+		// this allows us to find logs we make via the context aware logger functions like
+		// logger.InfoContext as well as the ones made by the Gin middleware using the same key and
+		// id
+		r.AddAttrs(slog.Group(rh.group, slog.String("id", sloggin.GetRequestID(ginCtx))))
+	}
+	return rh.Handler.Handle(ctx, r)
+}

--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -45,9 +45,9 @@ func (m AuthorizationMiddleware) RequireAdministrator(c *gin.Context) {
 	}
 
 	if !userWithGroups.IsAdministrator() {
-		// TODO investigate how to log user related info without logging sensitive information
-		// failed requests are already logged by samber/slog-gin so we would want to add necessary
-		// debug info into the middleware if possible
+		// TODO(DEVOPS-170) investigate how to log user related info without logging sensitive
+		// information failed requests are already logged by samber/slog-gin so we would want to add
+		// necessary debug info into the middleware if possible
 		m.logger.ErrorContext(c, "User tried to access administrator restricted endpoint", "user", u.ID)
 		_ = c.AbortWithError(http.StatusUnauthorized, errors.New("administrator access denied"))
 		return

--- a/internal/middleware/errorHandler.go
+++ b/internal/middleware/errorHandler.go
@@ -2,12 +2,11 @@ package middleware
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
+	sloggin "github.com/samber/slog-gin"
 )
 
 func ErrorHandler() gin.HandlerFunc {
@@ -37,8 +36,7 @@ func ErrorHandler() gin.HandlerFunc {
 		} else if errdef.IsConflict(err) {
 			c.String(http.StatusConflict, err.Error())
 		} else {
-			id := uuid.New()
-			log.Printf("unhandled error: %q, log id: %s\n", err, id)
+			id := sloggin.GetRequestID(c)
 			err := fmt.Errorf("something went wrong. We'll look into it if you send us the id %q :)", id)
 			c.String(http.StatusInternalServerError, err.Error())
 		}

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -3,13 +3,12 @@ package server
 import (
 	"log/slog"
 
-	sloggin "github.com/samber/slog-gin"
-
 	"github.com/dhis2-sre/im-manager/internal/middleware"
 	"github.com/dhis2-sre/im-manager/pkg/health"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	redocMiddleware "github.com/go-openapi/runtime/middleware"
+	sloggin "github.com/samber/slog-gin"
 )
 
 func GetEngine(logger *slog.Logger, basePath string, allowedOrigins []string) *gin.Engine {

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -11,10 +11,10 @@ import (
 	sloggin "github.com/samber/slog-gin"
 )
 
-func GetEngine(logger *slog.Logger, basePath string, allowedOrigins []string) *gin.Engine {
+func GetEngine(logger *slog.Logger, loggerGroup, basePath string, allowedOrigins []string) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.Use(sloggin.New(logger.WithGroup("http")))
+	r.Use(sloggin.New(logger.WithGroup(loggerGroup)))
 
 	corsConfig := cors.DefaultConfig()
 	// Without specifying origins, secure cookies won't work

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	SMTP                           smtp
 	Redis                          redis
 	Authentication                 Authentication
-	Groups                         []group
+	Groups                         []Group
 	AdminUser                      user
 	E2eTestUser                    user
 	S3Bucket                       string
@@ -198,12 +198,12 @@ func (k keys) GetPublicKey() (*rsa.PublicKey, error) {
 	return publicKey.(*rsa.PublicKey), nil
 }
 
-type group struct {
+type Group struct {
 	Name     string
 	Hostname string
 }
 
-func newGroups() []group {
+func newGroups() []Group {
 	groupNames := requireEnvAsArray("GROUP_NAMES")
 	groupHostnames := requireEnvAsArray("GROUP_HOSTNAMES")
 
@@ -211,7 +211,7 @@ func newGroups() []group {
 		log.Fatalf("len(GROUP_NAMES) != len(GROUP_HOSTNAMES)")
 	}
 
-	groups := make([]group, len(groupNames))
+	groups := make([]Group, len(groupNames))
 	for i := 0; i < len(groupNames); i++ {
 		groups[i].Name = groupNames[i]
 		groups[i].Hostname = groupHostnames[i]

--- a/pkg/inttest/http.go
+++ b/pkg/inttest/http.go
@@ -29,7 +29,7 @@ func SetupHTTPServer(t *testing.T, f func(engine *gin.Engine)) *HTTPClient {
 	gin.SetMode(gin.TestMode)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	engine := server.GetEngine(logger, "", []string{"http://localhost"})
+	engine := server.GetEngine(logger, "http", "", []string{"http://localhost"})
 	f(engine)
 
 	//goland:noinspection GoImportUsedAsName

--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -3,7 +3,9 @@ package user_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -35,7 +37,7 @@ func TestUserHandler(t *testing.T) {
 	err := user.CreateUser("admin", "admin", userService, groupService, model.AdministratorGroupName, "admin")
 	require.NoError(t, err, "failed to create admin user and group")
 
-	authorization := middleware.NewAuthorization(userService)
+	authorization := middleware.NewAuthorization(slog.New(slog.NewTextHandler(os.Stdout, nil)), userService)
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "failed to generate private key")
 	// TODO(DEVOPS-259) we should not use a pointer as we do not mutate and should not mutate the


### PR DESCRIPTION
* Set `GIN_MODE` to release. We need to make sure every im-manager log line uses the key=val format so we can parse it in Loki using logfmt. Gin prints some debug info and a warning in a non logfmt at the start of im-manager. Setting the mode to release stops this.
* Return `http.request.id` to users receiving an HTTP 500. The id is generated by https://github.com/samber/slog-gin and put into the Gin context. Once we have configured Loki to extract that id and index it we can find all logs to the users failed request.
* Do not log HTTP 500 errors in our error handler. The logging middleware for Gin will [already log errors](https://github.com/samber/slog-gin/blob/812b3ffb5d6c562fa79e00edaef5409cd053f4d0/middleware.go#L62) using `slog.Error`.
* Log `http.id` when in Gin context. `RequestIDHandler` wraps an `slog.Handler` like the `TextHandler` and adds attribute `<group>.id` to the log record. This ensure that when we log using context methods like `logger.InfoContext` the log entries will have the request id logged. We can then find all logs, whether we logged them or middleware `samber/slog-gin` logged them.

# Next

* Replace using https://pkg.go.dev/log with https://pkg.go.dev/log/slog in im-manager code.
* Configure Loki to extract and index some of the key/value pairs in our log lines. I am hoping that https://grafana.com/docs/loki/latest/send-data/promtail/stages/logfmt works since the TextHandler emits space separated `key=val` pairs. Extract at least `http.id` which is the request/trace id generated by the slog middleware at the start of a request.