### PR TITLE
fix: persist group namespace in findOrCreate

### DIFF
--- a/pkg/group/group_integration_test.go
+++ b/pkg/group/group_integration_test.go
@@ -166,6 +166,23 @@ func TestGroupHandler(t *testing.T) {
 			assert.Nil(t, group.ClusterID)
 		})
 
+		t.Run("FindOrCreatePersistsAllFields", func(t *testing.T) {
+			t.Parallel()
+
+			g, err := groupService.FindOrCreate(t.Context(), "find-or-create-group", "find-or-create-namespace", "find-or-create-hostname.com", true)
+			require.NoError(t, err)
+			assert.Equal(t, "find-or-create-group", g.Name)
+			assert.Equal(t, "find-or-create-namespace", g.Namespace)
+			assert.Equal(t, "find-or-create-hostname.com", g.Hostname)
+			assert.True(t, g.Deployable)
+
+			persisted, err := groupService.Find(t.Context(), "find-or-create-group")
+			require.NoError(t, err)
+			assert.Equal(t, "find-or-create-namespace", persisted.Namespace)
+			assert.Equal(t, "find-or-create-hostname.com", persisted.Hostname)
+			assert.True(t, persisted.Deployable)
+		})
+
 		t.Run("CreateDeployableGroup", func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/group/repository.go
+++ b/pkg/group/repository.go
@@ -138,7 +138,7 @@ func (r repository) findOrCreate(ctx context.Context, group *model.Group) (*mode
 	err := r.db.
 		WithContext(ctx).
 		Where(model.Group{Name: group.Name}).
-		Attrs(model.Group{Hostname: group.Hostname, Deployable: group.Deployable}).
+		Attrs(model.Group{Namespace: group.Namespace, Hostname: group.Hostname, Deployable: group.Deployable}).
 		FirstOrCreate(&g).Error
 	return g, err
 }


### PR DESCRIPTION
Groups seeded via `Service.FindOrCreate` (e.g. `GROUP_NAMESPACES` from helm) landed in the DB with an empty `namespace`. Adds Namespace to Attrs(...) plus a regression test.