### PR TITLE
chore: ban logging using log via linter DEVOPS-170

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
 linters:
   enable:
     - errcheck
+    - forbidigo
     - gosimple
     - govet
     - ineffassign
@@ -10,6 +11,12 @@ linters:
     - staticcheck
     - unused
 linters-settings:
+  forbidigo:
+    forbid:
+      - p: ^log\.Print.*$
+        msg: Use log/slog to log
+      - p: ^log\.Fatal.*$
+        msg: Only main should call os.Exit(). Return an error instead
   sloglint:
     no-global: "all"
     static-msg: true


### PR DESCRIPTION
enforce we are logging using `log/slog` instead of `log`

These are the errors you will get when you add a change using `log`

```
pkg/config/config.go:211:2: use of `log.Println` forbidden because "Use log/slog to log" (forbidigo)
        log.Println("len(GROUP_NAMES) != len(GROUP_HOSTNAMES)")
        ^
```

Use of `log.Fatal` is a bad idea as it calls `os.Exit` under the hood. This means you will have multiple places in your app that can exit. That makes it harder to understand where our app can terminate. We should only call `os.Exit` in main. All other places should return an error. The error is then either handled as its recoverable/temporary or it is handed to main which exits.

```
pkg/config/config.go:211:2: use of `log.Fatalf` forbidden because "Only main should call os.Exit(). Return an error instead" (forbidigo)
        log.Fatalf("len(GROUP_NAMES) != len(GROUP_HOSTNAMES)")
        ^

```

https://dhis2.atlassian.net/browse/DEVOPS-394 is a follow up to remove the last places we use `log.Fatal`. I already removed some in the past.