### PR TITLE
fix: require group membership or admin for group/user enumeration endpoints

### DIFF
--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -57,6 +57,30 @@ func IsGroupAdministrator(groupName string, groups []model.Group) bool {
 	return isMemberOf(groupName, groups)
 }
 
+func CanAccessGroup(user *model.User, groupName string) bool {
+	return IsAdministrator(user) ||
+		isMemberOf(groupName, user.Groups) ||
+		IsGroupAdministrator(groupName, user.AdminGroups)
+}
+
+func CanAccessUser(caller *model.User, target *model.User) bool {
+	return IsAdministrator(caller) || caller.ID == target.ID || sharesGroup(caller, target)
+}
+
+func sharesGroup(caller *model.User, target *model.User) bool {
+	for _, g := range target.Groups {
+		if isMemberOf(g.Name, caller.Groups) || isMemberOf(g.Name, caller.AdminGroups) {
+			return true
+		}
+	}
+	for _, g := range target.AdminGroups {
+		if isMemberOf(g.Name, caller.Groups) || isMemberOf(g.Name, caller.AdminGroups) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetUserFromContext returns the User value stored in ctx, if any otherwise it returns an error.
 func GetUserFromContext(ctx context.Context) (*model.User, error) {
 	user, ok := model.GetUserFromContext(ctx)

--- a/pkg/group/group_integration_test.go
+++ b/pkg/group/group_integration_test.go
@@ -42,12 +42,21 @@ func TestGroupHandler(t *testing.T) {
 	err = user.CreateUser(context.Background(), "admin", "admin", userService, groupService, model.AdministratorGroupName, "", "admin")
 	require.NoError(t, err, "failed to create admin user and group")
 
-	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {
-		handler := group.NewHandler(groupService)
-		authentication := TestAuthenticationMiddleware{}
-		authorization := TestAuthorizationMiddleware{}
-		group.Routes(engine, authentication, authorization, handler)
-	})
+	adminBase, err := userService.FindOrCreate(context.Background(), "admin", "admin")
+	require.NoError(t, err)
+	adminUser, err := userService.FindById(context.Background(), adminBase.ID)
+	require.NoError(t, err)
+
+	newClient := func(u *model.User) *inttest.HTTPClient {
+		return inttest.SetupHTTPServer(t, func(engine *gin.Engine) {
+			handler := group.NewHandler(groupService)
+			authentication := TestAuthenticationMiddleware{user: u}
+			authorization := TestAuthorizationMiddleware{}
+			group.Routes(engine, authentication, authorization, handler)
+		})
+	}
+
+	client := newClient(adminUser)
 
 	var userId string
 	var user *model.User
@@ -251,6 +260,18 @@ func TestGroupHandler(t *testing.T) {
 
 			require.Equal(t, "group \"non-existing-group\" doesn't exist", string(response))
 		})
+
+		t.Run("FindGroupAsForbiddenNonMember", func(t *testing.T) {
+			nonMember, err := userService.FindOrCreate(context.Background(), "nonmember@dhis2.org", "oneoneoneoneoneoneone111")
+			require.NoError(t, err)
+			nonMemberWithGroups, err := userService.FindById(context.Background(), nonMember.ID)
+			require.NoError(t, err)
+
+			nonMemberClient := newClient(nonMemberWithGroups)
+
+			nonMemberClient.Do(t, http.MethodGet, fmt.Sprintf("/groups/%s", groupName), nil, http.StatusForbidden)
+			nonMemberClient.Do(t, http.MethodGet, fmt.Sprintf("/groups/%s/details", groupName), nil, http.StatusForbidden)
+		})
 	})
 }
 
@@ -260,9 +281,17 @@ func (f fakeDialer) DialAndSend(m ...*mail.Message) error {
 	panic("not implemented")
 }
 
-type TestAuthenticationMiddleware struct{}
+type TestAuthenticationMiddleware struct {
+	user *model.User
+}
 
-func (t TestAuthenticationMiddleware) TokenAuthentication(c *gin.Context) {}
+func (m TestAuthenticationMiddleware) TokenAuthentication(c *gin.Context) {
+	if m.user != nil {
+		ctx := model.NewContextWithUser(c.Request.Context(), m.user)
+		c.Request = c.Request.WithContext(ctx)
+	}
+	c.Next()
+}
 
 type TestAuthorizationMiddleware struct{}
 

--- a/pkg/group/handler.go
+++ b/pkg/group/handler.go
@@ -226,6 +226,17 @@ func (h Handler) Find(c *gin.Context) {
 	//   oauth2:
 	name := c.Param("name")
 
+	user, err := handler.GetUserFromContext(c.Request.Context())
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	if !handler.CanAccessGroup(user, name) {
+		_ = c.AbortWithError(http.StatusForbidden, errdef.NewForbidden("access denied"))
+		return
+	}
+
 	group, err := h.groupService.Find(c.Request.Context(), name)
 	if err != nil {
 		_ = c.Error(err)
@@ -253,6 +264,17 @@ func (h Handler) FindWithDetails(c *gin.Context) {
 	// security:
 	//   oauth2:
 	name := c.Param("name")
+
+	user, err := handler.GetUserFromContext(c.Request.Context())
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	if !handler.CanAccessGroup(user, name) {
+		_ = c.AbortWithError(http.StatusForbidden, errdef.NewForbidden("access denied"))
+		return
+	}
 
 	group, err := h.groupService.FindWithDetails(c.Request.Context(), name)
 	if err != nil {
@@ -324,6 +346,17 @@ func (h Handler) FindResources(c *gin.Context) {
 	name := c.Param("name")
 	if name == "" {
 		_ = c.AbortWithError(http.StatusBadRequest, errors.New("group name not found"))
+		return
+	}
+
+	user, err := handler.GetUserFromContext(c.Request.Context())
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	if !handler.CanAccessGroup(user, name) {
+		_ = c.AbortWithError(http.StatusForbidden, errdef.NewForbidden("access denied"))
 		return
 	}
 

--- a/pkg/user/handler.go
+++ b/pkg/user/handler.go
@@ -463,9 +463,21 @@ func (h Handler) FindById(c *gin.Context) {
 		return
 	}
 
-	userWithGroups, err := h.userService.FindById(c.Request.Context(), id)
+	ctx := c.Request.Context()
+	caller, err := handler.GetUserFromContext(ctx)
 	if err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	userWithGroups, err := h.userService.FindById(ctx, id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	if !handler.CanAccessUser(caller, userWithGroups) {
+		_ = c.AbortWithError(http.StatusForbidden, errdef.NewForbidden("access denied"))
 		return
 	}
 


### PR DESCRIPTION
Fixes DEVOPS-691.

`GET /groups/:name`, `/groups/:name/details`, `/groups/:name/resources` now return 403 for authenticated users who are neither a member/admin of the group nor a global admin.

`GET /users/:id` now returns 403 unless the caller is a global admin, the same user, or shares a group with the target.