### PR TITLE
fix: default TARGETARCH to amd64 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26.2-alpine3.23 AS build
 
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
 ARG KUBECTL_VERSION=v1.33.3


### PR DESCRIPTION
`TARGETARCH` is a Buildx automatic build arg that CI sets via `--platform`. Plain `docker build` (used by skaffold locally) leaves it empty, breaking the kubectl download URL. Defaulting to `amd64` fixes local builds without affecting CI.