### PR TITLE
feat: optionally log SQL queries via DATABASE_LOG_QUERIES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,4 @@ E2E_TEST_USER_EMAIL=im-e2e-test@dhis2.org
 E2E_TEST_USER_PASSWORD=somepassword
 
 LOG_PRETTY_PRINT=false
+DATABASE_LOG_QUERIES=false

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -296,9 +296,11 @@ func newDB(logger *slog.Logger) (*gorm.DB, error) {
 		return nil, err
 	}
 
+	logQueries := os.Getenv("DATABASE_LOG_QUERIES") == "true"
+
 	db, err := storage.NewDatabase(
 		logger,
-		storage.PostgresqlConfig{Host: host, Port: port, Username: username, Password: password, DatabaseName: name},
+		storage.PostgresqlConfig{Host: host, Port: port, Username: username, Password: password, DatabaseName: name, LogQueries: logQueries},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup DB: %v", err)

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -21,14 +21,19 @@ type PostgresqlConfig struct {
 	Username     string
 	Password     string
 	DatabaseName string
+	LogQueries   bool
 }
 
 func NewDatabase(logger *slog.Logger, c PostgresqlConfig) (*gorm.DB, error) {
-	gormLogger := slogGorm.New(
+	gormLoggerOpts := []slogGorm.Option{
 		slogGorm.WithHandler(logger.Handler()),
 		slogGorm.WithRecordNotFoundError(),
-		slogGorm.WithSlowThreshold(200*time.Millisecond),
-	)
+		slogGorm.WithSlowThreshold(200 * time.Millisecond),
+	}
+	if c.LogQueries {
+		gormLoggerOpts = append(gormLoggerOpts, slogGorm.WithTraceAll())
+	}
+	gormLogger := slogGorm.New(gormLoggerOpts...)
 
 	databaseConfig := gorm.Config{
 		Logger:         gormLogger,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -121,6 +121,7 @@ deploy:
             DEFAULT_TTL: "172800" # 48 hours
             PASSWORD_TOKEN_TTL: "900" # 15 minutes
             LOG_PRETTY_PRINT: "{{ .LOG_PRETTY_PRINT }}"
+            DATABASE_LOG_QUERIES: "{{ .DATABASE_LOG_QUERIES }}"
         useHelmSecrets: true
         valuesFiles:
           - helm/data/secrets/{{ .CLASSIFICATION }}/values.yaml


### PR DESCRIPTION
## Summary

Enables per-query SQL logging via slog-gorm's `WithTraceAll()` when `DATABASE_LOG_QUERIES=true`. Defaults off so prod stays quiet. Slow-query and error logging are unchanged.

## Test plan

- [ ] Set `DATABASE_LOG_QUERIES=true` locally and confirm `SQL query executed [...]` log lines appear with `query`, `duration`, `rows`, `file`, and `correlationId` fields.
- [ ] Leave it unset (or `false`) and confirm only slow-query/error logs are emitted.