### PR TITLE
fix: check CanWriteDeployment in SaveInstance

### DIFF
--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -302,9 +302,20 @@ func (h Handler) SaveInstance(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
+	user, err := handler.GetUserFromContext(ctx)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
 	deployment, err := h.instanceService.FindDeploymentById(ctx, deploymentId)
 	if err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	if canWrite := handler.CanWriteDeployment(user, deployment); !canWrite {
+		_ = c.AbortWithError(http.StatusUnauthorized, fmt.Errorf("write access denied"))
 		return
 	}
 


### PR DESCRIPTION
Fixes DEVOPS-688. Adds a `CanWriteDeployment` authorization check in `SaveInstance`, matching the pattern used by sibling handlers (Pause, Restart, Reset, etc.). Previously any authenticated user could attach an instance to any other group's deployment.