### PR TITLE
docs: add local development environment section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
-# TODO
+# Getting Started
 
-* Write readme
+## Start local development environment with Docker
+
+1. Start by copying the `.env.example` file into a new `.env` file:
+```
+cp .env.example .env
+```
+2. Create a private key:
+```
+make keys
+```
+3. Copy the private key contents, with actual newlines replaced by "\n", into the `PRIVATE_KEY` environment variable within the `.env` file:
+*This should work on macOS to copy the key contents*
+```
+cat rsa_private.pem | awk '{printf "%s\\n", $0}' | pbcopy
+```
+4. Initialize the environment and install dev dependencies:
+```
+make init
+```
+5. Start a development environment:
+```
+make dev
+```
 
 # Add a group
 * Add group in IM (either through the UI or by using the user script found [here](scripts/users/createGroup.sh)


### PR DESCRIPTION
The intent is to have a minimal step-by-step guide for starting a local development environment (albeit not fully functional).