### PR TITLE
feat: batch deploy wrapper and config

### DIFF
--- a/scripts/instances/deploy-batch.sh
+++ b/scripts/instances/deploy-batch.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# Ensure yq is installed
+if ! command -v yq &> /dev/null
+then
+    echo "yq could not be found. Please install yq to proceed."
+    exit
+fi
+
+# File path
+CONFIG_FILE="./deploy-batch.yaml"
+DEPLOY_SCRIPT="./deploy-dhis2.sh"
+
+# Display and select a set for deployment
+select_set() {
+    echo "Available Sets:"
+    set_names=$(yq e '.sets[].name' "$CONFIG_FILE")
+    IFS=$'\n' read -rd '' -a set_array <<<"$set_names"
+
+    for i in "${!set_array[@]}"; do
+        echo "$((i+1)). ${set_array[i]}"
+    done
+
+    echo -n "Enter the number of the set you want to select, or 'c' to cancel: "
+    read selection
+
+    if [ "$selection" == "c" ]; then
+        echo "Selection cancelled."
+        exit
+    fi
+
+    if ! [[ "$selection" =~ ^[0-9]+$ ]] || [ "$selection" -le 0 ] || [ "$selection" -gt "${#set_array[@]}" ]; then
+        echo "Invalid selection."
+        exit
+    fi
+
+    selected_set=$(yq e ".sets[$((selection-1))]" "$CONFIG_FILE")
+    if [ -z "$selected_set" ]; then
+        echo "Set not found."
+    # else
+    #     echo "----------------------------------------"
+    #     echo "Selected Set:"
+    #     echo "$selected_set"
+    #     echo "----------------------------------------"
+    fi
+
+    # store the IMAGE_REPOSITORY of the selected set
+    export IMAGE_REPOSITORY=$(echo "$selected_set" | yq e '.IMAGE_REPOSITORY' -)
+
+
+    # Set environment variables based on preferences and selected set
+    # echo "Setting environment variables based on preferences and selected set..."
+    preferences=$(yq e '.preferences' "$CONFIG_FILE")
+    # echo "prefs $preferences"
+    for pref in $(echo "$preferences" | yq e 'keys | .[]' -); do
+        export ${pref}=$(echo "$preferences" | yq e ".$pref" -)
+    done
+
+    # check if the IM_PREFIX_MULTI is set
+    if [ -z "$IM_PREFIX_MULTI" ]; then
+        echo -c "Instance prefix is not set. Please provide a prefix for the instances: "
+        read im_prefix
+        export IM_PREFIX_MULTI=$im_prefix
+    fi
+
+
+# Now, loop over the instances and set the environment variables, then call deploy-dhis2.sh script for each instance
+    instances=$(echo "$selected_set" | yq e '.instances' -)
+
+    # Loop over the instances first just to list the instances that will be created
+    # and get confirmation to continue
+    echo "----------------------------------------"
+    echo "Instances to be created:"
+    for instance in $(echo "$instances" | yq e 'keys | .[]' -); do
+        instance_data=$(echo "$instances" | yq e ".$instance" -)
+        # add 1 to the index to start from 1
+        echo "Instance $((instance+1)):"
+        for key in $(echo "$instance_data" | yq e 'keys | .[]' -); do
+            if [ "$key" == "name" ]; then
+                # echo with tabs and newline
+                echo -e "\tName: ${IM_PREFIX_MULTI}$(echo "$instance_data" | yq e ".$key" -)"
+            elif [ "$key" == "description" ]; then
+                echo -e "\tDescription: $(echo "$instance_data" | yq e ".$key" -)"
+            fi
+        done
+    done
+    echo "----------------------------------------"
+
+    echo -n "Do you want to continue? (y/n): "
+    read confirmation
+    if [ "$confirmation" != "y" ]; then
+        echo "Operation cancelled."
+        exit
+    fi
+
+    for instance in $(echo "$instances" | yq e 'keys | .[]' -); do
+        instance_data=$(echo "$instances" | yq e ".$instance" -)
+        for key in $(echo "$instance_data" | yq e 'keys | .[]' -); do
+            export "$key"="$(echo "$instance_data" | yq e ".$key" -)"
+        done
+
+        echo "Deploying DHIS2 instance $((instance+1))..."
+        ${DEPLOY_SCRIPT} $IM_GROUP_MULTI ${IM_PREFIX_MULTI}${name} ${description}   #  deploy_dhis2
+
+    done
+
+
+}
+
+# Main script execution
+select_set

