### PR TITLE
feat: support setting cluster when creating a group

### DIFF
--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -27,6 +27,7 @@ type CreateGroupRequest struct {
 	Description string `json:"description" binding:"required"`
 	Hostname    string `json:"hostname" binding:"required"`
 	Deployable  bool   `json:"deployable"`
+	ClusterID   *uint  `json:"clusterId"`
 }
 
 // Create group
@@ -53,7 +54,7 @@ func (h Handler) Create(c *gin.Context) {
 		return
 	}
 
-	group, err := h.groupService.Create(c.Request.Context(), request.Name, request.Namespace, request.Description, request.Hostname, request.Deployable)
+	group, err := h.groupService.Create(c.Request.Context(), request.Name, request.Namespace, request.Description, request.Hostname, request.Deployable, request.ClusterID)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/group/service.go
+++ b/pkg/group/service.go
@@ -36,13 +36,21 @@ func (s *Service) FindWithDetails(ctx context.Context, name string) (*model.Grou
 	return s.groupRepository.findWithDetails(ctx, name)
 }
 
-func (s *Service) Create(ctx context.Context, name, namespace, description, hostname string, deployable bool) (*model.Group, error) {
+func (s *Service) Create(ctx context.Context, name, namespace, description, hostname string, deployable bool, clusterID *uint) (*model.Group, error) {
 	group := &model.Group{
 		Name:        name,
 		Namespace:   namespace,
 		Description: description,
 		Hostname:    hostname,
 		Deployable:  deployable,
+	}
+
+	if clusterID != nil {
+		c, err := s.clusterService.Find(ctx, *clusterID)
+		if err != nil {
+			return nil, err
+		}
+		group.ClusterID = &c.ID
 	}
 
 	err := s.groupRepository.create(ctx, group)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -97,6 +97,10 @@ definitions:
         x-go-package: github.com/dhis2-sre/im-manager/pkg/database
     CreateGroupRequest:
         properties:
+            clusterId:
+                format: uint64
+                type: integer
+                x-go-name: ClusterID
             deployable:
                 type: boolean
                 x-go-name: Deployable


### PR DESCRIPTION
Add optional `clusterId` field to the group creation request. If provided, the cluster is validated and associated with the group at creation time.