### PR TITLE
fix: disable helmfile createNamespace default so deploys don't need namespaces:create

### DIFF
--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -32,10 +32,23 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestInstanceHandler(t *testing.T) {
 	k8sClient := inttest.SetupK8s(t)
+
+	// In production the group's namespace is created out-of-band by skaffold via
+	// the im-group chart before any instance deploys. Stack helmfiles no longer
+	// pass --create-namespace, so mirror that here.
+	_, err := k8sClient.Client.CoreV1().Namespaces().Create(
+		context.TODO(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "group-name"}},
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err, "failed to create test namespace")
+
 	db := inttest.SetupDB(t)
 	redis := inttest.SetupRedis(t)
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -39,14 +39,7 @@ import (
 func TestInstanceHandler(t *testing.T) {
 	k8sClient := inttest.SetupK8s(t)
 
-	// In production the group's namespace is created out-of-band by skaffold via
-	// the im-group chart before any instance deploys. Stack helmfiles no longer
-	// pass --create-namespace, so mirror that here.
-	_, err := k8sClient.Client.CoreV1().Namespaces().Create(
-		context.TODO(),
-		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "group-name"}},
-		metav1.CreateOptions{},
-	)
+	err := createNamespace(t, k8sClient, "group-name")
 	require.NoError(t, err, "failed to create test namespace")
 
 	db := inttest.SetupDB(t)
@@ -347,6 +340,16 @@ func TestInstanceHandler(t *testing.T) {
 		assert.Equal(t, "0.6.0", updatedInstance.Parameters["IMAGE_TAG"].Value,
 			"parameters should be preserved when the patch body only changes public")
 	})
