### PR TITLE
fix: return 400 instead of 500 for password validation errors on reset

### DIFF
--- a/internal/handler/dataBinder.go
+++ b/internal/handler/dataBinder.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
-	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"errors"
 
+	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 )
 
 func DataBinder(c *gin.Context, req interface{}) error {
@@ -12,6 +14,10 @@ func DataBinder(c *gin.Context, req interface{}) error {
 	}
 
 	if err := c.ShouldBind(req); err != nil {
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			return errdef.NewBadRequest("%s", err.Error())
+		}
 		return err
 	}
 

--- a/internal/handler/dataBinder.go
+++ b/internal/handler/dataBinder.go
@@ -1,11 +1,9 @@
 package handler
 
 import (
-	"errors"
-
 	"github.com/dhis2-sre/im-manager/internal/errdef"
+
 	"github.com/gin-gonic/gin"
-	"github.com/go-playground/validator/v10"
 )
 
 func DataBinder(c *gin.Context, req interface{}) error {
@@ -14,10 +12,6 @@ func DataBinder(c *gin.Context, req interface{}) error {
 	}
 
 	if err := c.ShouldBind(req); err != nil {
-		var ve validator.ValidationErrors
-		if errors.As(err, &ve) {
-			return errdef.NewBadRequest("%s", err.Error())
-		}
 		return err
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -76,7 +76,7 @@ func (h Handler) SignUp(c *gin.Context) {
 	//   415: Error
 	var request signUpRequest
 	if err := handler.DataBinder(c, &request); err != nil {
-		_ = c.Error(handleSignUpErrors(err))
+		_ = c.Error(handleValidationErrors(err))
 		return
 	}
 
@@ -89,29 +89,7 @@ func (h Handler) SignUp(c *gin.Context) {
 	c.JSON(http.StatusCreated, user)
 }
 
-func handleSignUpErrors(err error) error {
-	var validationErrors validator.ValidationErrors
-	ok := errors.As(err, &validationErrors)
-	if !ok {
-		return errdef.NewBadRequest("Error binding data: %+v", err)
-	}
-
-	var errs error
-	for _, fieldError := range validationErrors {
-		if fieldError.Field() == "Password" && (fieldError.Tag() == "gte" || fieldError.Tag() == "lte") {
-			badRequest := errdef.NewBadRequest("password must be between 24 and 128 characters")
-			errs = errors.Join(errs, badRequest)
-		}
-
-		if fieldError.Field() == "Email" && fieldError.Tag() == "email" {
-			badRequest := errdef.NewBadRequest("invalid email provided: %s", fieldError.Value())
-			errs = errors.Join(errs, badRequest)
-		}
-	}
-	return errs
-}
-
-func handleResetPasswordErrors(err error) error {
+func handleValidationErrors(err error) error {
 	var validationErrors validator.ValidationErrors
 	if !errors.As(err, &validationErrors) {
 		return errdef.NewBadRequest("%s", err)
@@ -119,12 +97,14 @@ func handleResetPasswordErrors(err error) error {
 
 	var errs error
 	for _, fieldError := range validationErrors {
-		if fieldError.Field() == "Password" && (fieldError.Tag() == "gte" || fieldError.Tag() == "lte") {
+		switch {
+		case fieldError.Field() == "Password" && (fieldError.Tag() == "gte" || fieldError.Tag() == "lte"):
 			errs = errors.Join(errs, errdef.NewBadRequest("password must be between 24 and 128 characters"))
+		case fieldError.Field() == "Email" && fieldError.Tag() == "email":
+			errs = errors.Join(errs, errdef.NewBadRequest("invalid email provided: %s", fieldError.Value()))
+		default:
+			errs = errors.Join(errs, errdef.NewBadRequest("%s", fieldError.Error()))
 		}
-	}
-	if errs == nil {
-		return errdef.NewBadRequest("%s", err)
 	}
 	return errs
 }
@@ -218,7 +198,7 @@ func (h Handler) ResetPassword(c *gin.Context) {
 	//   415: Error
 	var request ResetPasswordRequest
 	if err := handler.DataBinder(c, &request); err != nil {
-		_ = c.Error(handleResetPasswordErrors(err))
+		_ = c.Error(handleValidationErrors(err))
 		return
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -111,6 +111,24 @@ func handleSignUpErrors(err error) error {
 	return errs
 }
 
+func handleResetPasswordErrors(err error) error {
+	var validationErrors validator.ValidationErrors
+	if !errors.As(err, &validationErrors) {
+		return errdef.NewBadRequest("%s", err)
+	}
+
+	var errs error
+	for _, fieldError := range validationErrors {
+		if fieldError.Field() == "Password" && (fieldError.Tag() == "gte" || fieldError.Tag() == "lte") {
+			errs = errors.Join(errs, errdef.NewBadRequest("password must be between 24 and 128 characters"))
+		}
+	}
+	if errs == nil {
+		return errdef.NewBadRequest("%s", err)
+	}
+	return errs
+}
+
 type validateEmailRequest struct {
 	Token string `json:"token" binding:"required"`
 }
@@ -200,7 +218,7 @@ func (h Handler) ResetPassword(c *gin.Context) {
 	//   415: Error
 	var request ResetPasswordRequest
 	if err := handler.DataBinder(c, &request); err != nil {
-		_ = c.Error(errdef.NewBadRequest("%s", err))
+		_ = c.Error(handleResetPasswordErrors(err))
 		return
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -200,7 +200,7 @@ func (h Handler) ResetPassword(c *gin.Context) {
 	//   415: Error
 	var request ResetPasswordRequest
 	if err := handler.DataBinder(c, &request); err != nil {
-		_ = c.Error(err)
+		_ = c.Error(errdef.NewBadRequest("%s", err))
 		return
 	}
 


### PR DESCRIPTION
Password reset was returning 500 when the submitted password failed validation (e.g. shorter than 24 characters). `DataBinder` now wraps `validator.ValidationErrors` as a bad request so the error handler returns 400.