### PR TITLE
fix: remove reflex from Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ ARG AWS_IAM_AUTHENTICATOR_VERSION=0.7.5
 ARG AWS_IAM_AUTHENTICATOR_CHECKSUM_AMD64=aef183b5b92f2cb135107234c7440f43638caa337190190cdd2ad9fd6bc4928e
 ARG AWS_IAM_AUTHENTICATOR_CHECKSUM_ARM64=80ab2b0d5a139e55408c785703e8fef8f4974a73409046b3e13df19b2a780a51
 
-# https://github.com/cespare/reflex/releases
-ARG REFLEX_VERSION=v0.3.1
-
 RUN apk add gcc musl-dev git && \
 \
     case "$TARGETARCH" in \
@@ -51,7 +48,6 @@ RUN apk add gcc musl-dev git && \
     install -o root -g root -m 0755 aws-iam-authenticator /usr/bin/aws-iam-authenticator
 
 WORKDIR /src
-RUN go install github.com/cespare/reflex@${REFLEX_VERSION}
 COPY go.mod go.sum ./
 RUN go mod download -x
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     <<: *common-dev-test
     ports:
       - "8080:8080"
-    command: reflex -r "Dockerfile|\.go|\.yml$$" -s -- sh -c "go run ./cmd/serve"
+    command: go run ./cmd/serve
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
Removes the reflex hot-reload tool from the build image. Reflex is only useful during development and adds unnecessary supply chain surface area to the production image.

The dev service in docker-compose now runs `go run ./cmd/serve` directly.