### PR TITLE
fix: make refresh access token expiry configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,8 @@ COOKIE_SECURE=false
 
 # 15 minutes
 ACCESS_TOKEN_EXPIRATION_IN_SECONDS=900
+# 30 minutes - lifetime of the token issued when refreshing an access token close to expiry
+REFRESH_ACCESS_TOKEN_EXPIRATION_IN_SECONDS=1800
 # 24 hours
 REFRESH_TOKEN_EXPIRATION_IN_SECONDS=86400
 # 30 days

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -137,7 +137,7 @@ func run() (err error) {
 	if err != nil {
 		return err
 	}
-	tokenService, err := token.NewService(logger, tokenRepository, privateKey, authConfig.AccessTokenExpirationSeconds, authConfig.RefreshTokenSecretKey, authConfig.RefreshTokenExpirationSeconds, authConfig.RefreshTokenRememberMeExpirationSeconds)
+	tokenService, err := token.NewService(logger, tokenRepository, privateKey, authConfig.AccessTokenExpirationSeconds, authConfig.RefreshAccessTokenExpirationSeconds, authConfig.RefreshTokenSecretKey, authConfig.RefreshTokenExpirationSeconds, authConfig.RefreshTokenRememberMeExpirationSeconds)
 	if err != nil {
 		return err
 	}
@@ -360,6 +360,7 @@ type authenticationConfig struct {
 	CookieSecure                            bool
 	RefreshTokenSecretKey                   string
 	AccessTokenExpirationSeconds            int
+	RefreshAccessTokenExpirationSeconds     int
 	RefreshTokenExpirationSeconds           int
 	RefreshTokenRememberMeExpirationSeconds int
 }
@@ -374,6 +375,10 @@ func newAuthenticationConfig() (authenticationConfig, error) {
 		return authenticationConfig{}, err
 	}
 	accessTokenExpirationSeconds, err := requireEnvAsInt("ACCESS_TOKEN_EXPIRATION_IN_SECONDS")
+	if err != nil {
+		return authenticationConfig{}, err
+	}
+	refreshAccessTokenExpirationSeconds, err := requireEnvAsInt("REFRESH_ACCESS_TOKEN_EXPIRATION_IN_SECONDS")
 	if err != nil {
 		return authenticationConfig{}, err
 	}
@@ -393,6 +398,7 @@ func newAuthenticationConfig() (authenticationConfig, error) {
 		CookieSecure:                            cookieSecure,
 		RefreshTokenSecretKey:                   refreshTokenSecretKey,
 		AccessTokenExpirationSeconds:            accessTokenExpirationSeconds,
+		RefreshAccessTokenExpirationSeconds:     refreshAccessTokenExpirationSeconds,
 		RefreshTokenExpirationSeconds:           refreshTokenExpirationSeconds,
 		RefreshTokenRememberMeExpirationSeconds: refreshTokenRememberMeExpirationSeconds,
 	}, nil

--- a/helm/chart/templates/configmap.yaml
+++ b/helm/chart/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
 {{- end }}
   SAME_SITE_MODE: {{ .Values.sameSiteMode }}
   ACCESS_TOKEN_EXPIRATION_IN_SECONDS: {{ .Values.accessTokenExpirationInSeconds | quote }}
+  REFRESH_ACCESS_TOKEN_EXPIRATION_IN_SECONDS: {{ .Values.refreshAccessTokenExpirationInSeconds | quote }}
   REFRESH_TOKEN_EXPIRATION_IN_SECONDS: {{ .Values.refreshTokenExpirationInSeconds | quote }}
   REFRESH_TOKEN_REMEMBER_ME_EXPIRATION_IN_SECONDS: {{ .Values.refreshTokenRememberMeExpirationInSeconds | quote }}
 

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -9,6 +9,7 @@ corsAllowOrigins:
 sameSiteMode: strict
 
 accessTokenExpirationInSeconds: 300 # 5 minutes
+refreshAccessTokenExpirationInSeconds: 1800 # 30 minutes
 refreshTokenExpirationInSeconds: 900 # 15 minutes
 refreshTokenRememberMeExpirationInSeconds: "2592000" # 30 days
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -94,7 +94,7 @@ func TestInstanceHandler(t *testing.T) {
 	tokenRepository := token.NewRepository(redis)
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err, "failed to generate RSA private key")
-	tokenService, err := token.NewService(logger, tokenRepository, privateKey, 100, "secret", 100, 100)
+	tokenService, err := token.NewService(logger, tokenRepository, privateKey, 100, 60, "secret", 100, 100)
 	require.NoError(t, err, "failed to create token service")
 	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, nil, "", tokenService)
 

--- a/pkg/token/helper/tokenHelper.go
+++ b/pkg/token/helper/tokenHelper.go
@@ -132,18 +132,17 @@ func ValidateRefreshToken(tokenString string, secretKey string) (*refreshTokenCl
 	}, nil
 }
 
