### PR TITLE
ci: add nodeSelector and tolerations for dedicated prod env node

### DIFF
--- a/helm/data/values/dev/postgresql.yaml
+++ b/helm/data/values/dev/postgresql.yaml
@@ -6,3 +6,10 @@ primary:
     limits:
       cpu: 250m
       memory: 128Mi
+  tolerations:
+    - key: im-dedicated
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+  nodeSelector:
+    im-dedicated: "true"

--- a/helm/data/values/dev/rabbitmq.yaml
+++ b/helm/data/values/dev/rabbitmq.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: Always
-sameSiteMode: none
 tolerations:
   - key: im-dedicated
     operator: Equal

--- a/helm/data/values/dev/redis.yaml
+++ b/helm/data/values/dev/redis.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: Always
-sameSiteMode: none
 tolerations:
   - key: im-dedicated
     operator: Equal

--- a/helm/data/values/prod/postgresql.yaml
+++ b/helm/data/values/prod/postgresql.yaml
@@ -6,3 +6,10 @@ primary:
     limits:
       cpu: 250m
       memory: 128Mi
+  tolerations:
+    - key: im-dedicated
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+  nodeSelector:
+    im-dedicated: "true"

--- a/helm/data/values/prod/rabbitmq.yaml
+++ b/helm/data/values/prod/rabbitmq.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: Always
-sameSiteMode: none
 tolerations:
   - key: im-dedicated
     operator: Equal

--- a/helm/data/values/prod/redis.yaml
+++ b/helm/data/values/prod/redis.yaml
@@ -1,6 +1,3 @@
-image:
-  pullPolicy: Always
-sameSiteMode: none
 tolerations:
   - key: im-dedicated
     operator: Equal

--- a/helm/data/values/prod/values.yaml
+++ b/helm/data/values/prod/values.yaml
@@ -1,3 +1,10 @@
 groups:
   names: dev,play,qa,meta-packages,design,research,android,implement
   hostnames: dev.im.dhis2.org,play.im.dhis2.org,qa.im.dhis2.org,meta-packages.im.dhis2.org,design.im.dhis2.org,research.im.dhis2.org,android.im.dhis2.org,implement.im.dhis2.org
+tolerations:
+  - key: im-dedicated
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+nodeSelector:
+  im-dedicated: "true"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,15 +14,6 @@
 #      corsAllowOrigins:
 #        - "https://{{ .UI_URL }}"
 
-.im-tolerations-config: &im-tolerations-config
-  key: im-dedicated
-  operator: Equal
-  value: true
-  effect: NoSchedule
-
-.im-node-selector-config: &im-node-selector-config
-  im-dedicated: "true"
-
 apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
@@ -52,12 +43,9 @@ deploy:
             - name: streams
               port: 5552
               targetPort: 5552
-          tolerations:
-            - <<: *im-tolerations-config
-          nodeSelector:
-            <<: *im-node-selector-config
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/rabbitmq.yaml
+          - helm/data/values/{{ .CLASSIFICATION }}/rabbitmq.yaml
 
       - name: im-manager-redis-{{ .ENVIRONMENT }}
         namespace: instance-manager-{{ .CLASSIFICATION }}
@@ -70,11 +58,8 @@ deploy:
           architecture: standalone
           auth:
             enabled: false
-          tolerations:
-            - <<: *im-tolerations-config
-          nodeSelector:
-            <<: *im-node-selector-config
-
+        valuesFiles:
+          - helm/data/values/{{ .CLASSIFICATION }}/redis.yaml
 
       - name: im-manager-postgresql-{{ .ENVIRONMENT }}
         namespace: instance-manager-{{ .CLASSIFICATION }}
@@ -84,12 +69,6 @@ deploy:
         version: 13.2.30
         upgradeOnChange: true
         useHelmSecrets: true
-        setValues:
-          primary:
-            tolerations:
-              - <<: *im-tolerations-config
-            nodeSelector:
-              <<: *im-node-selector-config
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/postgresql.yaml
           - helm/data/values/{{ .CLASSIFICATION }}/postgresql.yaml
@@ -128,10 +107,6 @@ deploy:
             S3_REGION: eu-west-1
             DEFAULT_TTL: "172800" # 48 hours
             PASSWORD_TOKEN_TTL: "900" # 15 minutes
-          tolerations:
-            - <<: *im-tolerations-config
-          nodeSelector:
-            <<: *im-node-selector-config
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/values.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,6 +14,15 @@
 #      corsAllowOrigins:
 #        - "https://{{ .UI_URL }}"
 
+.im-tolerations-config: &im-tolerations-config
+  key: im-dedicated
+  operator: Equal
+  value: true
+  effect: NoSchedule
+
+.im-node-selector-config: &im-node-selector-config
+  im-dedicated: "true"
+
 apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
@@ -43,6 +52,10 @@ deploy:
             - name: streams
               port: 5552
               targetPort: 5552
+          tolerations:
+            - <<: *im-tolerations-config
+          nodeSelector:
+            <<: *im-node-selector-config
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/rabbitmq.yaml
 
@@ -57,6 +70,11 @@ deploy:
           architecture: standalone
           auth:
             enabled: false
+          tolerations:
+            - <<: *im-tolerations-config
+          nodeSelector:
+            <<: *im-node-selector-config
+
 
       - name: im-manager-postgresql-{{ .ENVIRONMENT }}
         namespace: instance-manager-{{ .CLASSIFICATION }}
@@ -66,6 +84,12 @@ deploy:
         version: 13.2.30
         upgradeOnChange: true
         useHelmSecrets: true
+        setValues:
+          primary:
+            tolerations:
+              - <<: *im-tolerations-config
+            nodeSelector:
+              <<: *im-node-selector-config
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/postgresql.yaml
           - helm/data/values/{{ .CLASSIFICATION }}/postgresql.yaml
@@ -104,6 +128,10 @@ deploy:
             S3_REGION: eu-west-1
             DEFAULT_TTL: "172800" # 48 hours
             PASSWORD_TOKEN_TTL: "900" # 15 minutes
+          tolerations:
+            - <<: *im-tolerations-config
+          nodeSelector:
+            <<: *im-node-selector-config
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/values.yaml


### PR DESCRIPTION
Added `nodeSelector` and `tolerations` config to all Helm releases in the Skaffold file, which means that all IM envs will get scheduled on the same dedicated IM node.

Related to https://github.com/dhis2-sre/im-web-client/pull/657