### PR TITLE
fix: exec pg_dump directly to prevent command injection

### DIFF
--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -709,8 +709,7 @@ func buildPgDumpCommand(dump *pg.Dump, format string) []string {
 	options = append(options, fmt.Sprintf("-F%s", format))
 	options = append(options, dump.IgnoreTableDataToString()...)
 
-	cmd := fmt.Sprintf("PGPASSWORD=%s pg_dump %s", dump.Password, strings.Join(options, " "))
-	return []string{"sh", "-c", cmd}
+	return append([]string{"env", "PGPASSWORD=" + dump.Password, "pg_dump"}, options...)
 }
 
 func (s service) StreamUpload(ctx context.Context, database model.Database, group *model.Group, body io.Reader, contentType string, contentLength int64) (model.Database, error) {


### PR DESCRIPTION
Fixes DEVOPS-689. Replaces `sh -c "PGPASSWORD=... pg_dump ..."` with `env PGPASSWORD=... pg_dump [args]`, eliminating the shell and preventing metacharacters in instance parameters (password, host, username, db name) from being interpreted as shell commands.