### PR TITLE
fix: return request ID on status 500

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/orandin/slog-gorm v1.3.2
 	github.com/orlangure/gnomock v0.30.0
 	github.com/rabbitmq/amqp091-go v1.10.0
-	github.com/samber/slog-gin v1.13.3
 	github.com/stretchr/testify v1.9.0
 	go.mozilla.org/sops/v3 v3.7.3
 	golang.org/x/crypto v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -713,8 +713,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/samber/slog-gin v1.13.3 h1:BXVMDktx27zrr/PMYLvrEAOeIylBFtuemlQjgDUT3fc=
-github.com/samber/slog-gin v1.13.3/go.mod h1:7+YTBV20co5pQ+802hgAncESKtcZMAOKFUBpuT8IhXo=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=

--- a/internal/middleware/errorHandler.go
+++ b/internal/middleware/errorHandler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/gin-gonic/gin"
-	sloggin "github.com/samber/slog-gin"
 )
 
 func ErrorHandler() gin.HandlerFunc {
@@ -36,7 +35,7 @@ func ErrorHandler() gin.HandlerFunc {
 		} else if errdef.IsConflict(err) {
 			c.String(http.StatusConflict, err.Error())
 		} else {
-			id := sloggin.GetRequestID(c)
+			id := GetRequestID(c)
 			err := fmt.Errorf("something went wrong. We'll look into it if you send us the request id %q :)", id)
 			c.String(http.StatusInternalServerError, err.Error())
 		}


### PR DESCRIPTION
We originally used slogin but switched away from it due to some limitations. We forgot to get the request id from the context via our own function. It was thus not found in the context.