### PR TITLE
fix: drop refresh token from validation error log

### DIFF
--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 
@@ -108,7 +109,8 @@ func (t TokenService) GetTokens(user *model.User, previousRefreshTokenId string,
 func (t TokenService) ValidateRefreshToken(ctx context.Context, tokenString string) (*RefreshTokenData, error) {
 	claims, err := helper.ValidateRefreshToken(tokenString, t.refreshTokenSecretKey)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Unable to validate token", "error", err)
+		userId := extractUserIdInsecure(tokenString)
+		t.logger.ErrorContext(ctx, "Unable to validate token", "error", err, "userId", userId)
 		return nil, errors.New("unable to verify refresh token")
 	}
 
@@ -131,4 +133,16 @@ func (t TokenService) SignOut(userId uint) error {
 
 func (t TokenService) RefreshAccessToken(accessToken string) (string, error) {
 	return helper.RefreshAccessToken(accessToken, t.privateKey, t.refreshAccessTokenExpirationSeconds)
+}
+
+func extractUserIdInsecure(tokenString string) any {
+	token, err := jwt.ParseInsecure([]byte(tokenString))
+	if err != nil {
+		return "unknown"
+	}
+	userId, ok := token.Get("userId")
+	if !ok {
+		return "unknown"
+	}
+	return userId
 }

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -108,7 +108,7 @@ func (t TokenService) GetTokens(user *model.User, previousRefreshTokenId string,
 func (t TokenService) ValidateRefreshToken(ctx context.Context, tokenString string) (*RefreshTokenData, error) {
 	claims, err := helper.ValidateRefreshToken(tokenString, t.refreshTokenSecretKey)
 	if err != nil {
-		t.logger.ErrorContext(ctx, "Unable to validate token", "error", err, "token", tokenString)
+		t.logger.ErrorContext(ctx, "Unable to validate token", "error", err)
 		return nil, errors.New("unable to verify refresh token")
 	}
 

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -135,6 +135,9 @@ func (t TokenService) RefreshAccessToken(accessToken string) (string, error) {
 	return helper.RefreshAccessToken(accessToken, t.privateKey, t.refreshAccessTokenExpirationSeconds)
 }
 
+// extractUserIdInsecure does a best-effort extraction of the userId claim from a JWT without
+// verifying the signature. It is used only for logging context when validation has already failed,
+// so parse errors are intentionally ignored — the caller's error is the one that matters.
 func extractUserIdInsecure(tokenString string) any {
 	token, err := jwt.ParseInsecure([]byte(tokenString))
 	if err != nil {


### PR DESCRIPTION
Fixes DEVOPS-693. Removes the `token` field from the error log in `ValidateRefreshToken` to prevent refresh tokens from reaching log storage.