### PR TITLE
fix: grant ingressclasses:list and clusterissuers:list to im-manager ClusterRole

### DIFF
--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -51,6 +51,12 @@ rules:
       - ingressclasses
     verbs:
       - list
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - clusterissuers
+    verbs:
+      - list
 # KEDA
   - apiGroups:
       - http.keda.sh

--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -45,6 +45,12 @@ rules:
       - networkpolicies
     verbs:
       - patch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - list
 # KEDA
   - apiGroups:
       - http.keda.sh


### PR DESCRIPTION
## Summary

Two discovery functions in `pkg/instance/kubernetes.go` list cluster-scoped resources before each deploy, but the matching ClusterRole rules were never added. Both functions intentionally fall back to `""` on error, so the gap has been silently producing degraded Ingresses across every deploy.

### `discoverIngressClass` (`kubernetes.go:181`)

Lists `IngressClasses`, logs `"Failed to discover ingress class"` at WARN on 403, falls back to `INGRESS_CLASS=""` which renders `className: ""` in the dhis2-core / dhis2-db / etc. helmfile templates. That makes k8s pick the default IngressClass if one is annotated, or otherwise produces an Ingress no controller routes.

### `discoverCertIssuer` (`kubernetes.go:217`)

Lists `ClusterIssuers` (cert-manager). The function swallows *any* list error to `"", nil` with no log line, intentionally so cert-manager-less clusters work silently. On this cluster:

- `clusterissuers.cert-manager.io` CRD has been installed since 2024-11-20.
- A READY `cert-issuer-prod` ClusterIssuer is sitting there ready to use (548 days old).
- `kubectl auth can-i --as=system:serviceaccount:instance-manager-dev:im-manager-dev list clusterissuers.cert-manager.io` → `no`.

So `CERT_ISSUER=""` flows into every helmfile render and the resulting Ingress has no `cert-manager.io/cluster-issuer` annotation — cert-manager never auto-issues TLS.

## Change

Add the missing rules:

```yaml
- apiGroups: ["networking.k8s.io"]
  resources: ["ingressclasses"]
  verbs: ["list"]
- apiGroups: ["cert-manager.io"]
  resources: ["clusterissuers"]
  verbs: ["list"]
```

## Test plan

- [ ] Deploy this chart change to an env. Confirm `Failed to discover ingress class` warning stops appearing in im-manager logs on new deploys.
- [ ] Trigger a fresh deploy and verify the rendered Ingress carries both `spec.ingressClassName` and the `cert-manager.io/cluster-issuer: cert-issuer-prod` annotation.
- [ ] On a cluster *without* cert-manager installed, confirm `discoverCertIssuer` still returns `""` silently (the function's existing fallback handles "CRD not registered" via the same error path; the only behavior change is that *granted-and-listed* succeeds where it previously was *denied-and-silently-empty*).

## Out of scope (follow-up)

The two discover functions arguably should ERROR (or fail the deploy) on a real API error rather than treating it the same as "no resource found" — that's a behavior change, not an RBAC fix, and doesn't belong in this PR.