### PR TITLE
chore: use single docker compose up

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   call-workflow:
-    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@master
+    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@retry-health
     with:
       PROCESS_NAME: im-manager
       POD_NAME: im-manager

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   call-workflow:
-    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@retry-health
+    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@master
     with:
       PROCESS_NAME: im-manager
       POD_NAME: im-manager

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
 im-manager
 .env
-.access_token_cache_*
+.access_token_cache*
 coverage.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-alpine3.18 AS build
+FROM golang:1.22.4-alpine3.20 AS build
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
 ARG KUBECTL_VERSION=v1.28.0

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ check:
 	pre-commit run --all-files --show-diff-on-failure
 
 smoke-test:
-	docker compose up -d database rabbitmq
-	sleep 10
 	IMAGE_TAG=$(tag) docker compose up -d prod
 
 docker-image:
@@ -42,9 +40,12 @@ test:
 test-coverage:
 	go test -coverprofile=./coverage.out ./... && go tool cover -html=./coverage.out -o ./coverage.html
 
-clean:
+clean-dev:
 	docker compose --profile dev down --remove-orphans --volumes
 	go clean
+
+clean:
+	docker compose --profile prod down --remove-orphans --volumes
 
 swagger-clean:
 	rm -f swagger/swagger.yaml

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -72,7 +72,10 @@ func run() error {
 	dailer := mail.NewDialer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password)
 	userService := user.NewService(cfg.UIURL, cfg.PasswordTokenTTL, userRepository, dailer)
 	authorization := middleware.NewAuthorization(logger, userService)
-	redis := storage.NewRedis(cfg)
+	redis, err := storage.NewRedis(cfg.Redis)
+	if err != nil {
+		return err
+	}
 	tokenRepository := token.NewRepository(redis)
 	authConfig := cfg.Authentication
 	privateKey, err := authConfig.Keys.GetPrivateKey(logger)

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -72,7 +72,7 @@ func run() error {
 	dailer := mail.NewDialer(cfg.SMTP.Host, cfg.SMTP.Port, cfg.SMTP.Username, cfg.SMTP.Password)
 	userService := user.NewService(cfg.UIURL, cfg.PasswordTokenTTL, userRepository, dailer)
 	authorization := middleware.NewAuthorization(logger, userService)
-	redis, err := storage.NewRedis(cfg.Redis)
+	redis, err := storage.NewRedis(cfg.Redis.Host, cfg.Redis.Port)
 	if err != nil {
 		return err
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ x-service: &common-dev-test
     - .:/src
   working_dir: /src
 
-version: "3.8"
 services:
   prod:
     image: dhis2/im-manager:${IMAGE_TAG:-latest}
@@ -17,6 +16,13 @@ services:
       - .env
     ports:
       - "8080:8080"
+    depends_on:
+      database:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     profiles:
       - prod
 
@@ -66,6 +72,7 @@ services:
       - database:/var/lib/postgresql/data
     profiles:
       - dev
+      - prod
 
   rabbitmq:
     image: rabbitmq:3-management-alpine
@@ -73,12 +80,14 @@ services:
       - "5672:5672"
       - "15672:15672"
     healthcheck:
-      test: [ "CMD", "rabbitmq-diagnostics", "-q", "ping" ]
+      # https://www.rabbitmq.com/docs/monitoring#stage-3
+      test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
       interval: 5s
       timeout: 3s
       retries: 5
     profiles:
       - dev
+      - prod
 
   redis:
     image: redis:6.2.5-alpine3.14
@@ -94,6 +103,7 @@ services:
     profiles:
       - dev
       - redis
+      - prod
 
   redisinsight:
     image: redislabs/redisinsight:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,15 +102,7 @@ services:
       - redis:/data
     profiles:
       - dev
-      - redis
       - prod
-
-  redisinsight:
-    image: redislabs/redisinsight:latest
-    ports:
-      - "8001:8001"
-    profiles:
-      - redis
 
   minio:
     image: quay.io/minio/minio:RELEASE.2023-07-21T21-12-44Z

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Postgresql                     Postgresql
 	RabbitMqURL                    rabbitmq
 	SMTP                           smtp
-	Redis                          redis
+	Redis                          Redis
 	Authentication                 Authentication
 	Groups                         []Group
 	AdminUser                      user
@@ -84,7 +84,7 @@ func New() Config {
 			Username: requireEnv("RABBITMQ_USERNAME"),
 			Password: requireEnv("RABBITMQ_PASSWORD"),
 		},
-		Redis: redis{
+		Redis: Redis{
 			Host: requireEnv("REDIS_HOST"),
 			Port: requireEnvAsInt("REDIS_PORT"),
 		},
@@ -163,7 +163,7 @@ func (r rabbitmq) GetUrl() string {
 	return fmt.Sprintf("amqp://%s:%s@%s:%d/", r.Username, r.Password, r.Host, r.Port)
 }
 
-type redis struct {
+type Redis struct {
 	Host string
 	Port int
 }

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -3,14 +3,12 @@ package storage
 import (
 	"fmt"
 
-	"github.com/dhis2-sre/im-manager/pkg/config"
-
 	"github.com/go-redis/redis"
 )
 
-func NewRedis(cfg config.Redis) (*redis.Client, error) {
+func NewRedis(host string, port int) (*redis.Client, error) {
 	client := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
+		Addr:     fmt.Sprintf("%s:%d", host, port),
 		Password: "",
 		DB:       0,
 	})

--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -8,18 +8,16 @@ import (
 	"github.com/go-redis/redis"
 )
 
-func NewRedis(c config.Config) *redis.Client {
-	host := c.Redis.Host
-	port := c.Redis.Port
-
+func NewRedis(cfg config.Redis) (*redis.Client, error) {
 	client := redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%d", host, port),
+		Addr:     fmt.Sprintf("%s:%d", cfg.Host, cfg.Port),
 		Password: "",
 		DB:       0,
 	})
 
-	pong, err := client.Ping().Result()
-	fmt.Println(pong, err)
+	if _, err := client.Ping().Result(); err != nil {
+		return nil, fmt.Errorf("failed to ping redis: %v", err)
+	}
 
-	return client
+	return client, nil
 }


### PR DESCRIPTION
Fail when redis cannot be reached on startup as we do with other services.

Improve the RabbitMQ healthcheck so it is ready to take connections. We can now rely on Docker healthchecks and use a single docker compose up to start the smoke-test.

https://github.com/dhis2-sre/gha-workflows/pull/55

uses a retry with timeout so we do not need to sleep to guess and wait when IM is ready. Cleanup containers created during the smoke test.
