### PR TITLE
chore: bump go version to 1.26.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ go test ./pkg/token/... -run TestRefreshAccessToken   # single test
 make check            # pre-commit: goimports, go-mod-tidy, golangci-lint, swagger validation, commitizen
 make swagger          # regenerate swagger/swagger.yaml from code annotations
 make keys             # generate the RSA private key required by .env's PRIVATE_KEY
+skaffold run -p dev   # run im-manager + deps via skaffold (dev profile)
 ```
 
 `make test` runs everything together — `*_integration_test.go` files have **no build tag**. They use `pkg/inttest` which

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine3.21 AS build
+FROM golang:1.26.2-alpine3.23 AS build
 
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhis2-sre/im-manager
 
-go 1.25.0
+go 1.26.2
 
 require (
 	filippo.io/age v1.3.1

--- a/pkg/database/repository.go
+++ b/pkg/database/repository.go
@@ -108,7 +108,7 @@ func (r repository) Lock(ctx context.Context, databaseId, instanceId, userId uin
 		}
 
 		if d.Lock != nil && d.Lock.InstanceID != 0 {
-			return errdef.NewBadRequest("database already locked by user %q and instance %q", userId, d.Lock.InstanceID)
+			return errdef.NewBadRequest("database already locked by user %d and instance %d", userId, d.Lock.InstanceID)
 		}
 
 		lock = &model.Lock{

--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -409,7 +409,7 @@ func (ks kubernetesService) restart(instance *model.DeploymentInstance, typeSele
 func (ks kubernetesService) pause(instance *model.DeploymentInstance) error {
 	err := ks.scale(instance, 0)
 	if err != nil {
-		return fmt.Errorf("failed to pause instance %q: %v", instance.ID, err)
+		return fmt.Errorf("failed to pause instance %d: %v", instance.ID, err)
 	}
 
 	return nil
@@ -418,7 +418,7 @@ func (ks kubernetesService) pause(instance *model.DeploymentInstance) error {
 func (ks kubernetesService) resume(instance *model.DeploymentInstance) error {
 	err := ks.scale(instance, 1)
 	if err != nil {
-		return fmt.Errorf("failed to resume instance %q: %v", instance.ID, err)
+		return fmt.Errorf("failed to resume instance %d: %v", instance.ID, err)
 	}
 
 	return nil


### PR DESCRIPTION
Bumps Go from 1.25.0 to 1.26.2 in go.mod and Dockerfile (also updates alpine from 3.21 to 3.23).

Once this PR is merged. Update the below PRs

* https://github.com/dhis2-sre/im-manager/pull/1471
* https://github.com/dhis2-sre/im-manager/pull/1478
* https://github.com/dhis2-sre/im-manager/pull/1479
