### PR TITLE
feat: include User and Instance when retrieving the Lock

### DIFF
--- a/pkg/database/repository.go
+++ b/pkg/database/repository.go
@@ -185,7 +185,7 @@ func (r repository) FindByGroupNames(ctx context.Context, groupNames []string) (
 	query := r.db.WithContext(ctx)
 	isAdmin := slices.Contains(groupNames, model.AdministratorGroupName)
 	if !isAdmin {
-		query = query.Where("group_name IN ?", groupNames)
+		query = query.Where("Databases.group_name IN ?", groupNames)
 	}
 
 	err := query.

--- a/pkg/database/repository.go
+++ b/pkg/database/repository.go
@@ -191,6 +191,8 @@ func (r repository) FindByGroupNames(ctx context.Context, groupNames []string) (
 	err := query.
 		Where("type = ?", "database").
 		Order("updated_at desc").
+		Joins("Lock.User").
+		Joins("Lock.Instance").
 		Find(&databases).Error
 
 	return databases, err

--- a/pkg/model/database.go
+++ b/pkg/model/database.go
@@ -27,9 +27,9 @@ type Database struct {
 type Lock struct {
 	DatabaseID uint               `json:"databaseId" gorm:"primaryKey"`
 	InstanceID uint               `json:"instanceId"`
-	Instance   DeploymentInstance `json:"-"`
+	Instance   DeploymentInstance `json:"instance"`
 	UserID     uint               `json:"userId"`
-	User       User               `json:"-"`
+	User       User               `json:"user"`
 }
 
 // swagger:model

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -353,10 +353,14 @@ definitions:
                 format: uint64
                 type: integer
                 x-go-name: DatabaseID
+            instance:
+                $ref: '#/definitions/DeploymentInstance'
             instanceId:
                 format: uint64
                 type: integer
                 x-go-name: InstanceID
+            user:
+                $ref: '#/definitions/User'
             userId:
                 format: uint64
                 type: integer


### PR DESCRIPTION
The reason for this PR is that when listing databases it'll be a better user experience if we can include who owns the lock and which instance it's associated with