### PR TITLE
feat: classify known helm errors on deploy and surface them via typed errdefs

### DIFF
--- a/pkg/instance/helm_errors.go
+++ b/pkg/instance/helm_errors.go
@@ -1,0 +1,46 @@
+package instance
+
+import (
+	"regexp"
+
+	"github.com/dhis2-sre/im-manager/internal/errdef"
+)
+
+// helmErrorPattern maps a regex over helm/helmfile stderr to a constructor for a
+// typed errdef error with a user-actionable message. Patterns are evaluated in
+// order; the first match wins.
+type helmErrorPattern struct {
+	re     *regexp.Regexp
+	format func(match []string) error
+}
+
+var helmErrorPatterns = []helmErrorPattern{
+	{
+		// helm 3.x against a missing namespace when --create-namespace is not set:
+		//   Error: ... namespaces "whoami" not found
+		re: regexp.MustCompile(`namespaces "([^"]+)" not found`),
+		format: func(m []string) error {
+			return errdef.NewBadRequest("namespace %q does not exist on the target cluster; the group needs to be set up before instances can be deployed to it", m[1])
+		},
+	},
+	{
+		// helm 3.x with --create-namespace under a ServiceAccount that lacks the perm:
+		//   namespaces is forbidden: User "system:serviceaccount:..." cannot create resource "namespaces" in API group "" at the cluster scope
+		re: regexp.MustCompile(`namespaces is forbidden:[^\n]*cannot create resource "namespaces"`),
+		format: func(m []string) error {
+			return errdef.NewServiceUnavailable("the cluster does not permit im-manager to create namespaces; the stack's helmfile must set helmDefaults.createNamespace: false")
+		},
+	},
+}
+
+// classifyHelmfileError inspects helm/helmfile stderr from a failed sync and
+// returns a typed errdef error with an actionable message for known patterns,
+// or nil if no pattern matched (the caller should fall back to the generic 500).
+func classifyHelmfileError(stderr string) error {
+	for _, p := range helmErrorPatterns {
+		if m := p.re.FindStringSubmatch(stderr); m != nil {
+			return p.format(m)
+		}
+	}
+	return nil
+}

--- a/pkg/instance/helm_errors_test.go
+++ b/pkg/instance/helm_errors_test.go
@@ -1,0 +1,62 @@
+package instance
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dhis2-sre/im-manager/internal/errdef"
+)
+
+func TestClassifyHelmfileError(t *testing.T) {
+	tests := []struct {
+		name      string
+		stderr    string
+		wantNil   bool
+		wantCheck func(error) bool
+		wantSub   string
+	}{
+		{
+			name:      "namespace forbidden create",
+			stderr:    `namespaces is forbidden: User "system:serviceaccount:instance-manager-dev:im-manager-dev" cannot create resource "namespaces" in API group "" at the cluster scope`,
+			wantCheck: errdef.IsServiceUnavailable,
+			wantSub:   "helmDefaults.createNamespace: false",
+		},
+		{
+			name:      "namespace not found",
+			stderr:    `Error: INSTALLATION FAILED: 1 error occurred: * namespaces "whoami" not found`,
+			wantCheck: errdef.IsBadRequest,
+			wantSub:   `"whoami"`,
+		},
+		{
+			name:    "unrelated error returns nil",
+			stderr:  `Error: failed to download "bitnami/postgresql"`,
+			wantNil: true,
+		},
+		{
+			name:    "empty stderr returns nil",
+			stderr:  "",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyHelmfileError(tt.stderr)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("classifyHelmfileError returned %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("classifyHelmfileError returned nil, want non-nil")
+			}
+			if !tt.wantCheck(got) {
+				t.Fatalf("classifyHelmfileError returned %v, did not match the expected errdef predicate", got)
+			}
+			if tt.wantSub != "" && !strings.Contains(got.Error(), tt.wantSub) {
+				t.Fatalf("classifyHelmfileError returned %q, want substring %q", got.Error(), tt.wantSub)
+			}
+		})
+	}
+}

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -390,7 +390,7 @@ func (s Service) DeployDeployment(ctx context.Context, token string, deployment 
 		}
 		err = s.deployDeploymentInstance(ctx, token, instance, deployment.TTL)
 		if err != nil {
-			return fmt.Errorf("failed to deploy instance(%s) %q: %v", instance.StackName, instance.Name, err)
+			return fmt.Errorf("failed to deploy instance(%s) %q: %w", instance.StackName, instance.Name, err)
 		}
 	}
 