+}
+
+func createNamespace(t *testing.T, k8sClient *inttest.K8sClient, namespace string) error {
+	t.Helper()
+	_, err := k8sClient.Client.CoreV1().Namespaces().Create(
+		t.Context(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		metav1.CreateOptions{},
+	)
+	return err
 }
 
 type groupService struct {

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -390,7 +390,7 @@ func (s Service) DeployDeployment(ctx context.Context, token string, deployment 
 		}
 		err = s.deployDeploymentInstance(ctx, token, instance, deployment.TTL)
 		if err != nil {
-			return fmt.Errorf("failed to deploy instance(%s) %q: %v", instance.StackName, instance.Name, err)
+			return fmt.Errorf("failed to deploy instance(%s) %q: %w", instance.StackName, instance.Name, err)
 		}
 	}
 
@@ -421,6 +421,9 @@ func (s Service) deployDeploymentInstance(ctx context.Context, token string, ins
 		if strings.Contains(string(deployErrorLog), "another operation (install/upgrade/rollback) is in progress") {
 			s.logger.WarnContext(ctx, "Helm operation already in progress, skipping", "instance", instance.Name, "stack", instance.StackName, "deployment", instance.DeploymentID, "errorLog", deployErrorLog)
 			return nil
+		}
+		if strings.Contains(string(deployErrorLog), fmt.Sprintf("namespaces %q not found", group.Namespace)) {
+			return errdef.NewBadRequest("namespace %q does not exist", group.Namespace)
 		}
 		return fmt.Errorf("%w: %s", err, deployErrorLog)
 	}

--- a/stacks/chap-core/helmfile.yaml.gotmpl
+++ b/stacks/chap-core/helmfile.yaml.gotmpl
@@ -1,5 +1,6 @@
 # consumedParameters: DATABASE_HOSTNAME,DATABASE_NAME,DATABASE_SECRET,REDIS_HOST,REDIS_SECRET
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/chap-db/helmfile.yaml.gotmpl
+++ b/stacks/chap-db/helmfile.yaml.gotmpl
@@ -1,4 +1,5 @@
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/chap-valkey/helmfile.yaml.gotmpl
+++ b/stacks/chap-valkey/helmfile.yaml.gotmpl
@@ -1,4 +1,5 @@
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/chap-worker/helmfile.yaml.gotmpl
+++ b/stacks/chap-worker/helmfile.yaml.gotmpl
@@ -1,5 +1,6 @@
 # consumedParameters: DATABASE_HOSTNAME,DATABASE_NAME,DATABASE_SECRET,REDIS_HOST,REDIS_SECRET
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/dhis2-core/helmfile.yaml.gotmpl
+++ b/stacks/dhis2-core/helmfile.yaml.gotmpl
@@ -2,6 +2,7 @@
 # hostnameVariable: DATABASE_HOSTNAME
 # stackParameters: DEPLOY_CHAP,GOOGLE_AUTH_PROJECT_ID,GOOGLE_AUTH_PRIVATE_KEY_ID,GOOGLE_AUTH_PRIVATE_KEY,GOOGLE_AUTH_CLIENT_EMAIL,GOOGLE_AUTH_CLIENT_ID
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/dhis2-db/helmfile.yaml.gotmpl
+++ b/stacks/dhis2-db/helmfile.yaml.gotmpl
@@ -1,5 +1,6 @@
 # hostnamePattern: %s-database-postgresql.%s.svc
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/dhis2/helmfile.yaml.gotmpl
+++ b/stacks/dhis2/helmfile.yaml.gotmpl
@@ -1,5 +1,8 @@
 # hostnamePattern: %s-database-postgresql.%s.svc
 # stackParameters: GOOGLE_AUTH_PROJECT_ID,GOOGLE_AUTH_PRIVATE_KEY_ID,GOOGLE_AUTH_PRIVATE_KEY,GOOGLE_AUTH_CLIENT_EMAIL,GOOGLE_AUTH_CLIENT_ID
+helmDefaults:
+  createNamespace: false
+
 releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"

--- a/stacks/im-job-runner/helmfile.yaml.gotmpl
+++ b/stacks/im-job-runner/helmfile.yaml.gotmpl
@@ -1,3 +1,6 @@
+helmDefaults:
+  createNamespace: false
+
 releases:
   - name: {{ requiredEnv "INSTANCE_NAME" }}-job
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"

--- a/stacks/minio/helmfile.yaml.gotmpl
+++ b/stacks/minio/helmfile.yaml.gotmpl
@@ -1,5 +1,6 @@
 # consumedParameters: DATABASE_ID
 helmDefaults:
+  createNamespace: false
   deleteWait: true
 
 releases:

--- a/stacks/pgadmin/helmfile.yaml.gotmpl
+++ b/stacks/pgadmin/helmfile.yaml.gotmpl
@@ -1,5 +1,8 @@
 # consumedParameters: DATABASE_USERNAME, DATABASE_NAME, DATABASE_HOSTNAME
 # hostnameVariable: DATABASE_HOSTNAME
+helmDefaults:
+  createNamespace: false
+
 releases:
   - name: {{ requiredEnv "INSTANCE_NAME" }}-pgadmin
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"

--- a/stacks/whoami-go/helmfile.yaml.gotmpl
+++ b/stacks/whoami-go/helmfile.yaml.gotmpl
@@ -1,3 +1,6 @@
+helmDefaults:
+  createNamespace: false
+
 releases:
   - name: "{{ requiredEnv "INSTANCE_NAME" }}"
     namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"


### PR DESCRIPTION
## Summary

After #1526 dropped `namespaces:create` from the im-manager ClusterRole, every `POST /deployments/{id}/deploy` started returning 500 with helm's stderr:

```
namespaces is forbidden: User "system:serviceaccount:instance-manager-dev:im-manager-dev"
cannot create resource "namespaces" in API group "" at the cluster scope
```

The PR description audited Go and helmfile templates and concluded nothing in IM creates namespaces, which is true at that layer — but helmfile itself passes `--create-namespace` to `helm upgrade --install` by default (`helmDefaults.createNamespace` defaults to `true`). Helm's internal `createNamespace` path then does a Get→Create against the cluster, and with the perm dropped both calls fail.

This matches the original intent of #1526: at runtime IM should not need cluster-scoped namespace-create rights. Namespaces are provisioned out-of-band by skaffold via the `im-group` chart at group bootstrap, and the im-group chart installs a per-namespace Role/RoleBinding granting the im-manager SA the permissions it needs *inside* that already-existing namespace.

## Changes

1. Set `helmDefaults.createNamespace: false` on every stack helmfile. For stacks that didn't already have a `helmDefaults` section (dhis2, im-job-runner, pgadmin, whoami-go), add one.
2. With `--create-namespace` off, helm now returns `namespaces "X" not found` when deploying to a namespace that hasn't been bootstrapped. Return that as a `400` with the namespace name in the body instead of the generic 500. The wrapping `fmt.Errorf` in `DeployDeployment` switches from `%v` to `%w` so the typed error survives.

## Test plan

- [x] Deployed the change to my feat env via skaffold and ran the im-web-client playwright e2e against it (`API_URL=https://tons.api.im-feat.dhis2.org`). 5/5 passed in 3.4 min, including the create+update instance specs that hit the `whoami` group and exercise the in-cluster SA path that was previously 500-ing.
- [ ] Reviewer: confirm no stack actually depends on `--create-namespace` for some new-group bootstrap flow that bypasses `im-group`.