--- a/scripts/instances/deploy-batch.yaml
+++ b/scripts/instances/deploy-batch.yaml
@@ -1,0 +1,57 @@
+preferences:
+  # prefix for instance names in IM
+  IM_PREFIX_MULTI: "pld-"
+  # target group in IM (usually qa)
+  IM_GROUP_MULTI: "qa"
+  # other parameters that you might want to adjust (but usually don't need to)
+  IMAGE_PULL_POLICY: "Always"
+  INSTANCE_TTL: "86400" # 86400 = 1 day
+  DATABASE_SIZE: "20Gi"
+  DB_RESOURCES_REQUESTS_CPU: "250m"
+  DB_RESOURCES_REQUESTS_MEMORY: "256Mi"
+  MIN_READY_SECONDS: "120"
+  STARTUP_PROBE_FAILURE_THRESHOLD: "26"
+  STARTUP_PROBE_PERIOD_SECONDS: "5"
+  LIVENESS_PROBE_TIMEOUT_SECONDS: "1"
+  READINESS_PROBE_TIMEOUT_SECONDS: "1"
+  CORE_RESOURCES_REQUESTS_CPU: "250m"
+  CORE_RESOURCES_REQUESTS_MEMORY: "2500Mi"
+  FLYWAY_MIGRATE_OUT_OF_ORDER: "false"
+  FLYWAY_REPAIR_BEFORE_MIGRATION: "false"
+
+# define sets of instances that you want to deploy in bulk here
+sets:
+  - name: "dev"
+    IMAGE_REPOSITORY: "core-dev"
+    instances:
+        - name: "dev"
+          description: "dev instance"
+          IMAGE_TAG: "dev"
+          DATABASE_ID: "test-dbs-sierra-leone-dev-sql-gz"
+        - name: "dev-41"
+          description: "v41 dev instance"
+          IMAGE_TAG: "41dev"
+          DATABASE_ID: "test-dbs-sierra-leone-2-41-sql-gz"
+        - name: "dev-40"
+          description: "v40 dev instance"
+          IMAGE_TAG: "40dev"
+          DATABASE_ID: "test-dbs-sierra-leone-2-40-sql-gz"
+        - name: "dev-39"
+          description: "v39 dev instance"
+          IMAGE_TAG: "39dev"
+          DATABASE_ID: "test-dbs-sierra-leone-2-39-sql-gz"
+  - name: "stable"
+    IMAGE_REPOSITORY: "core"
+    instances:
+        - name: "41-0-1"
+          description: "stable 41"
+          IMAGE_TAG: "41.0.1"
+          DATABASE_ID: "test-dbs-sierra-leone-2-41-0-sql-gz"
+        - name: "40-4-0"
+          description: "stable 40"
+          IMAGE_TAG: "40.4.0"
+          DATABASE_ID: "test-dbs-sierra-leone-2-40-4-sql-gz"
+        - name: "39-6-0"
+          description: "stable 39"
+          IMAGE_TAG: "39.6.0"
+          DATABASE_ID: "est-dbs-sierra-leone-2-39-6-sql-gz"

--- a/scripts/instances/deploy-batch.yaml
+++ b/scripts/instances/deploy-batch.yaml
@@ -54,4 +54,4 @@ sets:
         - name: "39-6-0"
           description: "stable 39"
           IMAGE_TAG: "39.6.0"
-          DATABASE_ID: "est-dbs-sierra-leone-2-39-6-sql-gz"
+          DATABASE_ID: "test-dbs-sierra-leone-2-39-6-sql-gz"


### PR DESCRIPTION
This is a wrapper to deploy-dhis2.sh script. The config file allows setting some global parameters, and defining sets of deployments that will be launched together.

Requires yq 

Docs here: https://github.com/dhis2-sre/im-doc/blob/master/api/README.md#deploy-monolith-instances-in-a-pre-defined-batch