### PR TITLE
fix: set proxy-busy-buffers-size alongside proxy-buffer-size

### DIFF
--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -104,6 +104,7 @@ ingress:
     nginx.ingress.kubernetes.io/client-body-buffer-size: "10m"
     # Increase the proxy response buffer size to fix the response headers limit issue.
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "32k"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
 


### PR DESCRIPTION
## The problem

An `im-manager-tons` deployment in the Hetzner `k3s-prod` cluster caused every newly-created ingress (including unrelated DHIS2 instances) to return `404 Not Found` from nginx. The chart's ingress annotations set `proxy-buffer-size: 16k` without a matching `proxy-busy-buffers-size`, which makes `nginx -t` fail on ingress-nginx v1.12+:

```
nginx: [emerg] "proxy_busy_buffers_size" must be equal to or greater than the maximum
of the value of "proxy_buffer_size" and one of the "proxy_buffers"
```

With reloads failing, the controller kept serving stale config from before the broken ingress landed; anything created afterwards was invisible to nginx.

## Why now / why Hetzner only

EKS production runs ingress-nginx `v1.11.3`, which auto-derives `proxy_busy_buffers_size` from the annotation and reloads cleanly — so the chart has been silently buggy there for months. The Hetzner cluster runs `v1.13.0`, which no longer auto-derives it. `im-manager-tons` was mistakenly deployed to Hetzner (im-manager releases belong on EKS) and became the first chart-rendered ingress on a v1.12+ controller, freezing reloads cluster-wide.

## Fix

Add `nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "32k"` alongside the existing `proxy-buffer-size: "16k"` in the chart. No-op on v1.11.x, unblocks reloads on v1.12+.