@@ -421,6 +421,10 @@ func (s Service) deployDeploymentInstance(ctx context.Context, token string, ins
 		if strings.Contains(string(deployErrorLog), "another operation (install/upgrade/rollback) is in progress") {
 			s.logger.WarnContext(ctx, "Helm operation already in progress, skipping", "instance", instance.Name, "stack", instance.StackName, "deployment", instance.DeploymentID, "errorLog", deployErrorLog)
 			return nil
+		}
+		if classified := classifyHelmfileError(string(deployErrorLog)); classified != nil {
+			s.logger.ErrorContext(ctx, "Helmfile sync failed with recognized error", "instance", instance.Name, "stack", instance.StackName, "deployment", instance.DeploymentID, "errorLog", string(deployErrorLog))
+			return classified
 		}
 		return fmt.Errorf("%w: %s", err, deployErrorLog)
 	}


### PR DESCRIPTION
## Summary

Helmfile stderr from a failed `sync` was previously wrapped in a non-typed error, so the API returned the generic 500:

```
something went wrong. We'll look into it if you send us the request id "779c23a9-..." :)
```

…and the real reason only lived in im-manager pod logs. Diagnosing #1531 took significantly longer than it should have because of this.

`classifyHelmfileError` matches a small set of known stderr patterns and returns a typed `errdef.*` error with a user-actionable message. The existing `errorHandler` middleware then maps it to an appropriate status code and writes the message into the response body. Unrecognized helm errors fall through to the existing generic 500 unchanged.

Two patterns to start:

| Stderr pattern | Typed error | Body |
|---|---|---|
| `namespaces "<X>" not found` | `errdef.BadRequest` (400) | `namespace "<X>" does not exist on the target cluster; the group needs to be set up before instances can be deployed to it` |
| `namespaces is forbidden: ... cannot create resource "namespaces"` | `errdef.ServiceUnavailable` (503) | `the cluster does not permit im-manager to create namespaces; the stack's helmfile must set helmDefaults.createNamespace: false` |

After #1531 lands, the second pattern shouldn't fire in practice, but I'm keeping it as defense-in-depth so the next time someone tweaks RBAC and a deploy starts failing for that reason, the API tells them what's wrong instead of hiding it.

`DeployDeployment`'s wrapping `fmt.Errorf` is changed from `%v` to `%w` so the typed error survives the wrap and `errors.As` in the middleware finds it.

## Adding a new pattern

Append to `helmErrorPatterns` in `pkg/instance/helm_errors.go`:

```go
{
    re: regexp.MustCompile(`some helm error fragment`),
    format: func(m []string) error {
        return errdef.NewBadRequest("user-actionable message about what to do")
    },
},
```

Add a row in `helm_errors_test.go`. That's it.

## Test plan

- [x] Unit test `classifyHelmfileError` against the exact stderr captured from a failing deploy on im-dev (the `namespaces is forbidden ... cannot create resource "namespaces"` line from helm). Status code and body substring verified.
- [x] Deployed this branch (which deliberately does NOT include the helmfile fix from #1531) to my feat env so deploys still 403. Ran the im-web-client playwright e2e against it. `POST /deployments/{id}/deploy` returned `503` with the body `failed to deploy instance(dhis2-db) "e2e-test-XXXX": the cluster does not permit im-manager to create namespaces; the stack's helmfile must set helmDefaults.createNamespace: false`. End-to-end confirmed.
- [ ] Reviewer: confirm the two messages read sensibly for a non-dev API consumer (UI or CLI). Open to tweaking wording.

## Follow-ups (not in this PR)

- im-web-client's `use-dhis2-deployment.ts` discards the API error and shows its own generic "Could not deploy deployment with id X". Worth letting the API message through to the UI in a separate PR there.
- Same classifier idea could apply to other helmfile-driven paths (`destroy`, etc.) — left for when a real complaint surfaces.