### PR TITLE
chore: replace all uses of log with slog DEVOPS-170

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,16 @@
 run:
   timeout: 4m
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - sloglint
+    - staticcheck
+    - unused
+linters-settings:
+  sloglint:
+    no-global: "all"
+    static-msg: true
+    key-naming-case: camel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: go-sec-repo-mod
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.54.2
+    rev: v1.57.2
     hooks:
       - id: golangci-lint
         args:

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -75,7 +75,7 @@ func run() error {
 	authorization := middleware.NewAuthorization(logger, userService)
 	redis := storage.NewRedis(cfg)
 	tokenRepository := token.NewRepository(redis)
-	privateKey, err := cfg.Authentication.Keys.GetPrivateKey()
+	privateKey, err := cfg.Authentication.Keys.GetPrivateKey(logger)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,9 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	tokenService, err := token.NewService(tokenRepository, privateKey, publicKey, cfg.Authentication.AccessTokenExpirationSeconds, cfg.Authentication.RefreshTokenSecretKey, cfg.Authentication.RefreshTokenExpirationSeconds)
+	tokenService, err := token.NewService(logger, tokenRepository, privateKey, publicKey,
+		cfg.Authentication.AccessTokenExpirationSeconds, cfg.Authentication.RefreshTokenSecretKey,
+		cfg.Authentication.RefreshTokenExpirationSeconds)
 	if err != nil {
 		return err
 	}
@@ -110,8 +112,8 @@ func run() error {
 	stackService := stack.NewService(stacks)
 
 	instanceRepository := instance.NewRepository(db, cfg.InstanceParameterEncryptionKey)
-	helmfileService := instance.NewHelmfileService("./stacks", stackService, cfg.Classification)
-	instanceService := instance.NewService(instanceRepository, groupService, stackService, helmfileService)
+	helmfileService := instance.NewHelmfileService(logger, stackService, "./stacks", cfg.Classification)
+	instanceService := instance.NewService(logger, instanceRepository, groupService, stackService, helmfileService)
 
 	dockerHubClient := integration.NewDockerHubClient(cfg.DockerHub.Username, cfg.DockerHub.Password)
 
@@ -155,8 +157,8 @@ func run() error {
 	s3Client := storage.NewS3Client(logger, s3AWSClient, uploader)
 
 	databaseRepository := database.NewRepository(db)
-	databaseService := database.NewService(cfg.S3Bucket, s3Client, groupService, databaseRepository)
-	databaseHandler := database.NewHandler(databaseService, groupService, instanceService, stackService)
+	databaseService := database.NewService(logger, cfg.S3Bucket, s3Client, groupService, databaseRepository)
+	databaseHandler := database.NewHandler(logger, databaseService, groupService, instanceService, stackService)
 
 	err = handler.RegisterValidation()
 	if err != nil {

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -127,7 +127,7 @@ func run() error {
 	}
 	defer consumer.Close()
 
-	ttlDestroyConsumer := instance.NewTTLDestroyConsumer(consumer, instanceService)
+	ttlDestroyConsumer := instance.NewTTLDestroyConsumer(logger, consumer, instanceService)
 	err = ttlDestroyConsumer.Consume()
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func run() error {
 		o.UsePathStyle = true
 	})
 	uploader := manager.NewUploader(s3AWSClient)
-	s3Client := storage.NewS3Client(s3AWSClient, uploader)
+	s3Client := storage.NewS3Client(logger, s3AWSClient, uploader)
 
 	databaseRepository := database.NewRepository(db)
 	databaseService := database.NewService(cfg.S3Bucket, s3Client, groupService, databaseRepository)

--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"crypto/rsa"
 	"errors"
-	"log"
 	"net/http"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -56,7 +55,6 @@ func (m AuthenticationMiddleware) handleError(c *gin.Context, e error) {
 func (m AuthenticationMiddleware) TokenAuthentication(c *gin.Context) {
 	user, err := parseRequest(c.Request, m.publicKey)
 	if err != nil {
-		log.Println("token not valid:", err)
 		_ = c.Error(errdef.NewUnauthorized("token not valid"))
 		c.Abort()
 		return

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -159,7 +160,7 @@ type keys struct {
 	PublicKey  string
 }
 
-func (k keys) GetPrivateKey() (*rsa.PrivateKey, error) {
+func (k keys) GetPrivateKey(logger *slog.Logger) (*rsa.PrivateKey, error) {
 	decode, _ := pem.Decode([]byte(k.PrivateKey))
 	if decode == nil {
 		return nil, errors.New("failed to decode private key")
@@ -170,7 +171,7 @@ func (k keys) GetPrivateKey() (*rsa.PrivateKey, error) {
 	privateKey, err := x509.ParsePKCS8PrivateKey(decode.Bytes)
 	if err != nil {
 		if err.Error() == "x509: failed to parse private key (use ParsePKCS1PrivateKey instead for this key format)" {
-			log.Println("Trying to parse PKCS1 format...")
+			logger.Info("Trying to parse PKCS1 format...")
 			privateKey, err = x509.ParsePKCS1PrivateKey(decode.Bytes)
 			if err != nil {
 				return nil, err
@@ -178,7 +179,7 @@ func (k keys) GetPrivateKey() (*rsa.PrivateKey, error) {
 		} else {
 			return nil, err
 		}
-		log.Println("Successfully parsed private key")
+		logger.Info("Successfully parsed private key")
 	}
 
 	return privateKey.(*rsa.PrivateKey), nil

--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -43,10 +43,10 @@ func TestDatabaseHandler(t *testing.T) {
 	s3Client := storage.NewS3Client(logger, s3.Client, uploader)
 
 	databaseRepository := database.NewRepository(db)
-	databaseService := database.NewService(s3Bucket, s3Client, groupService{}, databaseRepository)
+	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService{}, databaseRepository)
 
 	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {
-		databaseHandler := database.NewHandler(databaseService, groupService{groupName: "packages"}, instanceService{}, stackService{})
+		databaseHandler := database.NewHandler(logger, databaseService, groupService{groupName: "packages"}, instanceService{}, stackService{})
 		authenticator := func(ctx *gin.Context) {
 			ctx.Set("user", &model.User{
 				ID:    1,

--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -36,9 +37,10 @@ func TestDatabaseHandler(t *testing.T) {
 	s3Bucket := "database-bucket"
 	err := os.Mkdir(s3Dir+"/"+s3Bucket, 0o755)
 	require.NoError(t, err, "failed to create S3 output bucket")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	s3 := inttest.SetupS3(t, s3Dir)
 	uploader := manager.NewUploader(s3.Client)
-	s3Client := storage.NewS3Client(s3.Client, uploader)
+	s3Client := storage.NewS3Client(logger, s3.Client, uploader)
 
 	databaseRepository := database.NewRepository(db)
 	databaseService := database.NewService(s3Bucket, s3Client, groupService{}, databaseRepository)

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"path"
@@ -20,16 +20,18 @@ import (
 	"github.com/google/uuid"
 )
 
-func NewHandler(databaseService Service, groupService groupService, instanceService instanceService, stackService stackService) Handler {
+func NewHandler(logger *slog.Logger, databaseService Service, groupService groupService, instanceService instanceService, stackService stackService) Handler {
 	return Handler{
-		databaseService,
-		groupService,
-		instanceService,
-		stackService,
+		logger:          logger,
+		databaseService: databaseService,
+		groupService:    groupService,
+		instanceService: instanceService,
+		stackService:    stackService,
 	}
 }
 
 type Handler struct {
+	logger          *slog.Logger
 	databaseService Service
 	groupService    groupService
 	instanceService instanceService
@@ -220,7 +222,7 @@ func (h Handler) SaveAs(c *gin.Context) {
 	}
 
 	save, err := h.databaseService.SaveAs(database, instance, stack, request.Name, request.Format, func(saved *model.Database) {
-		log.Printf("Database %s/%s from instance: %v", saved.GroupName, saved.Name, instance)
+		h.logger.Info("Save an instances database as", "groupName", saved.GroupName, "databaseName", saved.Name, "instanceName", instance.Name)
 	})
 	if err != nil {
 		_ = c.Error(err)

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -61,6 +61,7 @@ func TestInstanceHandler(t *testing.T) {
 	}
 	db.Create(user)
 
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	encryptionKey := strings.Repeat("a", 32)
 	instanceRepo := instance.NewRepository(db, encryptionKey)
 	groupService := groupService{group: group}
@@ -70,19 +71,18 @@ func TestInstanceHandler(t *testing.T) {
 	}
 	stackService := stack.NewService(stacks)
 	// classification 'test' does not actually exist, this is used to decrypt the stack parameters
-	helmfileService := instance.NewHelmfileService("../../stacks", stackService, "test")
-	instanceService := instance.NewService(instanceRepo, groupService, stackService, helmfileService)
+	helmfileService := instance.NewHelmfileService(logger, stackService, "../../stacks", "test")
+	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService)
 
 	s3Dir := t.TempDir()
 	s3Bucket := "database-bucket"
 	err = os.Mkdir(s3Dir+"/"+s3Bucket, 0o755)
 	require.NoError(t, err, "failed to create S3 output bucket")
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	s3 := inttest.SetupS3(t, s3Dir)
 	uploader := manager.NewUploader(s3.Client)
 	s3Client := storage.NewS3Client(logger, s3.Client, uploader)
 	databaseRepository := database.NewRepository(db)
-	databaseService := database.NewService(s3Bucket, s3Client, groupService, databaseRepository)
+	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository)
 
 	authenticator := func(ctx *gin.Context) {
 		ctx.Set("user", user)
@@ -92,7 +92,7 @@ func TestInstanceHandler(t *testing.T) {
 		instanceHandler := instance.NewHandler(groupService, instanceService, twoDayTTL)
 		instance.Routes(engine, authenticator, instanceHandler)
 
-		databaseHandler := database.NewHandler(databaseService, groupService, instanceService, stackService)
+		databaseHandler := database.NewHandler(logger, databaseService, groupService, instanceService, stackService)
 		database.Routes(engine, authenticator, databaseHandler)
 	})
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -3,6 +3,7 @@ package instance_test
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -76,9 +77,10 @@ func TestInstanceHandler(t *testing.T) {
 	s3Bucket := "database-bucket"
 	err = os.Mkdir(s3Dir+"/"+s3Bucket, 0o755)
 	require.NoError(t, err, "failed to create S3 output bucket")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	s3 := inttest.SetupS3(t, s3Dir)
 	uploader := manager.NewUploader(s3.Client)
-	s3Client := storage.NewS3Client(s3.Client, uploader)
+	s3Client := storage.NewS3Client(logger, s3.Client, uploader)
 	databaseRepository := database.NewRepository(db)
 	databaseService := database.NewService(s3Bucket, s3Client, groupService, databaseRepository)
 

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os/exec"
 	"slices"
 
@@ -23,16 +23,18 @@ import (
 
 //goland:noinspection GoExportedFuncWithUnexportedType
 func NewService(
+	logger *slog.Logger,
 	instanceRepository Repository,
 	groupService groupService,
 	stackService stack.Service,
 	helmfileService helmfile,
 ) *service {
 	return &service{
-		instanceRepository,
-		groupService,
-		stackService,
-		helmfileService,
+		logger:             logger,
+		instanceRepository: instanceRepository,
+		groupService:       groupService,
+		stackService:       stackService,
+		helmfileService:    helmfileService,
 	}
 }
 
@@ -60,6 +62,7 @@ type helmfile interface {
 }
 
 type service struct {
+	logger             *slog.Logger
 	instanceRepository Repository
 	groupService       groupService
 	stackService       stack.Service
@@ -342,8 +345,7 @@ func (s service) deployDeploymentInstance(token string, instance *model.Deployme
 	}
 
 	deployLog, deployErrorLog, err := commandExecutor(syncCmd, group.ClusterConfiguration)
-	log.Printf("Deploy log: %s\n", deployLog)
-	log.Printf("Deploy error log: %s\n", deployErrorLog)
+	s.logger.Info("Deploy log", "log", deployLog, "errorLog", deployErrorLog)
 	/* TODO: return error log if relevant
 	if len(deployErrorLog) > 0 {
 		return errors.New(string(deployErrorLog))
@@ -358,7 +360,7 @@ func (s service) deployDeploymentInstance(token string, instance *model.Deployme
 	instance.DeployLog = string(deployLog)
 	if err != nil {
 		// TODO
-		log.Printf("Store error log: %s", deployErrorLog)
+		s.logger.Error("Failed saving deploy log", "error", err)
 		return err
 	}
 	return nil
@@ -420,8 +422,7 @@ func (s service) destroyDeploymentInstance(instance *model.DeploymentInstance) e
 	}
 
 	destroyLog, destroyErrorLog, err := commandExecutor(destroyCmd, group.ClusterConfiguration)
-	log.Printf("Destroy log: %s\n", destroyLog)
-	log.Printf("Destroy error log: %s\n", destroyErrorLog)
+	s.logger.Info("Destroy log", "log", destroyLog, "errorLog", destroyErrorLog)
 	if err != nil {
 		return err
 	}

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -24,7 +24,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, stackService, nil)
+		service := NewService(nil, nil, nil, stackService, nil)
 		instance := &model.DeploymentInstance{
 			StackName: "stack",
 			Parameters: map[string]model.DeploymentInstanceParameter{
@@ -49,7 +49,7 @@ func TestResolveParameters(t *testing.T) {
 			"name-a": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, stackService, nil)
+		service := NewService(nil, nil, nil, stackService, nil)
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -87,7 +87,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-a": stackA,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, stackService, nil)
+		service := NewService(nil, nil, nil, stackService, nil)
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -154,7 +154,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-b": stackB,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, stackService, nil)
+		service := NewService(nil, nil, nil, stackService, nil)
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{

--- a/pkg/instance/ttlDestroyConsumer_test.go
+++ b/pkg/instance/ttlDestroyConsumer_test.go
@@ -2,6 +2,8 @@ package instance_test
 
 import (
 	"context"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -29,7 +31,8 @@ func TestConsumeDeletesInstance(t *testing.T) {
 	is := &instanceService{}
 	is.On("Delete", uint(1)).Return(nil)
 
-	td := instance.NewTTLDestroyConsumer(consumer, is)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	td := instance.NewTTLDestroyConsumer(logger, consumer, is)
 	require.NoError(t, td.Consume())
 
 	require.NoError(t, amqpClient.Channel.PublishWithContext(context.TODO(), "", "ttl-destroy", false, false, amqp.Publishing{

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -68,10 +68,8 @@ func (s S3Client) Move(bucket string, source string, destination string) error {
 func (s S3Client) Upload(bucket string, key string, body ReadAtSeeker, size int64) error {
 	s.logger.Info("Uploading", "bucket", bucket, "key", key)
 	reader, err := newProgressReader(body, size, func(read int64, size int64) {
-		// TODO(DEVOPS-390) we should not use log anymore but slog instead. Since this is likely
-		// meant for the user we first need to figure out how exactly it should work. It does not
-		// seem to be working right now.
-		log.Printf("%s/%s - total read:%d\tprogress:%d%%", bucket, key, read, int(float32(read*100)/float32(size)))
+		// TODO(DEVOPS-390) this is meant to be read by users but this implementation does not work
+		fmt.Fprintf(os.Stdout, "%s/%s - total read:%d\tprogress:%d%%", bucket, key, read, int(float32(read*100)/float32(size)))
 	})
 	if err != nil {
 		return err

--- a/pkg/token/helper/tokenHelper.go
+++ b/pkg/token/helper/tokenHelper.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
@@ -78,7 +77,6 @@ func GenerateRefreshToken(user *model.User, secretKey string, expirationInSecond
 
 	signed, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, []byte(secretKey)))
 	if err != nil {
-		log.Printf("Failed to sign token: %s", err)
 		return nil, err
 	}
 

--- a/pkg/token/repository.go
+++ b/pkg/token/repository.go
@@ -1,9 +1,7 @@
 package token
 
 import (
-	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/go-redis/redis"
@@ -38,8 +36,7 @@ func (r redisTokenRepository) DeleteRefreshToken(userId uint, previousTokenId st
 	}
 
 	if result.Val() < 1 {
-		log.Printf("Refresh token to redis for userId/tokenId: %d/%s does not exist\n", userId, previousTokenId)
-		return errors.New("invalid refresh token")
+		return fmt.Errorf("refresh token to redis for userId/tokenId does not exist: %d/%s", userId, previousTokenId)
 	}
 
 	return nil
@@ -53,7 +50,6 @@ func (r redisTokenRepository) DeleteRefreshTokens(userId uint) error {
 
 	for iterator.Next() {
 		if err := r.redis.Del(iterator.Val()).Err(); err != nil {
-			log.Printf("Failed to delete refresh token: %s\n", iterator.Val())
 			failCount++
 		}
 	}

--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -44,9 +44,10 @@ func TestUserHandler(t *testing.T) {
 	// certificate
 	authentication := middleware.NewAuthentication(&key.PublicKey, userService)
 
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	redis := inttest.SetupRedis(t)
 	tokenRepository := token.NewRepository(redis)
-	tokenService, err := token.NewService(tokenRepository, key, &key.PublicKey, 10, "secret", 10)
+	tokenService, err := token.NewService(logger, tokenRepository, key, &key.PublicKey, 10, "secret", 10)
 	require.NoError(t, err)
 
 	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {


### PR DESCRIPTION
* replace all uses of log with slog.
* setup https://golangci-lint.run/usage/linters/#sloglint so we
    * don't go back to the log package.
    * don't use the default logger via slog.Info and the like. Doing that will likely log in a different format than what we configure in main.
    * stick to the same key naming style.
    * use static messages and put dynamic values into key/values.

# Next

* Configure Loki to extract and index some of the key/value pairs in our log lines. I am hoping that https://grafana.com/docs/loki/latest/send-data/promtail/stages/logfmt works since the TextHandler emits space separated `key=val` pairs. Extract at least `http.id` which is the request/trace id generated by the slog middleware at the start of a request.