### PR TITLE
chore: let user implement LogValuer to hide secrets DEVOPS-389

### DIFF
--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -45,10 +45,7 @@ func (m AuthorizationMiddleware) RequireAdministrator(c *gin.Context) {
 	}
 
 	if !userWithGroups.IsAdministrator() {
-		// TODO(DEVOPS-170) investigate how to log user related info without logging sensitive
-		// information failed requests are already logged by samber/slog-gin so we would want to add
-		// necessary debug info into the middleware if possible
-		m.logger.ErrorContext(c, "User tried to access administrator restricted endpoint", "user", u.ID)
+		m.logger.ErrorContext(c, "User tried to access administrator restricted endpoint", "user", u)
 		_ = c.AbortWithError(http.StatusUnauthorized, errors.New("administrator access denied"))
 		return
 	}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"database/sql"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,4 +43,8 @@ func (u *User) contains(group string, groups []Group) bool {
 
 func (u *User) IsAdministrator() bool {
 	return u.IsMemberOf(AdministratorGroupName)
+}
+
+func (u *User) LogValue() slog.Value {
+	return slog.Uint64Value(uint64(u.ID))
 }


### PR DESCRIPTION
- [x] depends on https://github.com/dhis2-sre/im-manager/pull/739

as described in https://pkg.go.dev/log/slog\#LogValuer. When we now log a user using slog it will only log the users id which should be enough for us to debug an issue. The id does not disclose any personal identifiable information as its an internal id that if we delete a user has no trace back to that person.