### PR TITLE
chore: fix/auth.sh

### DIFF
--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -7,7 +7,7 @@ IM_USER_TYPE="${1:-}"
 TOKEN_CACHE_FILE=./.access_token_cache_$IM_USER_TYPE
 touch "$TOKEN_CACHE_FILE"
 
-ACCESS_TOKEN="$(cat "$TOKEN_CACHE_FILE" || "")"
+ACCESS_TOKEN="$(cat "$TOKEN_CACHE_FILE" || echo "")"
 exp=$(echo "$ACCESS_TOKEN" | jq -R 'split(".")? | .[1] | @base64d | fromjson | .exp')
 NOW=$(date +%s)
 if [[ -z "$exp" ]] || (( exp < NOW )); then

--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -8,7 +8,7 @@ TOKEN_CACHE_FILE=./.access_token_cache_$IM_USER_TYPE
 touch "$TOKEN_CACHE_FILE"
 
 ACCESS_TOKEN="$(cat "$TOKEN_CACHE_FILE" || echo "")"
-exp=$(echo "$ACCESS_TOKEN" | jq -R 'split(".")? | .[1] | @base64d | fromjson | .exp')
+exp=$(echo "$ACCESS_TOKEN" | jq -r 'split(".")? | .[1] | @base64d | fromjson | .exp')
 NOW=$(date +%s)
 if [[ -z "$exp" ]] || (( exp < NOW )); then
   if [ "$IM_USER_TYPE" == "Admin" ]; then


### PR DESCRIPTION
The goal of this PR is to fix a bug which resulted in the below error if running a user script with an empty token cache file.

    jq: error (at <stdin>:1): Malformed BOM (while parsing '��')
