### PR TITLE
fix: replace AES-CFB with AES-GCM for instance parameter encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ RABBITMQ_STREAM_PORT=5552
 RABBITMQ_USERNAME=guest
 RABBITMQ_PASSWORD=guest
 
+# Must be exactly 16, 24, or 32 bytes (AES-128/192/256). Generate with: openssl rand -hex 16 (32 hex chars = 16 bytes) or openssl rand -base64 24 (32-char base64 = 24 bytes)
 INSTANCE_PARAMETER_ENCRYPTION_KEY=<instance-parameter-encryption-key>
 
 INSTANCE_SERVICE_HOST=im-manager:8080

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ RABBITMQ_USERNAME=guest
 RABBITMQ_PASSWORD=guest
 
 # Must be exactly 16, 24, or 32 bytes (AES-128/192/256). Generate with: openssl rand -hex 16 (32 hex chars = 16 bytes) or openssl rand -base64 24 (32-char base64 = 24 bytes)
-INSTANCE_PARAMETER_ENCRYPTION_KEY=<instance-parameter-encryption-key>
+INSTANCE_PARAMETER_ENCRYPTION_KEY=this-is-not-secure-please-change
 
 INSTANCE_SERVICE_HOST=im-manager:8080
 

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -480,6 +480,15 @@ func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Ser
 		return nil, err
 	}
 	instanceRepository := instance.NewRepository(db, instanceParameterEncryptionKey)
+
+	allStacks, err := stackService.FindAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load stacks for encryption migration: %v", err)
+	}
+	if err := instanceRepository.MigrateLegacyEncryption(allStacks); err != nil {
+		return nil, fmt.Errorf("failed to migrate legacy parameter encryption: %v", err)
+	}
+
 	classification, err := requireEnv("CLASSIFICATION")
 	if err != nil {
 		return nil, err

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -480,15 +480,6 @@ func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Ser
 		return nil, err
 	}
 	instanceRepository := instance.NewRepository(db, instanceParameterEncryptionKey)
-
-	allStacks, err := stackService.FindAll()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load stacks for encryption migration: %v", err)
-	}
-	if err := instanceRepository.MigrateLegacyEncryption(allStacks); err != nil {
-		return nil, fmt.Errorf("failed to migrate legacy parameter encryption: %v", err)
-	}
-
 	classification, err := requireEnv("CLASSIFICATION")
 	if err != nil {
 		return nil, err

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -479,7 +479,10 @@ func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Ser
 	if err != nil {
 		return nil, err
 	}
-	instanceRepository := instance.NewRepository(db, instanceParameterEncryptionKey)
+	instanceRepository, err := instance.NewRepository(db, instanceParameterEncryptionKey)
+	if err != nil {
+		return nil, err
+	}
 	classification, err := requireEnv("CLASSIFICATION")
 	if err != nil {
 		return nil, err

--- a/pkg/instance/crypt.go
+++ b/pkg/instance/crypt.go
@@ -3,14 +3,17 @@ package instance
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/getsops/sops/v3/cmd/sops/formats"
 	"github.com/getsops/sops/v3/decrypt"
 )
 
-var iv = []byte{83, 108, 97, 118, 97, 32, 85, 107, 114, 97, 105, 110, 105, 33, 33, 33}
+const gcmPrefix = "v2:"
 
 func encryptText(key string, text string) (string, error) {
 	block, err := aes.NewCipher([]byte(key))
@@ -18,18 +21,61 @@ func encryptText(key string, text string) (string, error) {
 		return "", fmt.Errorf("failed to create AES cipher: %v", err)
 	}
 
-	plainText := []byte(text)
-	cfb := cipher.NewCFBEncrypter(block, iv)
-	cipherText := make([]byte, len(plainText))
-	cfb.XORKeyStream(cipherText, plainText)
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %v", err)
+	}
 
-	base64Encoded := base64.StdEncoding.EncodeToString(cipherText)
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %v", err)
+	}
 
-	return base64Encoded, nil
+	cipherText := gcm.Seal(nonce, nonce, []byte(text), nil)
+	return gcmPrefix + base64.StdEncoding.EncodeToString(cipherText), nil
 }
 
 func decryptText(key string, text string) (string, error) {
-	cipherText, err := base64.StdEncoding.DecodeString(text)
+	if strings.HasPrefix(text, gcmPrefix) {
+		return decryptGCM(key, text[len(gcmPrefix):])
+	}
+	return decryptCFB(key, text)
+}
+
+func decryptGCM(key string, encoded string) (string, error) {
+	cipherText, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed to base64 decode: %v", err)
+	}
+
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return "", fmt.Errorf("failed to create AES cipher: %v", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %v", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(cipherText) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, cipherText := cipherText[:nonceSize], cipherText[nonceSize:]
+	plainText, err := gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt: %v", err)
+	}
+
+	return string(plainText), nil
+}
+
+// decryptCFB decrypts legacy AES-CFB ciphertext with the static IV.
+// Only used for backward compatibility with existing database rows.
+func decryptCFB(key string, encoded string) (string, error) {
+	cipherText, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
 		return "", err
 	}
