### PR TITLE
chore: only try to parse access token if there is one

### DIFF
--- a/scripts/auth.sh
+++ b/scripts/auth.sh
@@ -8,7 +8,10 @@ TOKEN_CACHE_FILE=./.access_token_cache_$IM_USER_TYPE
 touch "$TOKEN_CACHE_FILE"
 
 ACCESS_TOKEN="$(cat "$TOKEN_CACHE_FILE" || echo "")"
-exp=$(echo "$ACCESS_TOKEN" | jq -r 'split(".")? | .[1] | @base64d | fromjson | .exp')
+exp=""
+if [[ -n "$ACCESS_TOKEN" ]]; then
+  exp=$(echo "$ACCESS_TOKEN" | jq -Rr 'split(".")? | .[1] | @base64d | fromjson | .exp')
+fi
 NOW=$(date +%s)
 if [[ -z "$exp" ]] || (( exp < NOW )); then
   if [ "$IM_USER_TYPE" == "Admin" ]; then


### PR DESCRIPTION
Fix the below error if the cache file doesn't contain a valid access token

    parse error: Invalid numeric literal at line 2, column 0
