### PR TITLE
fix: align admin user update password minimum to 24 characters

### DIFF
--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -549,7 +549,7 @@ func (h Handler) Delete(c *gin.Context) {
 
 type updateUserRequest struct {
 	Email    string `json:"email" binding:"omitempty,email"`
-	Password string `json:"password" binding:"omitempty,gte=16,lte=128"`
+	Password string `json:"password" binding:"omitempty,gte=24,lte=128"`
 }
 
 // Update user


### PR DESCRIPTION
Fixes DEVOPS-696. Changes the `updateUserRequest.Password` validator from `gte=16` to `gte=24` to match the signup requirement. Note: the frontend validation should also be updated in the im-manager-ui repo.