### PR TITLE
revert: signed download URLs commit that landed on master directly

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -210,11 +210,10 @@ func run() (err error) {
 
 	notificationHandler := newNotificationHandler(logger, db)
 
-	databaseHandler, databaseService, err := newDatabaseHandler(ctx, logger, db, groupService, instanceService, stackService, streamEnv, streamName)
+	databaseHandler, err := newDatabaseHandler(ctx, logger, db, groupService, instanceService, stackService, streamEnv, streamName)
 	if err != nil {
 		return err
 	}
-	instanceService.SetExternalDownloads(databaseService)
 
 	err = handler.RegisterValidation()
 	if err != nil {
@@ -610,26 +609,26 @@ func newInstanceHandler(stackService stack.Service, groupService *group.Service,
 	return instance.NewHandler(stackService, groupService, instanceService, defaultTTL), nil
 }
 
-func newDatabaseHandler(ctx context.Context, logger *slog.Logger, db *gorm.DB, groupService *group.Service, instanceService *instance.Service, stackService stack.Service, env *stream.Environment, streamName string) (database.Handler, *database.Service, error) {
+func newDatabaseHandler(ctx context.Context, logger *slog.Logger, db *gorm.DB, groupService *group.Service, instanceService *instance.Service, stackService stack.Service, env *stream.Environment, streamName string) (database.Handler, error) {
 	s3Bucket, err := requireEnv("S3_BUCKET")
 	if err != nil {
-		return database.Handler{}, nil, err
+		return database.Handler{}, err
 	}
 	s3Client, err := newS3Client(ctx, logger)
 	if err != nil {
-		return database.Handler{}, nil, err
+		return database.Handler{}, err
 	}
 	databaseRepository := database.NewRepository(db)
 	notificationRepository := notification.NewRepository(db)
 	publisher, err := notification.NewPublisher(logger, env, streamName, notificationRepository)
 	if err != nil {
-		return database.Handler{}, nil, fmt.Errorf("failed to create database notification publisher: %w", err)
+		return database.Handler{}, fmt.Errorf("failed to create database notification publisher: %w", err)
 	}
 	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, func(c model.Cluster) (database.PodExecutor, error) {
 		return instance.NewKubernetesService(c)
 	}, publisher, instanceService)
 
-	return database.NewHandler(logger, databaseService, groupService, instanceService, stackService), databaseService, nil
+	return database.NewHandler(logger, databaseService, groupService, instanceService, stackService), nil
 }
 
 func newS3Client(ctx context.Context, logger *slog.Logger) (*storage.S3Client, error) {

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 )
 
-func NewHandler(logger *slog.Logger, databaseService *Service, groupService groupService, instanceService instanceService, stackService stackService) Handler {
+func NewHandler(logger *slog.Logger, databaseService *service, groupService groupService, instanceService instanceService, stackService stackService) Handler {
 	return Handler{
 		logger:          logger,
 		databaseService: databaseService,
@@ -31,7 +31,7 @@ func NewHandler(logger *slog.Logger, databaseService *Service, groupService grou
 
 type Handler struct {
 	logger          *slog.Logger
-	databaseService *Service
+	databaseService *service
 	groupService    groupService
 	instanceService instanceService
 	stackService    stackService

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/url"
+	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -33,8 +34,8 @@ type Publisher interface {
 }
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func NewService(logger *slog.Logger, s3Bucket string, s3Client S3Client, groupService groupService, repository *repository, podExecutor podExecutorFunc, publisher Publisher, filestoreBackuper FilestoreBackuper) *Service {
-	return &Service{
+func NewService(logger *slog.Logger, s3Bucket string, s3Client S3Client, groupService groupService, repository *repository, podExecutor podExecutorFunc, publisher Publisher, filestoreBackuper FilestoreBackuper) *service {
+	return &service{
 		logger:            logger,
 		s3Bucket:          s3Bucket,
 		s3Client:          s3Client,
@@ -62,7 +63,7 @@ type FilestoreBackuper interface {
 	FilestoreBackup(ctx context.Context, instance *model.DeploymentInstance, name string, database *model.Database) error
 }
 
-type Service struct {
+type service struct {
 	logger            *slog.Logger
 	s3Bucket          string
 	s3Client          S3Client
@@ -82,7 +83,7 @@ type S3Client interface {
 	StreamUpload(ctx context.Context, bucket, key, contentType string, r io.Reader) (int64, error)
 }
 
-func (s Service) FindByIdentifier(ctx context.Context, identifier string) (*model.Database, error) {
+func (s service) FindByIdentifier(ctx context.Context, identifier string) (*model.Database, error) {
 	id, err := strconv.ParseUint(identifier, 10, 32)
 	if err != nil {
 		database, err := s.FindBySlug(ctx, identifier)
@@ -99,7 +100,7 @@ func (s Service) FindByIdentifier(ctx context.Context, identifier string) (*mode
 	return database, nil
 }
 
-func (s Service) Copy(ctx context.Context, id uint, d *model.Database, group *model.Group) error {
+func (s service) Copy(ctx context.Context, id uint, d *model.Database, group *model.Group) error {
 	source, err := s.FindById(ctx, id)
 	if err != nil {
 		return err
@@ -136,7 +137,7 @@ func (s Service) Copy(ctx context.Context, id uint, d *model.Database, group *mo
 	return s.copyFS(ctx, d, group, source.FilestoreID)
 }
 
-func (s Service) copyFS(ctx context.Context, d *model.Database, group *model.Group, filestoreID uint) error {
+func (s service) copyFS(ctx context.Context, d *model.Database, group *model.Group, filestoreID uint) error {
 	fs, err := s.repository.FindById(ctx, filestoreID)
 	if err != nil {
 		if errdef.IsNotFound(err) {
@@ -186,19 +187,19 @@ func (s Service) copyFS(ctx context.Context, d *model.Database, group *model.Gro
 	return nil
 }
 
-func (s Service) FindById(ctx context.Context, id uint) (*model.Database, error) {
+func (s service) FindById(ctx context.Context, id uint) (*model.Database, error) {
 	return s.repository.FindById(ctx, id)
 }
 
-func (s Service) FindBySlug(ctx context.Context, slug string) (*model.Database, error) {
+func (s service) FindBySlug(ctx context.Context, slug string) (*model.Database, error) {
 	return s.repository.FindBySlug(ctx, slug)
 }
 
-func (s Service) Lock(ctx context.Context, databaseId uint, instanceId uint, userId uint) (*model.Lock, error) {
+func (s service) Lock(ctx context.Context, databaseId uint, instanceId uint, userId uint) (*model.Lock, error) {
 	return s.repository.Lock(ctx, databaseId, instanceId, userId)
 }
 
-func (s Service) Unlock(ctx context.Context, databaseId uint) error {
+func (s service) Unlock(ctx context.Context, databaseId uint) error {
 	return s.repository.Unlock(ctx, databaseId)
 }
 
@@ -207,7 +208,7 @@ type ReadAtSeeker interface {
 	io.ReadSeeker
 }
 
-func (s Service) Upload(ctx context.Context, d *model.Database, group *model.Group, reader ReadAtSeeker, size int64) (*model.Database, error) {
+func (s service) Upload(ctx context.Context, d *model.Database, group *model.Group, reader ReadAtSeeker, size int64) (*model.Database, error) {
 	key := fmt.Sprintf("%s/%s", group.Name, d.Name)
 	err := s.s3Client.Upload(ctx, s.s3Bucket, key, reader, size)
 	if err != nil {
@@ -225,7 +226,7 @@ func (s Service) Upload(ctx context.Context, d *model.Database, group *model.Gro
 	return d, nil
 }
 
-func (s Service) Download(ctx context.Context, id uint, dst io.Writer, cb func(contentLength int64)) error {
+func (s service) Download(ctx context.Context, id uint, dst io.Writer, cb func(contentLength int64)) error {
 	d, err := s.repository.FindById(ctx, id)
 	if err != nil {
 		return err
@@ -244,7 +245,7 @@ func (s Service) Download(ctx context.Context, id uint, dst io.Writer, cb func(c
 	return s.s3Client.Download(ctx, s.s3Bucket, key, dst, cb)
 }
 
-func (s Service) Delete(ctx context.Context, id uint) error {
+func (s service) Delete(ctx context.Context, id uint) error {
 	d, err := s.repository.FindById(ctx, id)
 	if err != nil {
 		return err
@@ -271,7 +272,7 @@ func (s Service) Delete(ctx context.Context, id uint) error {
 	return s.deleteFS(ctx, d)
 }
 
-func (s Service) deleteFS(ctx context.Context, d *model.Database) error {
+func (s service) deleteFS(ctx context.Context, d *model.Database) error {
 	fs, err := s.repository.FindById(ctx, d.FilestoreID)
 	if err != nil {
 		if errdef.IsNotFound(err) {
@@ -301,7 +302,7 @@ func (s Service) deleteFS(ctx context.Context, d *model.Database) error {
 	return nil
 }
 
-func (s Service) List(ctx context.Context, user *model.User) ([]GroupsWithDatabases, error) {
+func (s service) List(ctx context.Context, user *model.User) ([]GroupsWithDatabases, error) {
 	groups := append(user.Groups, user.AdminGroups...) //nolint:gocritic
 	groupsByName := make(map[string]model.Group)
 	for _, group := range groups {
@@ -356,7 +357,7 @@ func filterDatabases(databases []model.Database, test func(database *model.Datab
 	return
 }
 
-func (s Service) Update(ctx context.Context, d *model.Database) error {
+func (s service) Update(ctx context.Context, d *model.Database) error {
 	sourceUrl, err := url.Parse(d.Url)
 	if err != nil {
 		return err
@@ -386,7 +387,7 @@ func (s Service) Update(ctx context.Context, d *model.Database) error {
 	return s.updateFS(ctx, d)
 }
 
-func (s Service) updateFS(ctx context.Context, d *model.Database) error {
+func (s service) updateFS(ctx context.Context, d *model.Database) error {
 	fs, err := s.repository.FindById(ctx, d.FilestoreID)
 	if err != nil {
 		if errdef.IsNotFound(err) {
@@ -416,7 +417,7 @@ func (s Service) updateFS(ctx context.Context, d *model.Database) error {
 	return s.repository.Update(ctx, fs)
 }
 
-func (s Service) CreateExternalDownload(ctx context.Context, databaseID uint, expiration uint) (*model.ExternalDownload, error) {
+func (s service) CreateExternalDownload(ctx context.Context, databaseID uint, expiration uint) (*model.ExternalDownload, error) {
 	err := s.repository.PurgeExternalDownload(ctx)
 	if err != nil {
 		return nil, err
@@ -425,7 +426,7 @@ func (s Service) CreateExternalDownload(ctx context.Context, databaseID uint, ex
 	return s.repository.CreateExternalDownload(ctx, databaseID, expiration)
 }
 
-func (s Service) FindExternalDownload(ctx context.Context, uuid uuid.UUID) (*model.ExternalDownload, error) {
+func (s service) FindExternalDownload(ctx context.Context, uuid uuid.UUID) (*model.ExternalDownload, error) {
 	err := s.repository.PurgeExternalDownload(ctx)
 	if err != nil {
 		return nil, err
@@ -433,7 +434,7 @@ func (s Service) FindExternalDownload(ctx context.Context, uuid uuid.UUID) (*mod
 	return s.repository.FindExternalDownload(ctx, uuid)
 }
 
-func (s Service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance) error {
+func (s service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance) error {
 	lock := database.Lock
 	isLocked := lock != nil
 	if isLocked && (lock.InstanceID != instance.ID || lock.UserID != userId) {
@@ -531,7 +532,7 @@ func getFormat(database *model.Database) string {
 	return "plain"
 }
 
-func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance, newName string, format string, done func(ctx context.Context, saved *model.Database)) (*model.Database, error) {
+func (s service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance, newName string, format string, done func(ctx context.Context, saved *model.Database)) (*model.Database, error) {
 	group, err := s.groupService.Find(ctx, instance.GroupName)
 	if err != nil {
 		return nil, err
@@ -680,9 +681,41 @@ func execPgDump(ctx context.Context, executor PodExecutor, namespace, podName st
 	return nil
 }
 
-func (s Service) logError(ctx context.Context, err error) {
+func (s service) logError(ctx context.Context, err error) {
 	// TODO: Persist error message
 	s.logger.ErrorContext(ctx, "Failed to SaveAs DB", "error", err)
+}
+
+func (s service) removeTempFile(ctx context.Context, fd *os.File) {
+	for _, err := range [...]error{fd.Close(), os.Remove(fd.Name())} {
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to remove temp file", "error", err)
+		}
+	}
+}
+
+func (s service) gz(ctx context.Context, gzFile string, database *model.Database, src *os.File) (*os.File, error) {
+	outFile, err := os.Create(gzFile) // #nosec
+	if err != nil {
+		return nil, err
+	}
+
+	zw := gzip.NewWriter(outFile)
+	zw.Name = strings.TrimSuffix(database.Name, ".gz")
+
+	defer func(zw *gzip.Writer) {
+		err := zw.Close()
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to close gzip writer", "error", err)
+		}
+	}(zw)
+
+	_, err = io.Copy(zw, src)
+	if err != nil {
+		return nil, err
+	}
+
+	return outFile, nil
 }
 
 func newPgDumpConfig(instance *model.DeploymentInstance, stack *model.Stack) (*pg.Dump, error) {
@@ -729,7 +762,7 @@ func buildPgDumpCommand(dump *pg.Dump, format string) []string {
 	return append([]string{"env", "PGPASSWORD=" + dump.Password, "pg_dump"}, options...)
 }
 
-func (s Service) StreamUpload(ctx context.Context, database model.Database, group *model.Group, body io.Reader, contentType string, contentLength int64) (model.Database, error) {
+func (s service) StreamUpload(ctx context.Context, database model.Database, group *model.Group, body io.Reader, contentType string, contentLength int64) (model.Database, error) {
 	ctx = context.WithoutCancel(ctx)
 
 	key := fmt.Sprintf("%s/%s", group.Name, database.Name)

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -59,12 +59,12 @@ type stackService interface {
 	Find(name string) (*model.Stack, error)
 }
 
-func (h helmfileService) sync(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint, extraEnv map[string]string) (*exec.Cmd, error) {
-	return h.executeHelmfileCommand(ctx, token, instance, group, ttl, extraEnv, "sync")
+func (h helmfileService) sync(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint) (*exec.Cmd, error) {
+	return h.executeHelmfileCommand(ctx, token, instance, group, ttl, "sync")
 }
 
 func (h helmfileService) destroy(ctx context.Context, instance *model.DeploymentInstance, group *model.Group) (*exec.Cmd, error) {
-	return h.executeHelmfileCommand(ctx, "token", instance, group, 0, nil, "destroy")
+	return h.executeHelmfileCommand(ctx, "token", instance, group, 0, "destroy")
 }
 
 // **Security considerations**
@@ -73,7 +73,7 @@ func (h helmfileService) destroy(ctx context.Context, instance *model.Deployment
 // * stack.Name is populated by reading the name of a folder and even if that folder name could contain something malicious it won't be running in a shell anyway
 // * stackPath is concatenated using path.Join which also cleans the path and furthermore it's existence is validated
 // * Binaries are executed using an absolute path resolved once at startup (via exec.LookPath or an explicit env override); PATH is not consulted per request
-func (h helmfileService) executeHelmfileCommand(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint, extraEnv map[string]string, operation string) (*exec.Cmd, error) {
+func (h helmfileService) executeHelmfileCommand(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint, operation string) (*exec.Cmd, error) {
 	//goland:noinspection GoImportUsedAsName
 	stack, err := h.stackService.Find(instance.StackName)
 	if err != nil {
@@ -92,7 +92,7 @@ func (h helmfileService) executeHelmfileCommand(ctx context.Context, token strin
 
 	cmd := exec.Command(h.helmfileBinary, "--helm-binary", h.helmBinary, "-f", stackPath, operation) // #nosec
 	h.logger.InfoContext(ctx, "Executing helmfile command", "command", cmd.String())
-	h.configureInstanceEnvironment(ctx, token, instance, group, ttl, stackParameters, extraEnv, cmd)
+	h.configureInstanceEnvironment(ctx, token, instance, group, ttl, stackParameters, cmd)
 
 	return cmd, nil
 }
@@ -124,9 +124,10 @@ func (h helmfileService) loadStackParameters(stackName string) (stackParameters,
 	return params, nil
 }
 
-func (h helmfileService) configureInstanceEnvironment(ctx context.Context, accessToken string, instance *model.DeploymentInstance, group *model.Group, ttl uint, stackParameters stackParameters, extraEnv map[string]string, cmd *exec.Cmd) {
+func (h helmfileService) configureInstanceEnvironment(ctx context.Context, accessToken string, instance *model.DeploymentInstance, group *model.Group, ttl uint, stackParameters stackParameters, cmd *exec.Cmd) {
+	// TODO: We should only inject what the stack require, currently we just blindly inject IM_ACCESS_TOKEN and others which may not be required by the stack
+	// We could probably list the required system parameters in the stacks helmfile and parse those as well as other parameters
 	// INSTANCE_NAME: unique name for K8s/Helm (release names, services). INSTANCE_PATH_NAME: deployment name for URL path/context (group-based subdomain already makes URL unique).
-	// IM_ACCESS_TOKEN is kept for stacks that need IM API access (e.g. im-job-runner). Seed stacks use per-deployment signed URLs via extraEnv instead.
 	instanceNameEnv := fmt.Sprintf("%s=%s-%d", "INSTANCE_NAME", instance.Name, group.ID)
 	instancePathNameEnv := fmt.Sprintf("%s=%s", "INSTANCE_PATH_NAME", instance.Name)
 	instanceNamespaceEnv := fmt.Sprintf("%s=%s", "INSTANCE_NAMESPACE", group.Namespace)
@@ -172,10 +173,6 @@ func (h helmfileService) configureInstanceEnvironment(ctx context.Context, acces
 	for parameter, value := range stackParameters {
 		instanceEnv := fmt.Sprintf("%s=%s", parameter, value)
 		cmd.Env = append(cmd.Env, instanceEnv)
-	}
-
-	for key, value := range extraEnv {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 }
 

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -116,7 +116,6 @@ func TestInstanceHandler(t *testing.T) {
 	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, func(c model.Cluster) (database.PodExecutor, error) {
 		return instance.NewKubernetesService(c)
 	}, noopPublisher{}, noopFilestoreBackuper{})
-	instanceService.SetExternalDownloads(databaseService)
 
 	authenticator := func(c *gin.Context) {
 		ctx := model.NewContextWithUser(c.Request.Context(), user)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -9,10 +9,8 @@ import (
 	"iter"
 	"log/slog"
 	"maps"
-	"os"
 	"os/exec"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -51,13 +49,8 @@ type groupService interface {
 }
 
 type helmfile interface {
-	sync(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint, extraEnv map[string]string) (*exec.Cmd, error)
+	sync(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint) (*exec.Cmd, error)
 	destroy(ctx context.Context, instance *model.DeploymentInstance, group *model.Group) (*exec.Cmd, error)
-}
-
-type externalDownloadCreator interface {
-	FindById(ctx context.Context, id uint) (*model.Database, error)
-	CreateExternalDownload(ctx context.Context, databaseID uint, expiration uint) (*model.ExternalDownload, error)
 }
 
 type Service struct {
@@ -69,53 +62,6 @@ type Service struct {
 	s3Client           *s3.Client
 	s3Bucket           string
 	tokenService       *token.TokenService
-	externalDownloads  externalDownloadCreator
-}
-
-func (s *Service) SetExternalDownloads(creator externalDownloadCreator) {
-	s.externalDownloads = creator
-}
-
-const seedDownloadTTLSeconds uint = 1800
-
-func (s Service) buildSeedEnv(ctx context.Context, instance *model.DeploymentInstance) (map[string]string, error) {
-	param, ok := instance.Parameters["DATABASE_ID"]
-	if !ok {
-		return nil, nil
-	}
-
-	databaseID, err := strconv.ParseUint(param.Value, 10, 64)
-	if err != nil || databaseID == 0 {
-		return nil, nil
-	}
-
-	if s.externalDownloads == nil {
-		return nil, fmt.Errorf("external download service not configured; cannot create seed URLs for DATABASE_ID=%s", param.Value)
-	}
-
-	hostname := os.Getenv("HOSTNAME")
-	extraEnv := make(map[string]string)
-
-	db, err := s.externalDownloads.FindById(ctx, uint(databaseID))
-	if err != nil {
-		return nil, fmt.Errorf("database %d not found: %w", databaseID, err)
-	}
-
-	dbDownload, err := s.externalDownloads.CreateExternalDownload(ctx, db.ID, seedDownloadTTLSeconds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create seed download link for database %d: %w", db.ID, err)
-	}
-	extraEnv["DATABASE_DOWNLOAD_URL"] = hostname + "/databases/external/" + dbDownload.UUID.String()
-
-	if db.FilestoreID != 0 {
-		fsDownload, err := s.externalDownloads.CreateExternalDownload(ctx, db.FilestoreID, seedDownloadTTLSeconds)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create seed download link for filestore %d: %w", db.FilestoreID, err)
-		}
-		extraEnv["FILESTORE_DOWNLOAD_URL"] = hostname + "/databases/external/" + fsDownload.UUID.String()
-	}
-
-	return extraEnv, nil
 }
 
 func (s Service) SaveDeployment(ctx context.Context, deployment *model.Deployment) error {
@@ -457,12 +403,7 @@ func (s Service) deployDeploymentInstance(ctx context.Context, token string, ins
 		return err
 	}
 
-	extraEnv, err := s.buildSeedEnv(ctx, instance)
-	if err != nil {
-		return fmt.Errorf("failed to build seed environment: %w", err)
-	}
-
-	syncCmd, err := s.helmfileService.sync(ctx, token, instance, group, ttl, extraEnv)
+	syncCmd, err := s.helmfileService.sync(ctx, token, instance, group, ttl)
 	if err != nil {
 		return err
 	}

--- a/stacks/dhis2-db/helmfile.yaml.gotmpl
+++ b/stacks/dhis2-db/helmfile.yaml.gotmpl
@@ -30,8 +30,10 @@ releases:
           extraEnvVars:
             - name: HOSTNAME
               value: {{ requiredEnv "HOSTNAME" }}
-            - name: DATABASE_DOWNLOAD_URL
-              value: {{ env "DATABASE_DOWNLOAD_URL" | default "" }}
+            - name: DATABASE_ID
+              value: "{{ requiredEnv "DATABASE_ID" }}"
+            - name: IM_ACCESS_TOKEN
+              value: {{ requiredEnv "IM_ACCESS_TOKEN" }}
             - name: DATABASE_USERNAME
               value: {{ requiredEnv "DATABASE_USERNAME" }}
             - name: DATABASE_PASSWORD

--- a/stacks/dhis2-db/seed.sh
+++ b/stacks/dhis2-db/seed.sh
@@ -8,11 +8,12 @@ function exec_psql() {
   psql --username=postgres --no-align --tuples-only --dbname="$DATABASE_NAME" --command="$1"
 }
 
-if [[ -z "${DATABASE_DOWNLOAD_URL:-}" ]]; then
-  echo "Seeding aborted. No database download URL found!"
+if [[ -z $DATABASE_ID ]]; then
+  echo "Seeding aborted. No database id found!"
   exit 0
 fi
 
+DATABASE_DOWNLOAD_URL="$HOSTNAME/databases/$DATABASE_ID/download"
 echo "DATABASE_DOWNLOAD_URL: $DATABASE_DOWNLOAD_URL"
 
 exec_psql "create extension if not exists postgis"
@@ -20,8 +21,20 @@ exec_psql "create extension if not exists pg_trgm"
 exec_psql "create extension if not exists btree_gin"
 
 tmp_file=$(mktemp)
-curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail -L "$DATABASE_DOWNLOAD_URL" >"$tmp_file" || {
+curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail -L "$DATABASE_DOWNLOAD_URL" --cookie "accessToken=$IM_ACCESS_TOKEN" >"$tmp_file" || {
   echo "curl failed with exit code $?"
+  ( set +e
+    payload=$(echo "$IM_ACCESS_TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null)
+    exp=$(echo "$payload" | grep -o '"exp":[0-9]*' | cut -d: -f2)
+    now=$(date +%s)
+    if [[ -n "$exp" && "$now" -gt "$exp" ]]; then
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      echo "!!! TOKEN EXPIRED: exp=$exp now=$now ($(( now - exp ))s ago) !!!"
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    else
+      echo "Token: exp=${exp:-unknown} now=$now remaining=${exp:+$((exp - now))}s"
+    fi
+  ) || true
   exit 1
 }
 

--- a/stacks/dhis2/helmfile.yaml.gotmpl
+++ b/stacks/dhis2/helmfile.yaml.gotmpl
@@ -93,8 +93,10 @@ releases:
           extraEnvVars:
             - name: HOSTNAME
               value: {{ requiredEnv "HOSTNAME" }}
-            - name: DATABASE_DOWNLOAD_URL
-              value: {{ env "DATABASE_DOWNLOAD_URL" | default "" }}
+            - name: DATABASE_ID
+              value: "{{ requiredEnv "DATABASE_ID" }}"
+            - name: IM_ACCESS_TOKEN
+              value: {{ requiredEnv "IM_ACCESS_TOKEN" }}
             - name: DATABASE_USERNAME
               value: {{ requiredEnv "DATABASE_USERNAME" }}
             - name: DATABASE_PASSWORD

--- a/stacks/minio/helmfile.yaml.gotmpl
+++ b/stacks/minio/helmfile.yaml.gotmpl
@@ -35,8 +35,14 @@ releases:
             image: bitnamilegacy/minio:2025.1.20-debian-12-r0
             pullPolicy: {{ requiredEnv "IMAGE_PULL_POLICY" }}
             env:
-              - name: FILESTORE_DOWNLOAD_URL
-                value: {{ env "FILESTORE_DOWNLOAD_URL" | default "" }}
+              - name: HOSTNAME
+                value: {{ requiredEnv "HOSTNAME" }}
+              - name: DATABASE_ID
+                value: "{{ requiredEnv "DATABASE_ID" }}"
+              - name: IM_ACCESS_TOKEN
+                value: {{ requiredEnv "IM_ACCESS_TOKEN" }}
+              - name: INSTANCE_NAME
+                value: {{ requiredEnv "INSTANCE_NAME" }}
             command:
               - "/bin/bash"
               - "-c"

--- a/stacks/minio/seed-minio.sh
+++ b/stacks/minio/seed-minio.sh
@@ -33,14 +33,21 @@ seed_file=local/dhis2/seeded.txt
 if mc stat $seed_file >/dev/null 2>&1; then
   echo "Already seeded, skipping..."
 else
-  if [[ -z "${FILESTORE_DOWNLOAD_URL:-}" ]]; then
-    echo "No filestore to seed"
+  DATABASE_URL="$HOSTNAME/databases/$DATABASE_ID"
+  echo "DATABASE_URL: $DATABASE_URL"
+  if ! FILESTORE_ID=$(curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail --show-error -L "$DATABASE_URL" --cookie "accessToken=$IM_ACCESS_TOKEN" | jq -r '.filestoreId'); then
+    echo "Failed to fetch database information from $DATABASE_URL"
+    exit 1
+  fi
+  if [[ "$FILESTORE_ID" == "0" ]]; then
+    echo "No filestore id associated with database"
   else
-    echo "Filestore download URL: $FILESTORE_DOWNLOAD_URL"
+    echo "Filestore ID: $FILESTORE_ID"
     echo "Seeding..."
 
     tmp_file=$(mktemp)
-    if ! curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail --show-error -L "$FILESTORE_DOWNLOAD_URL" > "$tmp_file"; then
+    FILESTORE_DOWNLOAD_URL="$HOSTNAME/databases/$FILESTORE_ID/download"
+    if ! curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail --show-error -L "$FILESTORE_DOWNLOAD_URL" --cookie "accessToken=$IM_ACCESS_TOKEN" > "$tmp_file"; then
       echo "Failed to download filestore from $FILESTORE_DOWNLOAD_URL"
       exit 1
     fi


### PR DESCRIPTION
Reverts 96409ea0 which was pushed directly to master by mistake. The fix will be re-applied via a proper PR from fix/signed-download-urls-for-seed-scripts.