### PR TITLE
chore: let Gorm log using slog DEVOPS-391

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -62,13 +62,13 @@ func main() {
 func run() error {
 	cfg := config.New()
 
-	db, err := storage.NewDatabase(cfg.Postgresql)
+	httpLoggerGroup := "http"
+	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil), httpLoggerGroup))
+	db, err := storage.NewDatabase(logger, cfg.Postgresql)
 	if err != nil {
 		return err
 	}
 
-	httpLoggerGroup := "http"
-	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil), httpLoggerGroup))
 	userRepository := user.NewRepository(db)
 	dailer := mail.NewDialer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password)
 	userService := user.NewService(cfg.UIURL, cfg.PasswordTokenTTL, userRepository, dailer)

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -206,7 +206,6 @@ func hostname() string {
 
 type groupService interface {
 	FindOrCreate(name string, hostname string, deployable bool) (*model.Group, error)
-	AddUser(groupName string, userId uint) error
 }
 
 func createGroups(logger *slog.Logger, groupService groupService, groups []config.Group) error {

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -62,8 +62,7 @@ func main() {
 func run() error {
 	cfg := config.New()
 
-	httpLoggerGroup := "http"
-	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil), httpLoggerGroup))
+	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil)))
 	db, err := storage.NewDatabase(logger, cfg.Postgresql)
 	if err != nil {
 		return err
@@ -184,7 +183,7 @@ func run() error {
 	if cfg.Environment != "production" {
 		cfg.AllowedOrigins = append(cfg.AllowedOrigins, "http://localhost:3000", "http://localhost:5173")
 	}
-	r := server.GetEngine(logger, httpLoggerGroup, cfg.BasePath, cfg.AllowedOrigins)
+	r := server.GetEngine(logger, cfg.BasePath, cfg.AllowedOrigins)
 
 	group.Routes(r, authentication, authorization, groupHandler)
 	user.Routes(r, authentication, authorization, userHandler)

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/habx/pg-commands v0.6.1
 	github.com/lestrrat-go/jwx/v2 v2.0.19-0.20240309224501-3735e8aace59
 	github.com/lib/pq v1.10.9
+	github.com/orandin/slog-gorm v1.3.2
 	github.com/orlangure/gnomock v0.30.0
 	github.com/rabbitmq/amqp091-go v1.9.0
 	github.com/samber/slog-gin v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runc v1.1.0 h1:O9+X96OcDjkmmZyfaG996kV7yq8HsoU2h1XRRQcefG8=
 github.com/opencontainers/runc v1.1.0/go.mod h1:Tj1hFw6eFWp/o33uxGf5yF2BX5yz2Z6iptFpuvbbKqc=
+github.com/orandin/slog-gorm v1.3.2 h1:C0lKDQPAx/pF+8K2HL7bdShPwOEJpPM0Bn80zTzxU1g=
+github.com/orandin/slog-gorm v1.3.2/go.mod h1:MoZ51+b7xE9lwGNPYEhxcUtRNrYzjdcKvA8QXQQGEPA=
 github.com/orlangure/gnomock v0.30.0 h1:WXq/3KTKRVYe9a3BXa5JMZCCrg2RwNAPB2bZHMxEntE=
 github.com/orlangure/gnomock v0.30.0/go.mod h1:vDur9icFVsecjDQrHn06SbUs0BXjJaNJRDexBsPh5f4=
 github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=

--- a/internal/log/hander_test.go
+++ b/internal/log/hander_test.go
@@ -23,7 +23,7 @@ func TestRequestIDHandler(t *testing.T) {
 	var b bytes.Buffer
 	var requestID string
 	r := gin.New()
-	logger := slog.New(RequestIDHandler{Handler: slog.NewJSONHandler(&b, nil)})
+	logger := slog.New(New(slog.NewJSONHandler(&b, nil)))
 	r.Use(sloggin.New(logger))
 
 	r.GET("/", func(ctx *gin.Context) {

--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -25,7 +26,7 @@ type AuthorizationMiddleware struct {
 }
 
 type userService interface {
-	FindById(id uint) (*model.User, error)
+	FindById(ctx context.Context, id uint) (*model.User, error)
 }
 
 func (m AuthorizationMiddleware) RequireAdministrator(c *gin.Context) {
@@ -34,7 +35,7 @@ func (m AuthorizationMiddleware) RequireAdministrator(c *gin.Context) {
 		return
 	}
 
-	userWithGroups, err := m.userService.FindById(u.ID)
+	userWithGroups, err := m.userService.FindById(c, u.ID)
 	if err != nil {
 		if errdef.IsNotFound(err) {
 			_ = c.AbortWithError(http.StatusUnauthorized, err)

--- a/internal/server/engine.go
+++ b/internal/server/engine.go
@@ -11,10 +11,10 @@ import (
 	sloggin "github.com/samber/slog-gin"
 )
 
-func GetEngine(logger *slog.Logger, loggerGroup, basePath string, allowedOrigins []string) *gin.Engine {
+func GetEngine(logger *slog.Logger, basePath string, allowedOrigins []string) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.Use(sloggin.New(logger.WithGroup(loggerGroup)))
+	r.Use(sloggin.New(logger))
 
 	corsConfig := cors.DefaultConfig()
 	// Without specifying origins, secure cookies won't work

--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -24,8 +25,8 @@ type Handler struct {
 
 type groupService interface {
 	Create(name string, hostname string, deployable bool) (*model.Group, error)
-	AddUser(groupName string, userId uint) error
-	RemoveUser(groupName string, userId uint) error
+	AddUser(ctx context.Context, groupName string, userId uint) error
+	RemoveUser(ctx context.Context, groupName string, userId uint) error
 	AddClusterConfiguration(clusterConfiguration *model.ClusterConfiguration) error
 	GetClusterConfiguration(groupName string) (*model.ClusterConfiguration, error)
 	Find(name string) (*model.Group, error)
@@ -96,7 +97,7 @@ func (h Handler) AddUserToGroup(c *gin.Context) {
 		return
 	}
 
-	err := h.groupService.AddUser(groupName, userId)
+	err := h.groupService.AddUser(c, groupName, userId)
 	if err != nil {
 		if errdef.IsNotFound(err) {
 			_ = c.AbortWithError(http.StatusNotFound, err)
@@ -133,7 +134,7 @@ func (h Handler) RemoveUserFromGroup(c *gin.Context) {
 		return
 	}
 
-	err := h.groupService.RemoveUser(groupName, userId)
+	err := h.groupService.RemoveUser(c, groupName, userId)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/group/service.go
+++ b/pkg/group/service.go
@@ -1,6 +1,8 @@
 package group
 
 import (
+	"context"
+
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
@@ -26,7 +28,7 @@ type groupRepository interface {
 }
 
 type userService interface {
-	FindById(id uint) (*model.User, error)
+	FindById(ctx context.Context, id uint) (*model.User, error)
 }
 
 type service struct {
@@ -72,13 +74,13 @@ func (s *service) FindOrCreate(name string, hostname string, deployable bool) (*
 	return g, err
 }
 
-func (s *service) AddUser(groupName string, userId uint) error {
+func (s *service) AddUser(ctx context.Context, groupName string, userId uint) error {
 	group, err := s.Find(groupName)
 	if err != nil {
 		return err
 	}
 
-	u, err := s.userService.FindById(userId)
+	u, err := s.userService.FindById(ctx, userId)
 	if err != nil {
 		return err
 	}
@@ -86,13 +88,13 @@ func (s *service) AddUser(groupName string, userId uint) error {
 	return s.groupRepository.addUser(group, u)
 }
 
-func (s *service) RemoveUser(groupName string, userId uint) error {
+func (s *service) RemoveUser(c context.Context, groupName string, userId uint) error {
 	group, err := s.Find(groupName)
 	if err != nil {
 		return err
 	}
 
-	u, err := s.userService.FindById(userId)
+	u, err := s.userService.FindById(c, userId)
 	if err != nil {
 		return err
 	}

--- a/pkg/inttest/db.go
+++ b/pkg/inttest/db.go
@@ -1,6 +1,8 @@
 package inttest
 
 import (
+	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/dhis2-sre/im-manager/pkg/config"
@@ -25,7 +27,8 @@ func SetupDB(t *testing.T) *gorm.DB {
 	require.NoError(t, err, "failed to start DB")
 	t.Cleanup(func() { require.NoError(t, gnomock.Stop(container), "failed to stop DB") })
 
-	db, err := storage.NewDatabase(config.Postgresql{
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	db, err := storage.NewDatabase(logger, config.Postgresql{
 		Host:         container.Host,
 		Port:         container.DefaultPort(),
 		Username:     "im",

--- a/pkg/inttest/http.go
+++ b/pkg/inttest/http.go
@@ -29,7 +29,7 @@ func SetupHTTPServer(t *testing.T, f func(engine *gin.Engine)) *HTTPClient {
 	gin.SetMode(gin.TestMode)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	engine := server.GetEngine(logger, "http", "", []string{"http://localhost"})
+	engine := server.GetEngine(logger, "", []string{"http://localhost"})
 	f(engine)
 
 	//goland:noinspection GoImportUsedAsName

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -14,10 +14,9 @@ import (
 
 func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
 	gormLogger := slogGorm.New(
-		slogGorm.WithHandler(logger.WithGroup("db").Handler()),
+		slogGorm.WithHandler(logger.Handler()),
 		slogGorm.WithRecordNotFoundError(),
 		slogGorm.WithSlowThreshold(200*time.Second),
-		slogGorm.WithContextValue("user", "user"),
 	)
 	databaseConfig := gorm.Config{
 		Logger:         gormLogger,

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -14,9 +14,9 @@ import (
 
 func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
 	gormLogger := slogGorm.New(
-		slogGorm.WithHandler(logger.Handler()),
+		slogGorm.WithHandler(logger.WithGroup("db").Handler()),
 		slogGorm.WithRecordNotFoundError(),
-		slogGorm.WithSlowThreshold(10*time.Millisecond),
+		slogGorm.WithSlowThreshold(5*time.Millisecond),
 		slogGorm.WithContextValue("user", "user"),
 	)
 	databaseConfig := gorm.Config{

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -17,6 +17,7 @@ func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
 		slogGorm.WithHandler(logger.Handler()),
 		slogGorm.WithRecordNotFoundError(),
 		slogGorm.WithSlowThreshold(200*time.Millisecond),
+		slogGorm.WithContextValue("user", "user"),
 	)
 	databaseConfig := gorm.Config{
 		Logger:         gormLogger,

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -16,7 +16,7 @@ func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
 	gormLogger := slogGorm.New(
 		slogGorm.WithHandler(logger.Handler()),
 		slogGorm.WithRecordNotFoundError(),
-		slogGorm.WithSlowThreshold(200*time.Millisecond),
+		slogGorm.WithSlowThreshold(10*time.Millisecond),
 		slogGorm.WithContextValue("user", "user"),
 	)
 	databaseConfig := gorm.Config{

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -2,28 +2,33 @@ package storage
 
 import (
 	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/dhis2-sre/im-manager/pkg/config"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	slogGorm "github.com/orandin/slog-gorm"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-func NewDatabase(c config.Postgresql) (*gorm.DB, error) {
+func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
+	gormLogger := slogGorm.New(
+		slogGorm.WithHandler(logger.Handler()),
+		slogGorm.WithRecordNotFoundError(),
+		slogGorm.WithSlowThreshold(200*time.Millisecond),
+	)
+	databaseConfig := gorm.Config{
+		Logger:         gormLogger,
+		TranslateError: true,
+	}
+
 	host := c.Host
 	port := c.Port
 	username := c.Username
 	password := c.Password
 	name := c.DatabaseName
-
 	dsn := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable", host, username, password, name, port)
-
-	databaseConfig := gorm.Config{
-		Logger:         logger.Default.LogMode(logger.Warn),
-		TranslateError: true,
-	}
-
 	db, err := gorm.Open(postgres.Open(dsn), &databaseConfig)
 	if err != nil {
 		return nil, err
@@ -44,7 +49,7 @@ func NewDatabase(c config.Postgresql) (*gorm.DB, error) {
 	)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open Gorm session: %v", err)
 	}
 
 	return db, nil

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -16,7 +16,7 @@ func NewDatabase(logger *slog.Logger, c config.Postgresql) (*gorm.DB, error) {
 	gormLogger := slogGorm.New(
 		slogGorm.WithHandler(logger.WithGroup("db").Handler()),
 		slogGorm.WithRecordNotFoundError(),
-		slogGorm.WithSlowThreshold(5*time.Millisecond),
+		slogGorm.WithSlowThreshold(200*time.Second),
 		slogGorm.WithContextValue("user", "user"),
 	)
 	databaseConfig := gorm.Config{

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -38,7 +39,7 @@ type userService interface {
 	SignUp(email string, password string) (*model.User, error)
 	SignIn(email string, password string) (*model.User, error)
 	FindById(id uint) (*model.User, error)
-	FindAll() ([]*model.User, error)
+	FindAll(ctx context.Context) ([]*model.User, error)
 	Delete(id uint) error
 	Update(id uint, email, password string) (*model.User, error)
 	ValidateEmail(token uuid.UUID) error
@@ -63,7 +64,7 @@ func (h Handler) SignUp(c *gin.Context) {
 	//
 	// SignUp user
 	//
-	// Sign up a user. This endpoint is publicly accessible and therefor anyone can sign up. However, before being able to perform any actions, users needs to be a member of a group. And only administrators can add users to groups.
+	// Sign up a user. This endpoint is publicly accessible and therefore anyone can sign up. However, before being able to perform any actions, users needs to be a member of a group. And only administrators can add users to groups.
 	//
 	// responses:
 	//   201: User
@@ -432,7 +433,7 @@ func (h Handler) FindAll(c *gin.Context) {
 	//	403: Error
 	//	404: Error
 	//	415: Error
-	users, err := h.userService.FindAll()
+	users, err := h.userService.FindAll(c)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -38,10 +38,10 @@ type Handler struct {
 type userService interface {
 	SignUp(email string, password string) (*model.User, error)
 	SignIn(email string, password string) (*model.User, error)
-	FindById(id uint) (*model.User, error)
+	FindById(ctx context.Context, id uint) (*model.User, error)
 	FindAll(ctx context.Context) ([]*model.User, error)
-	Delete(id uint) error
-	Update(id uint, email, password string) (*model.User, error)
+	Delete(ctx context.Context, id uint) error
+	Update(ctx context.Context, id uint, email, password string) (*model.User, error)
 	ValidateEmail(token uuid.UUID) error
 	RequestPasswordReset(email string) error
 	ResetPassword(token string, password string) error
@@ -288,7 +288,7 @@ func (h Handler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	user, err := h.userService.FindById(refreshToken.UserId)
+	user, err := h.userService.FindById(c, refreshToken.UserId)
 	if err != nil {
 		if errdef.IsNotFound(err) {
 			_ = c.AbortWithError(http.StatusUnauthorized, err)
@@ -340,7 +340,7 @@ func (h Handler) Me(c *gin.Context) {
 		return
 	}
 
-	userWithGroups, err := h.userService.FindById(user.ID)
+	userWithGroups, err := h.userService.FindById(c, user.ID)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -407,7 +407,7 @@ func (h Handler) FindById(c *gin.Context) {
 		return
 	}
 
-	userWithGroups, err := h.userService.FindById(id)
+	userWithGroups, err := h.userService.FindById(c, id)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -470,7 +470,7 @@ func (h Handler) Delete(c *gin.Context) {
 		return
 	}
 
-	_, err = h.userService.FindById(id)
+	_, err = h.userService.FindById(c, id)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -481,7 +481,7 @@ func (h Handler) Delete(c *gin.Context) {
 		return
 	}
 
-	err = h.userService.Delete(id)
+	err = h.userService.Delete(c, id)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -528,7 +528,7 @@ func (h Handler) Update(c *gin.Context) {
 		return
 	}
 
-	user, err := h.userService.Update(id, request.Email, request.Password)
+	user, err := h.userService.Update(c, id, request.Email, request.Password)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -191,7 +191,7 @@ func (m *mockUserService) SignIn(email string, password string) (*model.User, er
 	panic("implement me")
 }
 
-func (m *mockUserService) FindById(id uint) (*model.User, error) {
+func (m *mockUserService) FindById(ctx context.Context, id uint) (*model.User, error) {
 	called := m.Called(id)
 	return called.Get(0).(*model.User), nil
 }
@@ -200,11 +200,11 @@ func (m *mockUserService) FindAll(ctx context.Context) ([]*model.User, error) {
 	panic("implement me")
 }
 
-func (m *mockUserService) Delete(id uint) error {
+func (m *mockUserService) Delete(ctx context.Context, id uint) error {
 	panic("implement me")
 }
 
-func (m *mockUserService) Update(id uint, email, password string) (*model.User, error) {
+func (m *mockUserService) Update(ctx context.Context, id uint, email, password string) (*model.User, error) {
 	panic("implement me")
 }
 

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -195,7 +196,7 @@ func (m *mockUserService) FindById(id uint) (*model.User, error) {
 	return called.Get(0).(*model.User), nil
 }
 
-func (m *mockUserService) FindAll() ([]*model.User, error) {
+func (m *mockUserService) FindAll(ctx context.Context) ([]*model.User, error) {
 	panic("implement me")
 }
 

--- a/pkg/user/repository.go
+++ b/pkg/user/repository.go
@@ -88,9 +88,10 @@ func (r repository) findOrCreate(user *model.User) (*model.User, error) {
 	return u, err
 }
 
-func (r repository) findById(id uint) (*model.User, error) {
+func (r repository) findById(ctx context.Context, id uint) (*model.User, error) {
 	var u *model.User
 	err := r.db.
+		WithContext(ctx).
 		Preload("Groups").
 		Preload("AdminGroups").
 		First(&u, id).Error
@@ -100,8 +101,8 @@ func (r repository) findById(id uint) (*model.User, error) {
 	return u, err
 }
 
-func (r repository) delete(id uint) error {
-	db := r.db.Unscoped().Delete(&model.User{}, id)
+func (r repository) delete(ctx context.Context, id uint) error {
+	db := r.db.WithContext(ctx).Unscoped().Delete(&model.User{}, id)
 	if db.Error != nil {
 		return fmt.Errorf("failed to delete user with id %d: %v", id, db.Error)
 	} else if db.RowsAffected < 1 {

--- a/pkg/user/repository.go
+++ b/pkg/user/repository.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -34,10 +35,11 @@ func (r repository) create(u *model.User) error {
 	return err
 }
 
-func (r repository) findAll() ([]*model.User, error) {
+func (r repository) findAll(ctx context.Context) ([]*model.User, error) {
 	var users []*model.User
 
 	err := r.db.
+		WithContext(ctx).
 		Preload("Groups").
 		Preload("AdminGroups").
 		Order("Email").

--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -27,10 +27,10 @@ func NewService(uiUrl string, passwordTokenTtl uint, repository userRepository, 
 type userRepository interface {
 	create(user *model.User) error
 	findByEmail(email string) (*model.User, error)
-	findById(id uint) (*model.User, error)
+	findById(ctx context.Context, id uint) (*model.User, error)
 	findOrCreate(email *model.User) (*model.User, error)
 	findAll(ctx context.Context) ([]*model.User, error)
-	delete(id uint) error
+	delete(ctx context.Context, id uint) error
 	update(user *model.User) (*model.User, error)
 	findByEmailToken(token uuid.UUID) (*model.User, error)
 	save(user *model.User) error
@@ -168,8 +168,8 @@ func (s service) FindAll(ctx context.Context) ([]*model.User, error) {
 	return s.repository.findAll(ctx)
 }
 
-func (s service) FindById(id uint) (*model.User, error) {
-	return s.repository.findById(id)
+func (s service) FindById(ctx context.Context, id uint) (*model.User, error) {
+	return s.repository.findById(ctx, id)
 }
 
 func (s service) FindOrCreate(email string, password string) (*model.User, error) {
@@ -187,12 +187,12 @@ func (s service) FindOrCreate(email string, password string) (*model.User, error
 	return s.repository.findOrCreate(user)
 }
 
-func (s service) Delete(id uint) error {
-	return s.repository.delete(id)
+func (s service) Delete(ctx context.Context, id uint) error {
+	return s.repository.delete(ctx, id)
 }
 
-func (s service) Update(id uint, email, password string) (*model.User, error) {
-	user, err := s.repository.findById(id)
+func (s service) Update(ctx context.Context, id uint, email, password string) (*model.User, error) {
+	user, err := s.repository.findById(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
@@ -28,7 +29,7 @@ type userRepository interface {
 	findByEmail(email string) (*model.User, error)
 	findById(id uint) (*model.User, error)
 	findOrCreate(email *model.User) (*model.User, error)
-	findAll() ([]*model.User, error)
+	findAll(ctx context.Context) ([]*model.User, error)
 	delete(id uint) error
 	update(user *model.User) (*model.User, error)
 	findByEmailToken(token uuid.UUID) (*model.User, error)
@@ -163,8 +164,8 @@ func comparePasswords(storedPassword string, suppliedPassword string) (bool, err
 	return hex.EncodeToString(hash) == passwordAndSalt[0], nil
 }
 
-func (s service) FindAll() ([]*model.User, error) {
-	return s.repository.findAll()
+func (s service) FindAll(ctx context.Context) ([]*model.User, error) {
+	return s.repository.findAll(ctx)
 }
 
 func (s service) FindById(id uint) (*model.User, error) {

--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -1,6 +1,7 @@
 package user_test
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"log/slog"
@@ -69,7 +70,7 @@ func TestUserHandler(t *testing.T) {
 		require.Empty(t, user1.Password)
 		user1ID = strconv.FormatUint(uint64(user1.ID), 10)
 
-		u1, err := userService.FindById(user1.ID)
+		u1, err := userService.FindById(context.Background(), user1.ID)
 		require.NoError(t, err)
 		err = userService.ValidateEmail(u1.EmailToken)
 		require.NoError(t, err)
@@ -83,7 +84,7 @@ func TestUserHandler(t *testing.T) {
 		require.Equal(t, "user2@dhis2.org", user2.Email)
 		require.Empty(t, user2.Password)
 
-		u2, err := userService.FindById(user2.ID)
+		u2, err := userService.FindById(context.Background(), user2.ID)
 		require.NoError(t, err)
 		err = userService.ValidateEmail(u2.EmailToken)
 		require.NoError(t, err)
@@ -226,7 +227,7 @@ func TestUserHandler(t *testing.T) {
 				user1ID, err := strconv.ParseUint(user1ID, 10, 0)
 				require.NoError(t, err)
 				user1IDInt := uint(user1ID)
-				user1, err := userService.FindById(user1IDInt)
+				user1, err := userService.FindById(context.Background(), user1IDInt)
 				require.NoError(t, err)
 
 				require.NotEmpty(t, user1.PasswordToken, "should have a password token")
@@ -243,7 +244,7 @@ func TestUserHandler(t *testing.T) {
 
 				client.Do(t, http.MethodPost, "/users/reset-password", resetRequestBody, http.StatusCreated, inttest.WithHeader("Content-Type", "application/json"))
 
-				newUser1, _ := userService.FindById(user1IDInt)
+				newUser1, _ := userService.FindById(context.Background(), user1IDInt)
 				newPassword := newUser1.Password
 
 				require.NotEqual(t, oldPassword, newPassword, "old and new password should be different")
@@ -259,7 +260,7 @@ func TestUserHandler(t *testing.T) {
 				user1ID, err := strconv.ParseUint(user1ID, 10, 0)
 				require.NoError(t, err)
 				user1IDInt := uint(user1ID)
-				user1, _ := newUserService.FindById(user1IDInt)
+				user1, _ := newUserService.FindById(context.Background(), user1IDInt)
 				require.NoError(t, err)
 
 				// Wait for token to expire

--- a/pkg/user/util.go
+++ b/pkg/user/util.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
@@ -8,7 +9,7 @@ import (
 
 type groupService interface {
 	FindOrCreate(group, hostname string, deployable bool) (*model.Group, error)
-	AddUser(group string, userId uint) error
+	AddUser(ctx context.Context, group string, userId uint) error
 }
 
 type userServiceUtil interface {
@@ -34,7 +35,7 @@ func CreateUser(email, password string, userService userServiceUtil, groupServic
 		return fmt.Errorf("error creating %s group: %v", groupName, err)
 	}
 
-	err = groupService.AddUser(g.Name, u.ID)
+	err = groupService.AddUser(context.Background(), g.Name, u.ID)
 	if err != nil {
 		return fmt.Errorf("error adding %s user to %s group: %v", userType, groupName, err)
 	}

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1602,7 +1602,7 @@ paths:
                 - oauth2: []
             summary: Find users
         post:
-            description: Sign up a user. This endpoint is publicly accessible and therefor anyone can sign up. However, before being able to perform any actions, users needs to be a member of a group. And only administrators can add users to groups.
+            description: Sign up a user. This endpoint is publicly accessible and therefore anyone can sign up. However, before being able to perform any actions, users needs to be a member of a group. And only administrators can add users to groups.
             operationId: signUp
             parameters:
                 - description: SignUp request body parameter


### PR DESCRIPTION
* let Gorm log using slog using https://github.com/orandin/slog-gorm which implements Gorms' Logger interface https://gorm.io/docs/logger.html#Customize-Logger
* we need to thread the `context.Context` through to Gorm if we want to log attributes from the context like the request `id`. Note that `gin.Context` implements `context.Context`
* remove slog groups so every log line produced with a Context gets attribute `id` with the request id.

I adjusted  `go test -v ./... -run "TestUserHandler/AsAdmin/DeleteUser"
` locally to use the same logging setup as in main.

Here is a sample output 

```
time=2024-05-03T17:01:06.118+02:00 level=INFO msg="SQL query executed [3.158881ms]" query="DELETE FROM \"users\" WHERE \"users\".\"id\" = 2" duration=3.158881ms rows=1 source=../im-manager/pkg/user/repository.go:105 id=0d3a93cb-322e-4fd1-93d0-869ba78d2e5a

time=2024-05-03T17:01:06.118+02:00 level=INFO msg="Incoming request" request.time=2024-05-03T17:01:06.114+02:00 request.method=DELETE request.host=[::]:44829 request.path=/users/2 request.query="" request.params=map[id:2] request.route=/users/:id request.ip=::1 request.referer="" request.length=0 response.time=2024-05-03T17:01:06.118+02:00 response.latency=4.636942ms response.status=202 response.length=0 id=0d3a93cb-322e-4fd1-93d0-869ba78d2e5a
```

1. line is from Gorm https://github.com/orandin/slog-gorm/blob/master/logger.go
2. line is from Gin https://github.com/samber/slog-gin/blob/main/middleware.go

You can see that both have the request `id` in the log line.

## Removal of slog groups

I had to remove our use of slog groups. There is no easy/low-cost way for us to add common attributes from the `context.Context` to the root level. As soon as you do `WithGroup` on a logger all its attributes will be under that group. This means if we put Gorm under group db with `logger.WithGroup("db").Handler()` it will add the request id into `db.id`. We want to have a common key so we can extract it into a label in Loki. There might be a way as described in https://groups.google.com/g/golang-nuts/c/NXpSEtKGiSI but I don't think its worth our effort.

Groups are useful to prevent attribute name conflicts. We do not log that much and only have a few components (Gorm, Gin, RabbitMQ) that log. Let's see if we even run into such conflicts before investing more time.