### PR TITLE
refactor: add endpoints for updating deployment and deployment instance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/docker/docker v28.0.4+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.3 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/dominikbraun/graph v0.23.0 h1:TdZB4pPqCLFxYhdyMFb1TBdFxp8XLcJfTTBQucV
 github.com/dominikbraun/graph v0.23.0/go.mod h1:yOjYyogZLY1LSG9E33JWZJiq5k83Qy2C6POAuiViluc=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
-github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
+github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=

--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -37,4 +37,11 @@ rules:
     verbs:
       - get
       - create
+      - patch
       - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - patch

--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -66,7 +66,7 @@ func TestDatabaseHandler(t *testing.T) {
 		requestBody := strings.NewReader("file contents")
 		nameHeader := inttest.WithHeader("X-Upload-Name", "path/name.extension")
 		groupHeader := inttest.WithHeader("X-Upload-Group", "packages")
-		body := client.Put(t, "/databases", requestBody, nameHeader, groupHeader)
+		body := client.Put(t, "/databases", requestBody, http.StatusCreated, nameHeader, groupHeader)
 
 		var database model.Database
 		err = json.Unmarshal(body, &database)

--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -110,3 +110,28 @@ type _ struct {
 	// in: body
 	_ model.DeploymentInstance
 }
+
+// swagger:parameters updateInstance
+type _ struct {
+	// in: path
+	// required: true
+	ID uint `json:"id"`
+	// in: path
+	// required: true
+	InstanceID uint `json:"instanceId"`
+	// Update instance request body parameter
+	// in: body
+	// required: true
+	Payload SaveInstanceRequest
+}
+
+// swagger:parameters updateDeployment
+type _ struct {
+	// in: path
+	// required: true
+	ID uint `json:"id"`
+	// Update deployment request body parameter
+	// in: body
+	// required: true
+	Payload UpdateDeploymentRequest
+}

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -995,9 +995,8 @@ func (h Handler) UpdateInstance(c *gin.Context) {
 }
 
 type UpdateDeploymentRequest struct {
-	TTL         uint   `json:"ttl" binding:"required"`
+	TTL         uint   `json:"ttl"`
 	Description string `json:"description"`
-	Group       string `json:"group" binding:"omitempty"`
 }
 
 // UpdateDeployment updates an existing Deployment's TTL and description
@@ -1036,7 +1035,7 @@ func (h Handler) UpdateDeployment(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description, request.Group)
+	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -925,3 +925,121 @@ func (h Handler) Status(c *gin.Context) {
 
 	c.JSON(http.StatusOK, status)
 }
+
+// UpdateInstance updates an existing deployment instance
+func (h Handler) UpdateInstance(c *gin.Context) {
+	// swagger:route PUT /deployments/{id}/instance/{instanceId} updateInstance
+	//
+	// Update a Deployment Instance
+	//
+	// Update a Deployment Instance ...
+	//
+	// Security:
+	//	oauth2:
+	//
+	// responses:
+	//	200: DeploymentInstance
+	//	401: Error
+	//	403: Error
+	//	404: Error
+	//	415: Error
+	deploymentId, ok := handler.GetPathParameter(c, "id")
+	if !ok {
+		return
+	}
+
+	instanceId, ok := handler.GetPathParameter(c, "instanceId")
+	if !ok {
+		return
+	}
+
+	var request SaveInstanceRequest
+	if err := handler.DataBinder(c, &request); err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	ctx := c.Request.Context()
+	user, err := handler.GetUserFromContext(ctx)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	deployment, err := h.instanceService.FindDeploymentById(ctx, deploymentId)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	canWrite := handler.CanWriteDeployment(user, deployment)
+	if !canWrite {
+		unauthorized := errdef.NewUnauthorized("write access denied")
+		_ = c.Error(unauthorized)
+		return
+	}
+
+	token, err := handler.GetTokenFromRequest(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	instance, err := h.instanceService.UpdateInstance(ctx, token, deploymentId, instanceId, request.Parameters, request.Public)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, instance)
+}
+
+type UpdateDeploymentRequest struct {
+	TTL         uint   `json:"ttl" binding:"required"`
+	Description string `json:"description"`
+}
+
+// UpdateDeployment updates an existing Deployment's TTL and description
+func (h Handler) UpdateDeployment(c *gin.Context) {
+	// swagger:route PUT /deployments/{id} updateDeployment
+	//
+	// Update a Deployment
+	//
+	// Update a Deployment ...
+	//
+	// Security:
+	//   oauth2:
+	//
+	// Responses:
+	//   200: Deployment
+	//   400: Error
+	//   401: Error
+	//   403: Error
+	//   404: Error
+	//   500: Error
+	id, ok := handler.GetPathParameter(c, "id")
+	if !ok {
+		return
+	}
+
+	var request UpdateDeploymentRequest
+	if err := handler.DataBinder(c, &request); err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	token, err := handler.GetTokenFromRequest(c)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	ctx := c.Request.Context()
+	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, updatedDeployment)
+}

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -997,6 +997,7 @@ func (h Handler) UpdateInstance(c *gin.Context) {
 type UpdateDeploymentRequest struct {
 	TTL         uint   `json:"ttl" binding:"required"`
 	Description string `json:"description"`
+	Group       string `json:"group" binding:"omitempty"`
 }
 
 // UpdateDeployment updates an existing Deployment's TTL and description
@@ -1035,7 +1036,7 @@ func (h Handler) UpdateDeployment(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description)
+	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description, request.Group)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -1035,6 +1035,25 @@ func (h Handler) UpdateDeployment(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
+	user, err := handler.GetUserFromContext(ctx)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	deployment, err := h.instanceService.FindDeploymentById(ctx, id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	canWrite := handler.CanWriteDeployment(user, deployment)
+	if !canWrite {
+		unauthorized := errdef.NewUnauthorized("write access denied")
+		_ = c.Error(unauthorized)
+		return
+	}
+
 	updatedDeployment, err := h.instanceService.UpdateDeployment(ctx, token, id, request.TTL, request.Description)
 	if err != nil {
 		_ = c.Error(err)

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -372,8 +372,8 @@ func TestInstanceHandler(t *testing.T) {
 
 		assert.Equal(t, "0.7.0", updatedInstance.Parameters["IMAGE_TAG"].Value)
 		assert.True(t, updatedInstance.Public)
-		assert.Equal(t, deploymentInstance.Name, updatedInstance.Name)
-		assert.Equal(t, deploymentInstance.GroupName, updatedInstance.GroupName)
+		assert.Equal(t, "test-deployment-instance-update", updatedInstance.Name)
+		assert.Equal(t, "group-name", updatedInstance.GroupName)
 	})
 }
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -307,23 +307,22 @@ func TestInstanceHandler(t *testing.T) {
 			"name": "test-deployment-update",
 			"group": "group-name",
 			"description": "initial description",
-			"ttl": 172800
+			"ttl": 86400
 		}`)
 
 		client.PostJSON(t, "/deployments", body, &deployment, inttest.WithAuthToken("sometoken"))
 
 		t.Log("Update deployment")
 		body = strings.NewReader(`{
-			"group": "group-name",
 			"description": "updated description",
-			"ttl": 86400
+			"ttl": 172800
 		}`)
 
 		path := fmt.Sprintf("/deployments/%d", deployment.ID)
 		var updatedDeployment model.Deployment
 		client.PutJSON(t, path, body, &updatedDeployment, inttest.WithAuthToken("sometoken"))
 
-		assert.Equal(t, uint(86400), updatedDeployment.TTL)
+		assert.Equal(t, uint(172800), updatedDeployment.TTL)
 		assert.Equal(t, "updated description", updatedDeployment.Description)
 		assert.Equal(t, "group-name", updatedDeployment.GroupName)
 		assert.Equal(t, "test-deployment-update", updatedDeployment.Name)

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -63,7 +63,7 @@ func (r repository) SaveDeployment(ctx context.Context, deployment *model.Deploy
 	// cancellation can lead to rollbacks which we should decide individually.
 	ctx = context.WithoutCancel(ctx)
 
-	err := r.db.WithContext(ctx).Create(&deployment).Error
+	err := r.db.WithContext(ctx).Save(&deployment).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return errdef.NewDuplicated("a deployment named %q already exists", deployment.Name)

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -63,7 +63,7 @@ func (r repository) SaveDeployment(ctx context.Context, deployment *model.Deploy
 	// cancellation can lead to rollbacks which we should decide individually.
 	ctx = context.WithoutCancel(ctx)
 
-	err := r.db.WithContext(ctx).Save(&deployment).Error
+	err := r.db.WithContext(ctx).Session(&gorm.Session{FullSaveAssociations: true}).Save(&deployment).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return errdef.NewDuplicated("a deployment named %q already exists", deployment.Name)

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -63,7 +63,7 @@ func (r repository) SaveDeployment(ctx context.Context, deployment *model.Deploy
 	// cancellation can lead to rollbacks which we should decide individually.
 	ctx = context.WithoutCancel(ctx)
 
-	err := r.db.WithContext(ctx).Session(&gorm.Session{FullSaveAssociations: true}).Save(&deployment).Error
+	err := r.db.WithContext(ctx).Save(&deployment).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return errdef.NewDuplicated("a deployment named %q already exists", deployment.Name)

--- a/pkg/instance/router.go
+++ b/pkg/instance/router.go
@@ -23,6 +23,8 @@ func Routes(r *gin.Engine, authenticator gin.HandlerFunc, handler Handler) {
 	tokenAuthenticationRouter.GET("/deployments/:id", handler.FindDeploymentById)
 	tokenAuthenticationRouter.DELETE("/deployments/:id", handler.DeleteDeployment)
 	tokenAuthenticationRouter.POST("/deployments/:id/instance", handler.SaveInstance)
+	tokenAuthenticationRouter.PUT("/deployments/:id/instance/:instanceId", handler.UpdateInstance)
 	tokenAuthenticationRouter.DELETE("/deployments/:id/instance/:instanceId", handler.DeleteDeploymentInstance)
 	tokenAuthenticationRouter.POST("/deployments/:id/deploy", handler.DeployDeployment)
+	tokenAuthenticationRouter.PUT("/deployments/:id", handler.UpdateDeployment)
 }

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -927,14 +927,32 @@ func (s Service) UpdateDeployment(ctx context.Context, token string, deploymentI
 	ttlChanged := deployment.TTL != ttl
 	groupChanged := group != "" && deployment.GroupName != group
 
-	oldGroup := deployment.GroupName
+	oldGroupName := deployment.GroupName
 
 	deployment.TTL = ttl
 	deployment.Description = description
 	if groupChanged {
+		newGroup, err := s.groupService.Find(ctx, group)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find new group: %v", err)
+		}
+		deployment.Group = newGroup
 		deployment.GroupName = group
 		for _, instance := range deployment.Instances {
+			instance.Group = newGroup
 			instance.GroupName = group
+
+			// Update DATABASE_HOSTNAME if it's a dhis2-core instance, otherwise the hostname remains pointing to the old group
+			// TODO is there a better way to do this?
+			if instance.StackName == "dhis2-core" {
+				newHostname, err := stack.PostgresHostnameProvider.Provide(*instance)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get new database hostname: %w", err)
+				}
+				instance.Parameters["DATABASE_HOSTNAME"] = model.DeploymentInstanceParameter{
+					Value: newHostname,
+				}
+			}
 		}
 	}
 
@@ -944,13 +962,21 @@ func (s Service) UpdateDeployment(ctx context.Context, token string, deploymentI
 	}
 
 	if groupChanged {
-		for _, instance := range deployment.Instances {
-			instance.GroupName = oldGroup
-			err = s.destroyDeploymentInstance(ctx, instance)
-			if err != nil {
-				return nil, fmt.Errorf("failed to destroy old instance resources: %v", err)
+		oldGroup, err := s.groupService.Find(ctx, oldGroupName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find old group: %v", err)
+		}
+
+		// Only destroy and recreate if the actual Kubernetes namespace is changing
+		if oldGroup.Namespace != deployment.Group.Namespace {
+			for _, instance := range deployment.Instances {
+				instance.GroupName = oldGroupName
+				err = s.destroyDeploymentInstance(ctx, instance)
+				if err != nil {
+					return nil, fmt.Errorf("failed to destroy old instance resources: %v", err)
+				}
+				instance.GroupName = group
 			}
-			instance.GroupName = group
 		}
 	}
 

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -151,7 +151,7 @@ var DHIS2DB = model.Stack{
 		"CHART_VERSION":             {Priority: 9, DisplayName: "Chart Version", DefaultValue: &dhis2DBDefaults.chartVersion},
 	},
 	ParameterProviders: model.ParameterProviders{
-		"DATABASE_HOSTNAME": PostgresHostnameProvider,
+		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 	KubernetesResource: model.StatefulSetResource,
 }
@@ -328,7 +328,7 @@ var DHIS2 = model.Stack{
 		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 0, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
 	},
 	ParameterProviders: model.ParameterProviders{
-		"DATABASE_HOSTNAME": PostgresHostnameProvider,
+		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 }
 
@@ -419,7 +419,7 @@ var imJobRunnerDefaults = struct {
 }
 
 // Provides the PostgreSQL hostname of an instance.
-var PostgresHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var postgresHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-database-postgresql.%s.svc", instance.Name, instance.Group.Namespace), nil
 })
 

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -151,7 +151,7 @@ var DHIS2DB = model.Stack{
 		"CHART_VERSION":             {Priority: 9, DisplayName: "Chart Version", DefaultValue: &dhis2DBDefaults.chartVersion},
 	},
 	ParameterProviders: model.ParameterProviders{
-		"DATABASE_HOSTNAME": postgresHostnameProvider,
+		"DATABASE_HOSTNAME": PostgresHostnameProvider,
 	},
 	KubernetesResource: model.StatefulSetResource,
 }
@@ -328,7 +328,7 @@ var DHIS2 = model.Stack{
 		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 0, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
 	},
 	ParameterProviders: model.ParameterProviders{
-		"DATABASE_HOSTNAME": postgresHostnameProvider,
+		"DATABASE_HOSTNAME": PostgresHostnameProvider,
 	},
 }
 
@@ -419,7 +419,7 @@ var imJobRunnerDefaults = struct {
 }
 
 // Provides the PostgreSQL hostname of an instance.
-var postgresHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var PostgresHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-database-postgresql.%s.svc", instance.Name, instance.Group.Namespace), nil
 })
 

--- a/scripts/instances/update-deployment.sh
+++ b/scripts/instances/update-deployment.sh
@@ -8,10 +8,12 @@ GROUP=$1
 NAME=$2
 TTL=$3
 DESCRIPTION=${4:-}
+NEW_GROUP=${5:-}
 
 DEPLOYMENT_ID=$(./findByName.sh "$GROUP" "$NAME" | jq -r '.id')
 
 echo "{
   \"ttl\": $TTL,
-  \"description\": \"$DESCRIPTION\"
+  \"description\": \"$DESCRIPTION\",
+  \"group\": \"$NEW_GROUP\"
 }" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/instances/update-deployment.sh
+++ b/scripts/instances/update-deployment.sh
@@ -6,14 +6,12 @@ source ./auth.sh
 
 GROUP=$1
 NAME=$2
-TTL=$3
+TTL=${3:-}
 DESCRIPTION=${4:-}
-NEW_GROUP=${5:-}
 
 DEPLOYMENT_ID=$(./findByName.sh "$GROUP" "$NAME" | jq -r '.id')
 
 echo "{
   \"ttl\": $TTL,
-  \"description\": \"$DESCRIPTION\",
-  \"group\": \"$NEW_GROUP\"
+  \"description\": \"$DESCRIPTION\"
 }" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/instances/update-deployment.sh
+++ b/scripts/instances/update-deployment.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./auth.sh
+
+GROUP=$1
+NAME=$2
+TTL=$3
+DESCRIPTION=${4:-}
+
+DEPLOYMENT_ID=$(./findByName.sh "$GROUP" "$NAME" | jq -r '.id')
+
+echo "{
+  \"ttl\": $TTL,
+  \"description\": \"$DESCRIPTION\"
+}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/instances/update-dhis2-core.sh
+++ b/scripts/instances/update-dhis2-core.sh
@@ -73,4 +73,4 @@ echo "{
       \"value\": \"$ENABLE_QUERY_LOGGING\"
     }
   }
-}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN" 
+}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/instances/update-dhis2-core.sh
+++ b/scripts/instances/update-dhis2-core.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./auth.sh
+
+GROUP=$1
+NAME=$2
+
+DEPLOYMENT_ID=$(./findByName.sh "$GROUP" "$NAME" | jq -r '.id')
+
+INSTANCE_ID=$($HTTP get "$IM_HOST/deployments/$DEPLOYMENT_ID" "Authorization: Bearer $ACCESS_TOKEN" | jq -r '.instances[] | select(.stackName=="dhis2-core") | .id')
+
+MIN_READY_SECONDS=${MIN_READY_SECONDS:-120}
+STARTUP_PROBE_FAILURE_THRESHOLD=${STARTUP_PROBE_FAILURE_THRESHOLD:-26}
+STARTUP_PROBE_PERIOD_SECONDS=${STARTUP_PROBE_PERIOD_SECONDS:-5}
+LIVENESS_PROBE_TIMEOUT_SECONDS=${LIVENESS_PROBE_TIMEOUT_SECONDS:-1}
+READINESS_PROBE_TIMEOUT_SECONDS=${LIVENESS_PROBE_TIMEOUT_SECONDS:-1}
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-core}
+IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY:-IfNotPresent}
+IMAGE_TAG=${IMAGE_TAG:-2.40.2}
+CORE_RESOURCES_REQUESTS_CPU=${CORE_RESOURCES_REQUESTS_CPU:-250m}
+CORE_RESOURCES_REQUESTS_MEMORY=${CORE_RESOURCES_REQUESTS_MEMORY:-1500Mi}
+FLYWAY_MIGRATE_OUT_OF_ORDER=${FLYWAY_MIGRATE_OUT_OF_ORDER:-false}
+FLYWAY_REPAIR_BEFORE_MIGRATION=${FLYWAY_REPAIR_BEFORE_MIGRATION:-false}
+ENABLE_QUERY_LOGGING=${ENABLE_QUERY_LOGGING:-false}
+PUBLIC=${PUBLIC:-false}
+
+echo "{
+  \"stackName\": \"dhis2-core\",
+  \"public\": $PUBLIC,
+  \"parameters\": {
+    \"MIN_READY_SECONDS\": {
+      \"value\": \"$MIN_READY_SECONDS\"
+    },
+    \"IMAGE_PULL_POLICY\": {
+      \"value\": \"$IMAGE_PULL_POLICY\"
+    },
+    \"STARTUP_PROBE_FAILURE_THRESHOLD\": {
+      \"value\": \"$STARTUP_PROBE_FAILURE_THRESHOLD\"
+    },
+    \"STARTUP_PROBE_PERIOD_SECONDS\": {
+      \"value\": \"$STARTUP_PROBE_PERIOD_SECONDS\"
+    },
+    \"LIVENESS_PROBE_TIMEOUT_SECONDS\": {
+      \"value\": \"$LIVENESS_PROBE_TIMEOUT_SECONDS\"
+    },
+    \"READINESS_PROBE_TIMEOUT_SECONDS\": {
+      \"value\": \"$READINESS_PROBE_TIMEOUT_SECONDS\"
+    },
+    \"IMAGE_REPOSITORY\": {
+      \"value\": \"$IMAGE_REPOSITORY\"
+    },
+    \"IMAGE_PULL_POLICY\": {
+      \"value\": \"$IMAGE_PULL_POLICY\"
+    },
+    \"IMAGE_TAG\": {
+      \"value\": \"$IMAGE_TAG\"
+    },
+    \"RESOURCES_REQUESTS_CPU\": {
+      \"value\": \"$CORE_RESOURCES_REQUESTS_CPU\"
+    },
+    \"RESOURCES_REQUESTS_MEMORY\": {
+      \"value\": \"$CORE_RESOURCES_REQUESTS_MEMORY\"
+    },
+    \"FLYWAY_MIGRATE_OUT_OF_ORDER\": {
+      \"value\": \"$FLYWAY_MIGRATE_OUT_OF_ORDER\"
+    },
+    \"FLYWAY_REPAIR_BEFORE_MIGRATION\": {
+      \"value\": \"$FLYWAY_REPAIR_BEFORE_MIGRATION\"
+    },
+    \"ENABLE_QUERY_LOGGING\": {
+      \"value\": \"$ENABLE_QUERY_LOGGING\"
+    }
+  }
+}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN" 

--- a/scripts/instances/update-dhis2-db.sh
+++ b/scripts/instances/update-dhis2-db.sh
@@ -32,4 +32,4 @@ echo "{
       \"value\": \"$DB_RESOURCES_REQUESTS_MEMORY\"
     }
   }
-}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN" 
+}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN"

--- a/scripts/instances/update-dhis2-db.sh
+++ b/scripts/instances/update-dhis2-db.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source ./auth.sh
+
+GROUP=$1
+NAME=$2
+
+DEPLOYMENT_ID=$(./findByName.sh "$GROUP" "$NAME" | jq -r '.id')
+
+INSTANCE_ID=$($HTTP get "$IM_HOST/deployments/$DEPLOYMENT_ID" "Authorization: Bearer $ACCESS_TOKEN" | jq -r '.instances[] | select(.stackName=="dhis2-db") | .id')
+
+DATABASE_ID=${DATABASE_ID:-test-dbs-sierra-leone-2-40-2-sql-gz}
+DATABASE_SIZE=${DATABASE_SIZE:-20Gi}
+DB_RESOURCES_REQUESTS_CPU=${DB_RESOURCES_REQUESTS_CPU:-250m}
+DB_RESOURCES_REQUESTS_MEMORY=${DB_RESOURCES_REQUESTS_MEMORY:-256Mi}
+
+echo "{
+  \"stackName\": \"dhis2-db\",
+  \"parameters\": {
+    \"DATABASE_ID\": {
+      \"value\": \"$DATABASE_ID\"
+    },
+    \"DATABASE_SIZE\": {
+      \"value\": \"$DATABASE_SIZE\"
+    },
+    \"RESOURCES_REQUESTS_CPU\": {
+      \"value\": \"$DB_RESOURCES_REQUESTS_CPU\"
+    },
+    \"RESOURCES_REQUESTS_MEMORY\": {
+      \"value\": \"$DB_RESOURCES_REQUESTS_MEMORY\"
+    }
+  }
+}" | $HTTP put "$IM_HOST/deployments/$DEPLOYMENT_ID/instance/$INSTANCE_ID" "Authorization: Bearer $ACCESS_TOKEN" 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -502,6 +502,9 @@ definitions:
             description:
                 type: string
                 x-go-name: Description
+            group:
+                type: string
+                x-go-name: Group
             ttl:
                 format: uint64
                 type: integer

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -497,6 +497,17 @@ definitions:
                 x-go-name: Name
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/database
+    UpdateDeploymentRequest:
+        properties:
+            description:
+                type: string
+                x-go-name: Description
+            ttl:
+                format: uint64
+                type: integer
+                x-go-name: TTL
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/instance
     User:
         description: User domain object defining a user
         properties:
@@ -1049,6 +1060,40 @@ paths:
             security:
                 - oauth2: []
             summary: Find a deployment
+        put:
+            description: Update a Deployment ...
+            operationId: updateDeployment
+            parameters:
+                - format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+                - description: Update deployment request body parameter
+                  in: body
+                  name: Payload
+                  required: true
+                  schema:
+                    $ref: '#/definitions/UpdateDeploymentRequest'
+            responses:
+                "200":
+                    description: Deployment
+                    schema:
+                        $ref: '#/definitions/Deployment'
+                "400":
+                    $ref: '#/responses/Error'
+                "401":
+                    $ref: '#/responses/Error'
+                "403":
+                    $ref: '#/responses/Error'
+                "404":
+                    $ref: '#/responses/Error'
+                "500":
+                    $ref: '#/responses/Error'
+            security:
+                - oauth2: []
+            summary: Update a Deployment
     /deployments/{id}/deploy:
         post:
             description: Deploy a deployment...
@@ -1136,6 +1181,42 @@ paths:
             security:
                 - oauth2: []
             summary: Delete deployment instance
+        put:
+            description: Update a Deployment Instance ...
+            operationId: updateInstance
+            parameters:
+                - format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+                - format: uint64
+                  in: path
+                  name: instanceId
+                  required: true
+                  type: integer
+                  x-go-name: InstanceID
+                - description: Update instance request body parameter
+                  in: body
+                  name: Payload
+                  required: true
+                  schema:
+                    $ref: '#/definitions/SaveInstanceRequest'
+            responses:
+                "200":
+                    $ref: '#/responses/DeploymentInstance'
+                "401":
+                    $ref: '#/responses/Error'
+                "403":
+                    $ref: '#/responses/Error'
+                "404":
+                    $ref: '#/responses/Error'
+                "415":
+                    $ref: '#/responses/Error'
+            security:
+                - oauth2: []
+            summary: Update a Deployment Instance
     /deployments/public:
         get:
             description: Find all public deployments

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -502,9 +502,6 @@ definitions:
             description:
                 type: string
                 x-go-name: Description
-            group:
-                type: string
-                x-go-name: Group
             ttl:
                 format: uint64
                 type: integer


### PR DESCRIPTION
Updating the Deployment's `Name` and `Group` is not allowed. The name of a K8s object is immutable, so we need to destroy and re-create the Instance again anyway. Same goes for the group, if the current and new group have different Namespaces. With that in mind, we are not allowing changing the group, as it requires too much conditional logic that we should like to avoid.