### PR TITLE
chore: validate CORS config

### DIFF
--- a/pkg/inttest/http.go
+++ b/pkg/inttest/http.go
@@ -29,7 +29,8 @@ func SetupHTTPServer(t *testing.T, f func(engine *gin.Engine)) *HTTPClient {
 	gin.SetMode(gin.TestMode)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	engine := server.GetEngine(logger, "", []string{"http://localhost"})
+	engine, err := server.GetEngine(logger, "", []string{"http://localhost"})
+	require.NoError(t, err, "failed to setup Gin")
 	f(engine)
 
 	//goland:noinspection GoImportUsedAsName


### PR DESCRIPTION
A panic in Gins server.GetEngine was not visible to us when deploying. This lead IM to be stuck in a CrashLoopBackoff. This is an example of the panic

```sh
panic: bad origin: origins must contain '*' or include http://,https://

goroutine 1 [running]:
github.com/gin-contrib/cors.newCors({0x0, {0xc0005ed5c0, 0x3, 0x3}, 0x0, 0x0, {0xc00059a070, 0x7, 0x7}, 0x0, ...})
        /go/pkg/mod/github.com/gin-contrib/cors@v1.7.2/config.go:44 +0x29c
github.com/gin-contrib/cors.New({0x0, {0xc0005ed5c0, 0x3, 0x3}, 0x0, 0x0, {0xc00059a070, 0x7, 0x7}, 0x0, ...})
        /go/pkg/mod/github.com/gin-contrib/cors@v1.7.2/cors.go:194 +0x39
github.com/dhis2-sre/im-manager/internal/server.GetEngine(0xc000519050, {0xc00001405a, 0x1}, {0xc0005ed5c0, 0x3, 0x3})
        /src/internal/server/engine.go:25 +0x525
main.run()
        /src/cmd/serve/main.go:203 +0x197a
main.main()
        /src/cmd/serve/main.go:56 +0x13
```

I only saw exit code 2 in k8s which turns out to come from a panic. No error from stdout was visible in the k8s logs. I was able to capture it locally when deploying using skaffold.

## Root cause

Changes in UI_HOSTNAME -> UI_URL and the addition of CORS_ALLOWED_ORIGINS meant my `.env` was wrong. Since we did not validate the CORS config Gin panicked.

## Solution

* Validate the CORS config so we can return an error from main instead of panicking.
* Recover from a panic in main so we can return it as an error.

After this change an invalid CORS config would result in exit code 1 with stdout showing

`im-manager exited due to: failed to configure CORS: bad origin: origins must contain '*' or include http://,https://`

A panic would result in exit code 1 with stdout showing something like

`im-manager exited due to: panicked due to: some error message`
