### PR TITLE
fix: persist user before sending validation email

### DIFF
--- a/pkg/user/service.go
+++ b/pkg/user/service.go
@@ -55,14 +55,14 @@ func (s Service) SignUp(ctx context.Context, email string, password string) (*mo
 		Password:   hashedPassword,
 	}
 
-	err = s.sendValidationEmail(user)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send validation email: %s", err)
-	}
-
 	err = s.repository.create(ctx, user)
 	if err != nil {
 		return nil, err
+	}
+
+	err = s.sendValidationEmail(user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send validation email: %s", err)
 	}
 
 	return user, nil


### PR DESCRIPTION
Fixes DEVOPS-692. Swaps the order in `SignUp` so the user is persisted before the validation email is sent. Previously a duplicate-email request would send an email before the DB constraint rejected it, enabling mail-bombing via the public signup endpoint.