### PR TITLE
fix: correct swagger spec for /databases/external/{uuid}

### DIFF
--- a/pkg/database/docs.go
+++ b/pkg/database/docs.go
@@ -87,7 +87,8 @@ type _ struct {
 type _ struct {
 	// in: path
 	// required: true
-	UUID uint `json:"uuid"`
+	// swagger:strfmt uuid
+	UUID string `json:"uuid"`
 }
 
 // swagger:response DownloadDatabaseResponse

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -818,13 +818,8 @@ func (h Handler) ExternalDownload(c *gin.Context) {
 	//
 	// Download a given database without authentication
 	//
-	// Security:
-	//	oauth2:
-	//
 	// Responses:
 	//	200: DownloadDatabaseResponse
-	//	401: Error
-	//	403: Error
 	//	404: Error
 	//	415: Error
 	uuidParam := c.Param("uuid")

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1124,25 +1124,19 @@ paths:
             description: Download a given database without authentication
             operationId: externalDownloadDatabase
             parameters:
-                - format: uint64
+                - format: uuid
                   in: path
                   name: uuid
                   required: true
-                  type: integer
+                  type: string
                   x-go-name: UUID
             responses:
                 "200":
                     $ref: '#/responses/DownloadDatabaseResponse'
-                "401":
-                    $ref: '#/responses/Error'
-                "403":
-                    $ref: '#/responses/Error'
                 "404":
                     $ref: '#/responses/Error'
                 "415":
                     $ref: '#/responses/Error'
-            security:
-                - oauth2: []
             summary: Externally download database
     /databases/save-as/{instanceId}:
         post:


### PR DESCRIPTION
Fixes DEVOPS-700. Removes the incorrect `security: oauth2` declaration and 401/403 responses from the unauthenticated `/databases/external/{uuid}` endpoint. Fixes the `uuid` path parameter type from `integer/uint64` to `string/uuid`. Regenerated via `make swagger`.