-func RefreshAccessToken(token string, privateKey *rsa.PrivateKey) (string, error) {
+func RefreshAccessToken(token string, privateKey *rsa.PrivateKey, newExpirationInSeconds int) (string, error) {
 	user, exp, err := ValidateAccessToken(token, &privateKey.PublicKey)
 	if err != nil {
 		return "", err
 	}
 
 	remaining := exp - time.Now().Unix()
-	if remaining > 60 {
+	if remaining > int64(newExpirationInSeconds) {
 		return token, nil
 	}
 
-	newExpirationInSeconds := 60
 	return GenerateAccessToken(user, privateKey, newExpirationInSeconds)
 }
 

--- a/pkg/token/helper/tokenHelper_test.go
+++ b/pkg/token/helper/tokenHelper_test.go
@@ -74,31 +74,33 @@ func TestRefreshAccessToken(t *testing.T) {
 		Email: "test@example.com",
 	}
 
+	const refreshExpiration = 60
+
 	t.Run("Long expiration time", func(t *testing.T) {
 		t.Parallel()
-		t.Log("Token with remaining time > 60 seconds, should return the same token")
+		t.Log("Token with remaining time > refresh expiration, should return the same token")
 
 		expirationTime, err := GenerateAccessToken(user, key, 120)
 		require.NoError(t, err)
-		refreshed, err := RefreshAccessToken(expirationTime, key)
+		refreshed, err := RefreshAccessToken(expirationTime, key, refreshExpiration)
 		assert.NoError(t, err)
 		assert.Equal(t, expirationTime, refreshed)
 	})
 
 	t.Run("Short expiration time", func(t *testing.T) {
 		t.Parallel()
-		t.Log("Token with remaining time <= 60 seconds, should generate a new token")
+		t.Log("Token with remaining time <= refresh expiration, should generate a new token")
 
 		expirationTime, err := GenerateAccessToken(user, key, 30)
 		require.NoError(t, err)
-		refreshed, err := RefreshAccessToken(expirationTime, key)
+		refreshed, err := RefreshAccessToken(expirationTime, key, refreshExpiration)
 		assert.NoError(t, err)
 		assert.NotEqual(t, expirationTime, refreshed)
 
-		t.Log("Verify the new token has an expiration close to 60 seconds from now")
+		t.Log("Verify the new token has an expiration close to the refresh expiration from now")
 		_, exp, err := ValidateAccessToken(refreshed, &key.PublicKey)
 		require.NoError(t, err)
 		now := time.Now().Unix()
-		assert.True(t, exp-now <= 60 && exp-now > 50, "new token expiration should be around 60 seconds")
+		assert.True(t, exp-now <= refreshExpiration && exp-now > refreshExpiration-10, "new token expiration should be around %d seconds", refreshExpiration)
 	})
 }

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -22,6 +22,7 @@ func NewService(
 	tokenRepository repository,
 	privateKey *rsa.PrivateKey,
 	accessTokenExpirationSeconds int,
+	refreshAccessTokenExpirationSeconds int,
 	refreshTokenSecretKey string,
 	refreshTokenExpirationSeconds int,
 	refreshTokenRememberMeExpirationSeconds int,
@@ -31,6 +32,7 @@ func NewService(
 		repository:                              tokenRepository,
 		privateKey:                              privateKey,
 		accessTokenExpirationSeconds:            accessTokenExpirationSeconds,
+		refreshAccessTokenExpirationSeconds:     refreshAccessTokenExpirationSeconds,
 		refreshTokenSecretKey:                   refreshTokenSecretKey,
 		refreshTokenExpirationSeconds:           refreshTokenExpirationSeconds,
 		refreshTokenRememberMeExpirationSeconds: refreshTokenRememberMeExpirationSeconds,
@@ -63,6 +65,7 @@ type TokenService struct {
 	repository                              repository
 	privateKey                              *rsa.PrivateKey
 	accessTokenExpirationSeconds            int
+	refreshAccessTokenExpirationSeconds     int
 	refreshTokenSecretKey                   string
 	refreshTokenExpirationSeconds           int
 	refreshTokenRememberMeExpirationSeconds int
@@ -127,5 +130,5 @@ func (t TokenService) SignOut(userId uint) error {
 }
 
 func (t TokenService) RefreshAccessToken(accessToken string) (string, error) {
-	return helper.RefreshAccessToken(accessToken, t.privateKey)
+	return helper.RefreshAccessToken(accessToken, t.privateKey, t.refreshAccessTokenExpirationSeconds)
 }

--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -61,7 +61,7 @@ func TestUserHandler(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	redis := inttest.SetupRedis(t)
 	tokenRepository := token.NewRepository(redis)
-	tokenService, err := token.NewService(logger, tokenRepository, key, 10, "secret", 20, 30)
+	tokenService, err := token.NewService(logger, tokenRepository, key, 10, 5, "secret", 20, 30)
 	require.NoError(t, err)
 
 	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {


### PR DESCRIPTION
## Summary
- `RefreshAccessToken` previously hard-coded the post-refresh token lifetime to 60 seconds. That value gets embedded in pods' `IM_ACCESS_TOKEN` env var (used by the minio and postgres seed scripts to download a database via curl) and is sometimes shorter than the time between helmfile sync and the pod actually running the curl, producing HTTP 401 during seed.
- Once the first seed fails, Bitnami never writes its idempotency marker, so every restart re-runs the seed against an already expired token. The pod ends up in a permanent `CrashLoopBackOff` until the instance is reset.
- This change makes the post-refresh expiry configurable via `REFRESH_ACCESS_TOKEN_EXPIRATION_IN_SECONDS`, defaulting to `1800` (30 minutes). The reuse threshold is also tied to this value: if the existing token already lasts longer than the refresh would give it, it is kept; otherwise a fresh one is issued.

## Test plan
- [ ] Unit tests pass (`go test ./pkg/token/...`).
- [ ] Deploy this branch via the PR feature env, then deploy a fresh DHIS2 instance with a non-trivial database and confirm the minio/postgres seed sidecars complete on the first try.
- [ ] Reset an existing instance against the feature env's API and confirm it stabilizes without a 401 cascade.