### PR TITLE
fix: save

### DIFF
--- a/pkg/database/repository.go
+++ b/pkg/database/repository.go
@@ -191,6 +191,7 @@ func (r repository) FindByGroupNames(ctx context.Context, groupNames []string) (
 	err := query.
 		Where("type = ?", "database").
 		Order("updated_at desc").
+		Joins("Lock").
 		Find(&databases).Error
 
 	return databases, err

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -524,13 +524,13 @@ func (s service) SaveAs(ctx context.Context, database *model.Database, instance 
 	go func() {
 		var ret *forwarder.Result
 		if group.ClusterConfiguration != nil && len(group.ClusterConfiguration.KubernetesConfiguration) > 0 {
-			hostname := fmt.Sprintf(stack.HostnamePattern, instance.Name, instance.GroupName)
+			hostname := fmt.Sprintf(stack.HostnamePattern, instance.Name, instance.Group.Namespace)
 			serviceName := strings.Split(hostname, ".")[0]
 			options := []*forwarder.Option{
 				{
 					RemotePort:  5432,
 					ServiceName: serviceName,
-					Namespace:   instance.GroupName,
+					Namespace:   instance.Group.Namespace,
 				},
 			}
 
@@ -678,7 +678,7 @@ func newPgDumpConfig(instance *model.DeploymentInstance, stack *model.Stack) (*p
 	}
 
 	dump, err := pg.NewDump(&pg.Postgres{
-		Host:     fmt.Sprintf(stack.HostnamePattern, instance.Name, instance.GroupName),
+		Host:     fmt.Sprintf(stack.HostnamePattern, instance.Name, instance.Group.Namespace),
 		Port:     5432,
 		DB:       databaseName.Value,
 		Username: databaseUsername.Value,

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -443,6 +443,11 @@ func (s service) Save(ctx context.Context, userId uint, database *model.Database
 			return
 		}
 
+		err = s.Unlock(ctx, database.ID)
+		if err != nil {
+			s.logError(ctx, fmt.Errorf("unlock database failed: %v", err))
+		}
+
 		err = s.Delete(ctx, database.ID)
 		if err != nil {
 			s.logError(ctx, err)

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -353,6 +353,11 @@ func (s service) Update(ctx context.Context, d *model.Database) error {
 		return err
 	}
 
+	// TODO: This shouldn't be necessary... But without it I get the following error: {"time":"2025-07-04T00:03:05.942946078Z","level":"ERROR","msg":"record not found","error":"record not found","query":"SELECT * FROM \"databases\" WHERE \"databases\".\"id\" = 0 ORDER BY \"databases\".\"id\" LIMIT 1","duration": 602547,"rows":0,"file":"/src/pkg/database/repository.go:63","correlationId":"4c39fa85-d8fb-4e75-a0cb-1ad4732b7f47","user":12}
+	if d.FilestoreID == 0 {
+		return nil
+	}
+
 	return s.updateFS(ctx, d)
 }
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -221,14 +221,14 @@ func TestInstanceHandler(t *testing.T) {
 		t.Log("Deploy deployment")
 		path = fmt.Sprintf("/deployments/%d/deploy", deployment.ID)
 		client.Do(t, http.MethodPost, path, nil, http.StatusOK, inttest.WithAuthToken("sometoken"))
-		k8sClient.AssertPodIsReady(t, deploymentInstance.GroupName, deploymentInstance.Name, 60)
+		k8sClient.AssertPodIsReady(t, deploymentInstance.Group.Namespace, deploymentInstance.Name, 60)
 
 		t.Log("Destroy deployment")
 		path = fmt.Sprintf("/deployments/%d", deployment.ID)
 		client.Do(t, http.MethodDelete, path, nil, http.StatusAccepted, inttest.WithAuthToken("sometoken"))
 		// TODO: Ideally we shouldn't use sleep here but rather watch the pod until it disappears or a timeout is reached
 		time.Sleep(3 * time.Second)
-		k8sClient.AssertPodIsNotRunning(t, deploymentInstance.GroupName, deploymentInstance.Name)
+		k8sClient.AssertPodIsNotRunning(t, deploymentInstance.Group.Namespace, deploymentInstance.Name)
 	})
 
 	t.Run("GetPublicDeployments", func(t *testing.T) {

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -236,7 +236,7 @@ func (ks kubernetesService) restart(instance *model.DeploymentInstance, typeSele
 	}
 
 	if instanceStack.KubernetesResource == model.StatefulSetResource {
-		statefulSets := ks.client.AppsV1().StatefulSets(instance.GroupName)
+		statefulSets := ks.client.AppsV1().StatefulSets(instance.Group.Namespace)
 		statefulSetsList, err := statefulSets.List(context.TODO(), listOptions)
 		if err != nil {
 			return err
@@ -261,7 +261,7 @@ func (ks kubernetesService) restart(instance *model.DeploymentInstance, typeSele
 	}
 
 	if instanceStack.KubernetesResource == model.DeploymentResource {
-		deployments := ks.client.AppsV1().Deployments(instance.GroupName)
+		deployments := ks.client.AppsV1().Deployments(instance.Group.Namespace)
 		deploymentList, err := deployments.List(context.TODO(), listOptions)
 		if err != nil {
 			return err
@@ -319,7 +319,7 @@ func (ks kubernetesService) deletePersistentVolumeClaim(instance *model.Deployme
 		return nil
 	}
 
-	pvcs := ks.client.CoreV1().PersistentVolumeClaims(instance.GroupName)
+	pvcs := ks.client.CoreV1().PersistentVolumeClaims(instance.Group.Namespace)
 
 	for _, pattern := range labelPatterns {
 		selector := fmt.Sprintf(pattern, instance.Name)
@@ -349,7 +349,7 @@ func (ks kubernetesService) scale(instance *model.DeploymentInstance, replicas u
 	labelSelector := fmt.Sprintf("im-id=%d", instance.ID)
 	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
 
-	deployments := ks.client.AppsV1().Deployments(instance.GroupName)
+	deployments := ks.client.AppsV1().Deployments(instance.Group.Namespace)
 	deploymentList, err := deployments.List(context.TODO(), listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding deployments using selector %q: %v", labelSelector, err)
@@ -362,7 +362,7 @@ func (ks kubernetesService) scale(instance *model.DeploymentInstance, replicas u
 		}
 	}
 
-	sets := ks.client.AppsV1().StatefulSets(instance.GroupName)
+	sets := ks.client.AppsV1().StatefulSets(instance.Group.Namespace)
 	setsList, err := sets.List(context.TODO(), listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding StatefulSets using selector %q: %v", labelSelector, err)

--- a/pkg/inttest/k8s.go
+++ b/pkg/inttest/k8s.go
@@ -54,8 +54,8 @@ type K8sClient struct {
 	Config []byte
 }
 
-func (k K8sClient) AssertPodIsNotRunning(t *testing.T, group string, instance string) {
-	pods, err := k.Client.CoreV1().Pods(group).List(context.TODO(), metav1.ListOptions{
+func (k K8sClient) AssertPodIsNotRunning(t *testing.T, namespace string, instance string) {
+	pods, err := k.Client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/instance=" + instance,
 	})
 	require.NoError(t, err)
@@ -63,9 +63,9 @@ func (k K8sClient) AssertPodIsNotRunning(t *testing.T, group string, instance st
 	require.Len(t, pods.Items, 0)
 }
 
-func (k K8sClient) AssertPodIsReady(t *testing.T, group string, instance string, timeoutInSeconds time.Duration) {
+func (k K8sClient) AssertPodIsReady(t *testing.T, namespace string, instance string, timeoutInSeconds time.Duration) {
 	ctx, cancel := context.WithCancel(context.Background())
-	watch, err := k.Client.CoreV1().Pods(group).Watch(ctx, metav1.ListOptions{
+	watch, err := k.Client.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/instance=" + instance,
 	})
 	require.NoErrorf(t, err, "failed to find pod for instance %q", instance)

--- a/pkg/inttest/k8s.go
+++ b/pkg/inttest/k8s.go
@@ -23,7 +23,7 @@ func SetupK8s(t *testing.T) *K8sClient {
 
 	container, err := gnomock.Start(
 		k3s.Preset(
-			k3s.WithVersion("v1.26.7-k3s1"),
+			k3s.WithVersion("v1.33.2-k3s1"),
 			func(p *k3s.P) {
 				p.K3sServerFlags = []string{"--debug"}
 			},

--- a/scripts/databases/unlock.sh
+++ b/scripts/databases/unlock.sh
@@ -6,4 +6,4 @@ source ./auth.sh
 
 DATABASE=$1
 
-$HTTP delete "$IM_HOST/databases/$DATABASE/unlock" "Authorization: Bearer $ACCESS_TOKEN"
+$HTTP delete "$IM_HOST/databases/$DATABASE/lock" "Authorization: Bearer $ACCESS_TOKEN"


### PR DESCRIPTION
In advance I'd like to apologize for this PR

* Include Locks when listing Databases
* Fix path when unlocking a database
* Use Group.Namespace rather than Instance.GroupName when interacting with the cluster
* Fix save by unlocking before deleting the original database

Save seems to work but I'm getting the below errors

    {"time":"2025-07-04T00:03:06.03324424Z","level":"ERROR","msg":"Failed to remove temp file","error":"close /mnt/data/e4526bab-8d89-4550-a040-750e6e6ab2ab.dump: file already closed","correlationId":"4c39fa85-d8fb-4e75-a0cb-1ad4732b7f47","user":12}
