### PR TITLE
fix: let skaffold update rabbitmq and redis on change

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -11,12 +11,6 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
   workflow_dispatch:
-    inputs:
-      deploy:
-        description: Deploy the environment
-        required: false
-        type: boolean
-        default: false
 
 # Cancel previous runs of the same workflow and PR number or branch/tag
 concurrency:
@@ -29,7 +23,6 @@ jobs:
     with:
       PROCESS_NAME: im-manager
       POD_NAME: im-manager
-      DEPLOY_ENVIRONMENT: ${{ inputs.deploy == true }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -34,6 +34,7 @@ deploy:
         remoteChart: rabbitmq
         repo: https://charts.bitnami.com/bitnami
         version: 14.4.2
+        upgradeOnChange: true
         useHelmSecrets: true
         setValues:
           extraPlugins: "rabbitmq_stream rabbitmq_stream_management"
@@ -51,6 +52,7 @@ deploy:
         remoteChart: redis
         repo: https://charts.bitnami.com/bitnami
         version: 18.2.2
+        upgradeOnChange: true
         setValues:
           architecture: standalone
           auth:


### PR DESCRIPTION
We have been bitten by this before

https://github.com/dhis2-sre/im-manager/pull/664

Skaffold changed its behavior. This is why changes to RabbitMQ in Skaffold did not trigger a deployment of RabbitMQ. Use the same setting for redis as well so we don't end up here again.