@@ -39,6 +85,7 @@ func decryptText(key string, text string) (string, error) {
 		return "", err
 	}
 
+	iv := []byte{83, 108, 97, 118, 97, 32, 85, 107, 114, 97, 105, 110, 105, 33, 33, 33}
 	cfb := cipher.NewCFBDecrypter(block, iv)
 	plainText := make([]byte, len(cipherText))
 	cfb.XORKeyStream(plainText, cipherText)

--- a/pkg/instance/crypt_test.go
+++ b/pkg/instance/crypt_test.go
@@ -1,0 +1,62 @@
+package instance
+
+import (
+	"strings"
+	"testing"
+)
+
+const testKey = "12345678901234567890123456789012" // 32 bytes
+
+func TestEncryptDecryptRoundtrip(t *testing.T) {
+	plaintext := "super-secret-value"
+
+	encrypted, err := encryptText(testKey, plaintext)
+	if err != nil {
+		t.Fatalf("encryptText: %v", err)
+	}
+
+	if !strings.HasPrefix(encrypted, gcmPrefix) {
+		t.Fatalf("expected v2: prefix, got %q", encrypted)
+	}
+
+	decrypted, err := decryptText(testKey, encrypted)
+	if err != nil {
+		t.Fatalf("decryptText: %v", err)
+	}
+
+	if decrypted != plaintext {
+		t.Fatalf("want %q, got %q", plaintext, decrypted)
+	}
+}
+
+func TestEncryptProducesUniqueOutputs(t *testing.T) {
+	plaintext := "same-value"
+
+	a, err := encryptText(testKey, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := encryptText(testKey, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a == b {
+		t.Fatal("two encryptions of the same plaintext produced identical ciphertext")
+	}
+}
+
+func TestDecryptLegacyCFB(t *testing.T) {
+	// Ciphertext produced by the old AES-CFB + static IV implementation.
+	// Plaintext: "legacy-secret", key: testKey
+	legacy := "wjifidx8JVrxlz8JWg=="
+
+	decrypted, err := decryptText(testKey, legacy)
+	if err != nil {
+		t.Fatalf("decryptText legacy: %v", err)
+	}
+
+	if decrypted != "legacy-secret" {
+		t.Fatalf("want %q, got %q", "legacy-secret", decrypted)
+	}
+}

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -78,7 +78,8 @@ func TestInstanceHandler(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	encryptionKey := strings.Repeat("a", 32)
-	instanceRepo := instance.NewRepository(db, encryptionKey)
+	instanceRepo, err := instance.NewRepository(db, encryptionKey)
+	require.NoError(t, err)
 	groupService := groupService{group: group}
 	stacks := stack.Stacks{
 		"minio":      stack.MINIO,

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -14,11 +14,16 @@ import (
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) *repository {
+func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) (*repository, error) {
+	switch len(instanceParameterEncryptionKey) {
+	case 16, 24, 32:
+	default:
+		return nil, fmt.Errorf("INSTANCE_PARAMETER_ENCRYPTION_KEY must be 16, 24, or 32 bytes, got %d", len(instanceParameterEncryptionKey))
+	}
 	return &repository{
 		db:                             db,
 		instanceParameterEncryptionKey: instanceParameterEncryptionKey,
-	}
+	}, nil
 }
 
 type repository struct {

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/gosimple/slug"
 
@@ -24,6 +25,54 @@ func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) *reposito
 type repository struct {
 	db                             *gorm.DB
 	instanceParameterEncryptionKey string
+}
+
+// MigrateLegacyEncryption re-encrypts all AES-CFB instance parameters to AES-GCM.
+// It is idempotent: parameters already in GCM format (v2: prefix) are skipped.
+func (r repository) MigrateLegacyEncryption(stacks []model.Stack) error {
+	sensitiveParams := map[string]map[string]bool{}
+	for _, s := range stacks {
+		m := map[string]bool{}
+		for name, p := range s.Parameters {
+			if p.Sensitive {
+				m[name] = true
+			}
+		}
+		sensitiveParams[s.Name] = m
+	}
+
+	var params []model.DeploymentInstanceParameter
+	if err := r.db.Find(&params).Error; err != nil {
+		return fmt.Errorf("failed to load instance parameters: %w", err)
+	}
+
+	for _, param := range params {
+		if !sensitiveParams[param.StackName][param.ParameterName] {
+			continue
+		}
+		if strings.HasPrefix(param.Value, gcmPrefix) {
+			continue
+		}
+
+		plaintext, err := decryptCFB(r.instanceParameterEncryptionKey, param.Value)
+		if err != nil {
+			return fmt.Errorf("failed to decrypt legacy parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+		}
+
+		encrypted, err := encryptText(r.instanceParameterEncryptionKey, plaintext)
+		if err != nil {
+			return fmt.Errorf("failed to re-encrypt parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+		}
+
+		err = r.db.Model(&param).
+			Where("deployment_instance_id = ? AND parameter_name = ?", param.DeploymentInstanceID, param.ParameterName).
+			Update("value", encrypted).Error
+		if err != nil {
+			return fmt.Errorf("failed to save re-encrypted parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+		}
+	}
+
+	return nil
 }
 
 func (r repository) DeleteDeploymentInstance(ctx context.Context, instance *model.DeploymentInstance) error {

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/gosimple/slug"
 
@@ -25,54 +24,6 @@ func NewRepository(db *gorm.DB, instanceParameterEncryptionKey string) *reposito
 type repository struct {
 	db                             *gorm.DB
 	instanceParameterEncryptionKey string
-}
-
-// MigrateLegacyEncryption re-encrypts all AES-CFB instance parameters to AES-GCM.
-// It is idempotent: parameters already in GCM format (v2: prefix) are skipped.
-func (r repository) MigrateLegacyEncryption(stacks []model.Stack) error {
-	sensitiveParams := map[string]map[string]bool{}
-	for _, s := range stacks {
-		m := map[string]bool{}
-		for name, p := range s.Parameters {
-			if p.Sensitive {
-				m[name] = true
-			}
-		}
-		sensitiveParams[s.Name] = m
-	}
-
-	var params []model.DeploymentInstanceParameter
-	if err := r.db.Find(&params).Error; err != nil {
-		return fmt.Errorf("failed to load instance parameters: %w", err)
-	}
-
-	for _, param := range params {
-		if !sensitiveParams[param.StackName][param.ParameterName] {
-			continue
-		}
-		if strings.HasPrefix(param.Value, gcmPrefix) {
-			continue
-		}
-
-		plaintext, err := decryptCFB(r.instanceParameterEncryptionKey, param.Value)
-		if err != nil {
-			return fmt.Errorf("failed to decrypt legacy parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
-		}
-
-		encrypted, err := encryptText(r.instanceParameterEncryptionKey, plaintext)
-		if err != nil {
-			return fmt.Errorf("failed to re-encrypt parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
-		}
-
-		err = r.db.Model(&param).
-			Where("deployment_instance_id = ? AND parameter_name = ?", param.DeploymentInstanceID, param.ParameterName).
-			Update("value", encrypted).Error
-		if err != nil {
-			return fmt.Errorf("failed to save re-encrypted parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
-		}
-	}
-
-	return nil
 }
 
 func (r repository) DeleteDeploymentInstance(ctx context.Context, instance *model.DeploymentInstance) error {

--- a/pkg/storage/migrations/20260515000_reencrypt_cfb_to_gcm.go
+++ b/pkg/storage/migrations/20260515000_reencrypt_cfb_to_gcm.go
@@ -1,0 +1,165 @@
+package migrations
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func reencryptCFBToGCM() *gormigrate.Migration {
+	const gcmPrefix = "v2:"
+
+	allStacks := []model.Stack{
+		stack.DHIS2DB,
+		stack.MINIO,
+		stack.DHIS2Core,
+		stack.DHIS2,
+		stack.PgAdmin,
+		stack.WhoamiGo,
+		stack.IMJobRunner,
+		stack.ChapDB,
+		stack.ChapValkey,
+		stack.ChapWorker,
+		stack.ChapCore,
+	}
+
+	sensitive := map[string]map[string]bool{}
+	for _, s := range allStacks {
+		m := map[string]bool{}
+		for name, p := range s.Parameters {
+			if p.Sensitive {
+				m[name] = true
+			}
+		}
+		sensitive[s.Name] = m
+	}
+
+	encryptGCM := func(key, plaintext string) (string, error) {
+		block, err := aes.NewCipher([]byte(key))
+		if err != nil {
+			return "", err
+		}
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return "", err
+		}
+		nonce := make([]byte, gcm.NonceSize())
+		if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+			return "", err
+		}
+		return gcmPrefix + base64.StdEncoding.EncodeToString(gcm.Seal(nonce, nonce, []byte(plaintext), nil)), nil
+	}
+
+	decryptCFB := func(key, encoded string) (string, error) {
+		ct, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", err
+		}
+		block, err := aes.NewCipher([]byte(key))
+		if err != nil {
+			return "", err
+		}
+		iv := []byte{83, 108, 97, 118, 97, 32, 85, 107, 114, 97, 105, 110, 105, 33, 33, 33}
+		pt := make([]byte, len(ct))
+		cipher.NewCFBDecrypter(block, iv).XORKeyStream(pt, ct) //nolint:staticcheck
+		return string(pt), nil
+	}
+
+	decryptGCM := func(key, encoded string) (string, error) {
+		ct, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return "", err
+		}
+		block, err := aes.NewCipher([]byte(key))
+		if err != nil {
+			return "", err
+		}
+		gcm, err := cipher.NewGCM(block)
+		if err != nil {
+			return "", err
+		}
+		ns := gcm.NonceSize()
+		if len(ct) < ns {
+			return "", fmt.Errorf("ciphertext too short")
+		}
+		pt, err := gcm.Open(nil, ct[:ns], ct[ns:], nil)
+		if err != nil {
+			return "", err
+		}
+		return string(pt), nil
+	}
+
+	encryptCFB := func(key, plaintext string) (string, error) {
+		block, err := aes.NewCipher([]byte(key))
+		if err != nil {
+			return "", err
+		}
+		iv := []byte{83, 108, 97, 118, 97, 32, 85, 107, 114, 97, 105, 110, 105, 33, 33, 33}
+		ct := make([]byte, len(plaintext))
+		cipher.NewCFBEncrypter(block, iv).XORKeyStream(ct, []byte(plaintext)) //nolint:staticcheck
+		return base64.StdEncoding.EncodeToString(ct), nil
+	}
+
+	reencrypt := func(tx *gorm.DB, fromEncrypted, toEncrypted func(key, val string) (string, error), skipPrefix string) error {
+		key := os.Getenv("INSTANCE_PARAMETER_ENCRYPTION_KEY")
+		if key == "" {
+			return fmt.Errorf("INSTANCE_PARAMETER_ENCRYPTION_KEY is not set")
+		}
+
+		var params []model.DeploymentInstanceParameter
+		if err := tx.Find(&params).Error; err != nil {
+			return fmt.Errorf("failed to load instance parameters: %w", err)
+		}
+
+		for _, param := range params {
+			if !sensitive[param.StackName][param.ParameterName] {
+				continue
+			}
+			if skipPrefix != "" && !strings.HasPrefix(param.Value, skipPrefix) {
+				continue
+			}
+			value := param.Value
+			if skipPrefix != "" {
+				value = value[len(skipPrefix):]
+			}
+
+			plaintext, err := fromEncrypted(key, value)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+			}
+
+			encrypted, err := toEncrypted(key, plaintext)
+			if err != nil {
+				return fmt.Errorf("failed to re-encrypt parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+			}
+
+			err = tx.Model(&param).
+				Where("deployment_instance_id = ? AND parameter_name = ?", param.DeploymentInstanceID, param.ParameterName).
+				Update("value", encrypted).Error
+			if err != nil {
+				return fmt.Errorf("failed to save re-encrypted parameter %q on instance %d: %w", param.ParameterName, param.DeploymentInstanceID, err)
+			}
+		}
+		return nil
+	}
+
+	return &gormigrate.Migration{
+		ID: "20260515000",
+		Migrate: func(tx *gorm.DB) error {
+			return reencrypt(tx, decryptCFB, encryptGCM, "")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return reencrypt(tx, decryptGCM, encryptCFB, gcmPrefix)
+		},
+	}
+}

--- a/pkg/storage/migrations/migrations.go
+++ b/pkg/storage/migrations/migrations.go
@@ -5,5 +5,6 @@ import "github.com/go-gormigrate/gormigrate/v2"
 func All() []*gormigrate.Migration {
 	return []*gormigrate.Migration{
 		backfillDeployChap(),
+		reencryptCFBToGCM(),
 	}
 }


### PR DESCRIPTION
Replaces the static-IV AES-CFB scheme in `pkg/instance/crypt.go` with AES-GCM + per-encryption random nonce. New ciphertexts carry a `v2:` prefix for format detection.

A gormigrate migration (20260515000) re-encrypts all existing CFB-encrypted sensitive parameters to GCM at deploy time, with rollback support.

Closes DEVOPS-701 and DEVOPS-702