### PR TITLE
feat: include lock when listing deployments

### DIFF
--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -176,6 +176,7 @@ func (r repository) FindDeployments(ctx context.Context, groupNames []string) ([
 		Joins("Group").
 		Joins("User").
 		Preload("Instances").
+		Preload("Instances.Lock").
 		Order("updated_at desc").
 		Find(&deployments).Error
 

--- a/pkg/model/database.go
+++ b/pkg/model/database.go
@@ -27,9 +27,9 @@ type Database struct {
 type Lock struct {
 	DatabaseID uint               `json:"databaseId" gorm:"primaryKey"`
 	InstanceID uint               `json:"instanceId"`
-	Instance   DeploymentInstance `json:"instance"`
+	Instance   DeploymentInstance `json:"instance,omitempty"`
 	UserID     uint               `json:"userId"`
-	User       User               `json:"user"`
+	User       User               `json:"user,omitempty"`
 }
 
 // swagger:model

--- a/pkg/model/instance.go
+++ b/pkg/model/instance.go
@@ -38,6 +38,8 @@ type DeploymentInstance struct {
 	//	Stack     *Stack `json:"stack,omitempty"`
 	StackName string `json:"stackName" gorm:"index:deployment_instance_name_group_stack_idx,unique"`
 
+	Lock *Lock `gorm:"foreignKey:InstanceID"`
+
 	DeploymentID uint        `json:"deploymentId"`
 	Deployment   *Deployment `json:"deployment,omitempty"`
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -178,6 +178,8 @@ definitions:
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
     DeploymentInstance:
         properties:
+            Lock:
+                $ref: '#/definitions/Lock'
             createdAt:
                 format: date-time
                 type: string


### PR DESCRIPTION
I wanted to delete an instance but were getting a 500 error. It turned out the instance had a lock on it. How exactly we'd like to deal with this client side isn't clear but we'll certainly need to include the lock when listing instances