### PR TITLE
chore: log JSON so we can parse groups in Loki DEVOPS-396

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.18 AS build
+FROM golang:1.22.3-alpine3.18 AS build
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
 ARG KUBECTL_VERSION=v1.28.0

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -62,7 +62,7 @@ func main() {
 func run() error {
 	cfg := config.New()
 
-	logger := slog.New(log.New(slog.NewTextHandler(os.Stdout, nil)))
+	logger := slog.New(log.New(slog.NewJSONHandler(os.Stdout, nil)))
 	db, err := storage.NewDatabase(logger, cfg.Postgresql)
 	if err != nil {
 		return err


### PR DESCRIPTION
The slog [TextHandler](https://pkg.go.dev/log/slog#TextHandler) we are using is separating groups by `.` which is invalid in Loki (as it takes a lot from prometheus).

https://grafana.com/docs/loki/latest/get-started/labels/#format

This means we currently get parsing errors when using [logfmt](https://grafana.com/docs/loki/latest/send-data/promtail/stages/logfmt/). We cannot extract labels/values from keys which are under a group. Examples are the response.status or response.latency. This limits our ability in searching and creating metrics.

Not using groups when logging is not a good option as
* we do not always control how a 3rd party logs
* we get context from a group like in `request.method`, `method` alone is very generic

We can pipe logs through `jq` if we want to only get the logs `msg` or any other key when developing. We can also implement a flag like `-dev` or so that would then switch to the `TextHandler` if that brings us benefits during development.

* also update Go to get a security fix
