### PR TITLE
docs: update command order in release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ It's advised to generate the release log before doing so.
 Example
 
 ```shell
-make change-log
-git commit CHANGELOG.md -m "chore: generate change log"
 git tag --sort=-creatordate | head --lines=1              # Get the latest tag
 git tag v0.53.0                                           # Use whichever tag you want to release
+make change-log
+git commit CHANGELOG.md -m "chore: generate change log"
 git push
 ```
 


### PR DESCRIPTION
We need to create a tag first before being able to generate a new change log for it.