### PR TITLE
chore: increase proxy buffer size

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -99,6 +99,8 @@ ingress:
     # for our workload it won't matter
     nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     nginx.ingress.kubernetes.io/client-body-buffer-size: "10m"
+    # Increase the proxy response buffer size to fix the response headers limit issue.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
The new value allows a user to be in all of the currently existing groups. If needed we can increase it further.
<img width="1701" height="961" alt="image" src="https://github.com/user-attachments/assets/a45123e6-cf65-4a72-8189-7ae6356d5330" />
