### PR TITLE
fix: bump core chart to 0.34.8

### DIFF
--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -306,7 +306,7 @@ var dhis2CoreDefaults = struct {
 	googleAuthClientEmail        string
 	googleAuthClientId           string
 }{
-	chartVersion:                 "0.34.7",
+	chartVersion:                 "0.34.8",
 	storageType:                  minIOStorage,
 	sameSiteCookies:              lax,
 	filesystemVolumeSize:         "8Gi",


### PR DESCRIPTION
## Summary
- Bump `dhis2/core` Helm chart from `0.34.7` to `0.34.8`.

## Why
Chart `0.34.8` adds a writable `emptyDir` mount at `/usr/local/tomcat/temp`, fixing a `Read-only file system` error in `BundledAppManager` when `readOnlyRootFilesystem` is enabled. See https://github.com/dhis2-sre/dhis2-core-chart/pull/79.