### PR TITLE
fix: preload Instances when finding Deployments

### DIFF
--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -224,12 +224,13 @@ func (r repository) SaveDatabase(ctx context.Context, database *model.Database) 
 func (r repository) FindAllDeployments(ctx context.Context) ([]model.Deployment, error) {
 	var deployments []model.Deployment
 	err := r.db.WithContext(ctx).
+		Preload("Instances").
 		Find(&deployments).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return []model.Deployment{}, nil
 		}
-		return nil, fmt.Errorf("failed to find instance: %v", err)
+		return nil, fmt.Errorf("failed to find deployments: %v", err)
 	}
 	return deployments, err
 }


### PR DESCRIPTION
If we don't preload instances, deployments with no instances will only be deleted from the database and not from the cluster.