### PR TITLE
ci: include orphaned releases list in Slack message

### DIFF
--- a/.github/workflows/find-orphaned-helm-releases.yaml
+++ b/.github/workflows/find-orphaned-helm-releases.yaml
@@ -55,6 +55,12 @@ jobs:
 
           ORPHANED_COUNT=$(grep 'Orphaned Deployments only in Helm' /tmp/find-helm-releases-output | grep --only-matching --regexp='[0-9]\+' || echo "0")
           echo "orphaned_count=$ORPHANED_COUNT" >> $GITHUB_OUTPUT
+
+          {
+            echo "orphaned_list<<ORPHANS_EOF"
+            sed -n '/^Orphaned Deployments only in Helm/,/^$/p' /tmp/find-helm-releases-output | sed '$d'
+            echo "ORPHANS_EOF"
+          } >> $GITHUB_OUTPUT
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,6 +76,10 @@ jobs:
 
             ${{ steps.find-orphaned-releases.outputs.orphaned_count }} orphaned deployment(s) detected.
 
-            View details and uninstall commands in the GitHub Actions logs (step: "Find orphaned Helm Releases"):
+            ```
+            ${{ steps.find-orphaned-releases.outputs.orphaned_list }}
+            ```
+
+            View uninstall commands in the GitHub Actions logs (step: "Find orphaned Helm Releases"):
             https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_COLOR: 'failure'


### PR DESCRIPTION
## Summary
- Slack notification now embeds the orphaned releases list inline (kubeconfig / namespace / release names), inside a code block.
- Previously the message only showed a count, requiring recipients to open GitHub Actions logs for the actual list.

## How it works
A new step output `orphaned_list` extracts the orphan section of the script's stdout via `sed -n '/^Orphaned Deployments only in Helm/,/^$/p'` and is exposed as a multi-line GH output (heredoc-style with `ORPHANS_EOF` delimiter). The Slack message embeds it in a code fence.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` with at least one orphan present and confirm the Slack message contains the orphan list.
- [ ] Confirm the message still renders correctly when no orphans exist (Slack notification step is gated on `orphaned_count > 0`, so it should not fire).