### PR TITLE
fix: encode rememberMe in refresh JWT instead of trusting client cookie

### DIFF
--- a/pkg/token/helper/tokenHelper.go
+++ b/pkg/token/helper/tokenHelper.go
@@ -48,7 +48,7 @@ type refreshToken struct {
 }
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func GenerateRefreshToken(user *model.User, secretKey string, expirationInSeconds int) (*refreshToken, error) {
+func GenerateRefreshToken(user *model.User, secretKey string, expirationInSeconds int, rememberMe bool) (*refreshToken, error) {
 	currentTime := time.Now()
 	tokenExpiration := currentTime.Add(time.Duration(expirationInSeconds) * time.Second)
 
@@ -75,6 +75,11 @@ func GenerateRefreshToken(user *model.User, secretKey string, expirationInSecond
 		return nil, err
 	}
 
+	err = token.Set("rememberMe", rememberMe)
+	if err != nil {
+		return nil, err
+	}
+
 	signed, err := jwt.Sign(token, jwt.WithKey(jwa.HS256, []byte(secretKey)))
 	if err != nil {
 		return nil, err
@@ -88,10 +93,11 @@ func GenerateRefreshToken(user *model.User, secretKey string, expirationInSecond
 }
 
 type refreshTokenClaims struct {
-	UserId    uint          `json:"uid"`
-	ID        string        `json:"jti"`
-	ExpiresIn time.Duration `json:"exp"`
-	IssuedAt  int64         `json:"iat"`
+	UserId     uint          `json:"uid"`
+	ID         string        `json:"jti"`
+	ExpiresIn  time.Duration `json:"exp"`
+	IssuedAt   int64         `json:"iat"`
+	RememberMe bool          `json:"rememberMe"`
 }
 
 //goland:noinspection GoExportedFuncWithUnexportedType
@@ -124,11 +130,15 @@ func ValidateRefreshToken(tokenString string, secretKey string) (*refreshTokenCl
 		return nil, fmt.Errorf("%s not found in claims", jwt.IssuedAtKey)
 	}
 
+	rememberMe, _ := token.Get("rememberMe")
+	rememberMeBool, _ := rememberMe.(bool)
+
 	return &refreshTokenClaims{
-		UserId:    uint(userId.(float64)),
-		ID:        fmt.Sprintf("%v", id),
-		ExpiresIn: time.Until(tokenExpiration.(time.Time)),
-		IssuedAt:  issuedAt.(time.Time).Unix(),
+		UserId:     uint(userId.(float64)),
+		ID:         fmt.Sprintf("%v", id),
+		ExpiresIn:  time.Until(tokenExpiration.(time.Time)),
+		IssuedAt:   issuedAt.(time.Time).Unix(),
+		RememberMe: rememberMeBool,
 	}, nil
 }
 

--- a/pkg/token/helper/tokenHelper_test.go
+++ b/pkg/token/helper/tokenHelper_test.go
@@ -40,7 +40,7 @@ func TestGenerateRefreshToken(t *testing.T) {
 	expiration := 12
 	signedStringPrefix := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
 
-	tokenData, err := GenerateRefreshToken(user, secretKey, expiration)
+	tokenData, err := GenerateRefreshToken(user, secretKey, expiration, false)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expiration, int(tokenData.ExpiresIn.Seconds()))
@@ -56,7 +56,7 @@ func TestValidateRefreshToken(t *testing.T) {
 
 	expiration := 12
 
-	tokenData, err := GenerateRefreshToken(user, secretKey, expiration)
+	tokenData, err := GenerateRefreshToken(user, secretKey, expiration, false)
 	assert.NoError(t, err)
 
 	refreshTokenData, err := ValidateRefreshToken(tokenData.SignedString, secretKey)

--- a/pkg/token/service.go
+++ b/pkg/token/service.go
@@ -58,6 +58,7 @@ type RefreshTokenData struct {
 	SignedToken string
 	ID          uuid.UUID
 	UserId      uint
+	RememberMe  bool
 }
 
 type TokenService struct {
@@ -88,7 +89,7 @@ func (t TokenService) GetTokens(user *model.User, previousRefreshTokenId string,
 		expiration = t.refreshTokenRememberMeExpirationSeconds
 	}
 
-	refreshToken, err := helper.GenerateRefreshToken(user, t.refreshTokenSecretKey, expiration)
+	refreshToken, err := helper.GenerateRefreshToken(user, t.refreshTokenSecretKey, expiration, rememberMe)
 	if err != nil {
 		return nil, fmt.Errorf("error generating refreshToken for user: %+v\nError: %s", user, err)
 	}
@@ -122,6 +123,7 @@ func (t TokenService) ValidateRefreshToken(ctx context.Context, tokenString stri
 		SignedToken: tokenString,
 		ID:          tokenId,
 		UserId:      claims.UserId,
+		RememberMe:  claims.RememberMe,
 	}, nil
 }
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -312,19 +312,13 @@ func (h Handler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	var rememberMe bool
-	rememberMeCookie, _ := c.Cookie("rememberMe")
-	if rememberMeCookie == "true" {
-		rememberMe = true
-	}
-
-	tokens, err := h.tokenService.GetTokens(user, refreshToken.ID.String(), rememberMe)
+	tokens, err := h.tokenService.GetTokens(user, refreshToken.ID.String(), refreshToken.RememberMe)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
 
-	h.setCookies(c, tokens, rememberMe)
+	h.setCookies(c, tokens, refreshToken.RememberMe)
 
 	c.Status(http.StatusCreated)
 }

--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -349,14 +349,18 @@ func TestUserHandler(t *testing.T) {
 				t.Log("RefreshTokensUsingCookieWithRememberMe")
 
 				_, email, password := createUser(t, client, userService)
-				_, refreshToken := client.SignIn(t, email, password)
+				signInReq := client.NewRequest(t, http.MethodPost, "/tokens", jsonBody(`{"rememberMe": true}`), inttest.WithBasicAuth(email, password), inttest.WithHeader("Content-Type", "application/json"))
+				signInResp, err := client.Client.Do(signInReq)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, signInResp.Body.Close()) })
+				require.Equal(t, http.StatusCreated, signInResp.StatusCode)
+				refreshToken := findCookieByName("refreshToken", signInResp.Cookies())
+				require.NotNil(t, refreshToken)
+
 				request := client.NewRequest(t, http.MethodPost, "/refresh", jsonBody(`{}`), inttest.WithHeader("Content-Type", "application/json"))
 				refreshCookie := &http.Cookie{Name: "refreshToken", Value: refreshToken.Value, Path: "/refresh"}
 				require.NoError(t, refreshCookie.Valid())
 				request.AddCookie(refreshCookie)
-				rememberMeCookie := &http.Cookie{Name: "rememberMe", Value: "true", Path: "/refresh"}
-				require.NoError(t, rememberMeCookie.Valid())
-				request.AddCookie(rememberMeCookie)
 
 				response, err := client.Client.Do(request)
 				require.NoError(t, err)


### PR DESCRIPTION
Fixes DEVOPS-695. Stores `rememberMe` as a claim in the refresh JWT at sign-in time. On `/refresh`, the value is read from the validated token instead of the `rememberMe` cookie, preventing a user from self-extending their session TTL by modifying the cookie.