### PR TITLE
chore: use sloglint context-only=scope DEVOPS-395

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,3 +23,4 @@ linters-settings:
     no-global: "all"
     static-msg: true
     key-naming-case: camel
+    context: scope

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,10 @@ repos:
       - id: go-mod-tidy
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.57.2
+    rev: v1.59.1
     hooks:
       - id: golangci-lint
+        args: [--verbose]
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.24.0

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ keys:
 
 init:
 	pip install pre-commit
+	pre-commit clean
 	pre-commit install --install-hooks --overwrite
 
 	go install github.com/direnv/direnv@latest
@@ -12,14 +13,11 @@ init:
 
 	go install golang.org/x/tools/cmd/goimports@latest
 
-	go install github.com/securego/gosec/v2/cmd/gosec@latest
-	gosec --version
-
 	go install github.com/go-swagger/go-swagger/cmd/swagger@latest
 	swagger version
 
 check:
-	pre-commit run --all-files --show-diff-on-failure
+	pre-commit run --verbose --all-files --show-diff-on-failure
 
 smoke-test:
 	IMAGE_TAG=$(tag) docker compose up -d prod


### PR DESCRIPTION
[sloglint](https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only) [context-only=scope](https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only) ([v0.6.0](https://github.com/go-simpler/sloglint/releases/tag/v0.6.0)) detects function declarations with a `context.Context` as the first parameter in the scope of a logger call.

Our [slog handler](https://github.com/dhis2-sre/im-manager/blob/657a8b19d82e882b505c53ca0b524fa05231710a/internal/log/handler.go#L32) will add the request id and user to the log when its present in the context. For this to work we have to log using the context aware logger methods. This slog linter setting helps to remind us of that like so

```
pre-commit run golangci-lint --all-files --show-diff-on-failure
golangci-lint............................................................Failed
- hook id: golangci-lint
- exit code: 1

cmd/serve/main.go:215:2: InfoContext should be used instead (sloglint)
        logger.Info("my log")
        ^
```

The setting is `context` with value `scope` in https://golangci-lint.run/usage/linters/#sloglint.

Added verbose flags so we see how long each hook took and what version golangci-lint we are running with which linters.

## Todo for devs

After this is merged update the pre-commit env

Either

```
make init
```

or if your python/pip is broken again like mine do

```
pre-commit clean
pre-commit install --install-hooks --overwrite
```

so you have the updated `golangci-lint`.