### PR TITLE
fix: abort with 401 when user context is missing in RequireAdministrator

### DIFF
--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -32,6 +32,7 @@ type userService interface {
 func (m AuthorizationMiddleware) RequireAdministrator(c *gin.Context) {
 	u, err := handler.GetUserFromContext(c.Request.Context())
 	if err != nil {
+		_ = c.AbortWithError(http.StatusUnauthorized, err)
 		return
 	}
 


### PR DESCRIPTION
Fixes DEVOPS-699. Calls `c.AbortWithError` instead of bare `return` when `GetUserFromContext` fails, preventing subsequent handlers from running.