### PR TITLE
chore: update alpine in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN go mod download -x
 COPY . .
 RUN go build -o /app/im-manager -ldflags "-s -w" ./cmd/serve
 
-FROM alpine:3.18
+FROM alpine:3.20
 RUN apk --no-cache -U upgrade \
     && apk add --no-cache postgresql-client
 COPY --from=build /usr/bin/kubectl /usr/bin/kubectl


### PR DESCRIPTION
when updating Go I had to go to alpine 3.20 as 3.18 was not available with the latest Go version. I think we can also update the alpine version to 3.20 of the final image.

https://alpinelinux.org/releases/