### PR TITLE
fix: cap external database download link expiration at 30 days

### DIFF
--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -755,6 +755,10 @@ func (h Handler) canAccess(c *gin.Context, d *model.Database) error {
 	return nil
 }
 
+// maxExternalDownloadExpirationSeconds is the maximum time a database can be downloaded without
+// authentication. 30 is simply chosen for the sake of having a reasonable default.
+const maxExternalDownloadExpirationSeconds uint = 30 * 24 * 60 * 60 // 30 days
+
 type CreateExternalDatabaseRequest struct {
 	// Expiration time in seconds
 	Expiration uint `json:"expiration" binding:"required"`
@@ -785,6 +789,11 @@ func (h Handler) CreateExternalDownload(c *gin.Context) {
 	var request CreateExternalDatabaseRequest
 	if err := handler.DataBinder(c, &request); err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	if request.Expiration > maxExternalDownloadExpirationSeconds {
+		_ = c.Error(errdef.NewBadRequest("expiration must not exceed 30 days (%d seconds)", maxExternalDownloadExpirationSeconds))
 		return
 	}
 


### PR DESCRIPTION
Closes DEVOPS-694.

`CreateExternalDatabaseRequest.Expiration` had no upper bound, allowing users to mint effectively permanent anonymous download links. This adds a 30-day cap and returns 400 for requests that exceed it.