### PR TITLE
ci: use gosec via golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ linters:
   enable:
     - errcheck
     - forbidigo
+    - gocritic
+    - gosec
     - gosimple
     - govet
     - ineffassign

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,11 @@ repos:
         args:
           - "-w"
       - id: go-mod-tidy
-      - id: go-sec-repo-mod
 
   - repo: https://github.com/golangci/golangci-lint
     rev: v1.57.2
     hooks:
       - id: golangci-lint
-        args:
-          - "--timeout=3m"
-          - "--enable=gocritic"
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.24.0


### PR DESCRIPTION
like any other linter. This way it will be kept up to date. https://github.com/tekwizely/pre-commit-golang has no new releases. And we can disable linting issues in the same way as for other linters.

Proof that gosec is enabled after this change

```
golangci-lint linters

Enabled by your configuration linters:
errcheck: errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
forbidigo: Forbids identifiers [fast: false, auto-fix: false]
gocritic: Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
gosec (gas): Inspects source code for security problems [fast: false, auto-fix: false]
gosimple (megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
govet (vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
ineffassign: Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
sloglint: ensure consistent code style when using log/slog [fast: false, auto-fix: false]
staticcheck (megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
unused (megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
```