### PR TITLE
fix: exclude apps/ from filestore backup to prevent accumulation

### DIFF
--- a/pkg/instance/backupService.go
+++ b/pkg/instance/backupService.go
@@ -80,8 +80,9 @@ func (s *BackupService) PerformBackup(ctx context.Context, s3Bucket, key string)
 	pr, pw := io.Pipe()
 
 	g.Go(func() error {
-		defer pw.Close()
-		return s.createTarGzStream(ctx, pw, stats)
+		err := s.createTarGzStream(ctx, pw, stats)
+		_ = pw.CloseWithError(err)
+		return err
 	})
 
 	g.Go(func() error {
@@ -147,7 +148,7 @@ func (s *BackupService) processSingleObject(ctx context.Context, tw *tar.Writer,
 	return nil
 }
 
-func (s *BackupService) streamToS3WithMultipart(ctx context.Context, bucket, key string, reader io.Reader) error {
+func (s *BackupService) streamToS3WithMultipart(ctx context.Context, bucket, key string, reader io.Reader) (err error) {
 	createResponse, err := s.s3Client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
 		Bucket:      &bucket,
 		Key:         &key,
@@ -165,17 +166,17 @@ func (s *BackupService) streamToS3WithMultipart(ctx context.Context, bucket, key
 	buffer := make([]byte, bufferSize)
 
 	for {
-		n, err := io.ReadFull(reader, buffer)
-		if err != nil && err != io.EOF && !errors.Is(err, io.ErrUnexpectedEOF) {
-			return fmt.Errorf("read from pipe: %v", err)
+		n, readErr := io.ReadFull(reader, buffer)
+		if readErr != nil && readErr != io.EOF && !errors.Is(readErr, io.ErrUnexpectedEOF) {
+			return fmt.Errorf("read from pipe: %v", readErr)
 		}
 		if n == 0 {
 			break
 		}
 
-		part, err := s.uploadPart(ctx, bucket, key, uploadID, partNumber, buffer[:n])
-		if err != nil {
-			return err
+		part, partErr := s.uploadPart(ctx, bucket, key, uploadID, partNumber, buffer[:n])
+		if partErr != nil {
+			return partErr
 		}
 
 		completedParts = append(completedParts, part)

--- a/pkg/instance/backupService_test.go
+++ b/pkg/instance/backupService_test.go
@@ -5,12 +5,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"sort"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/dhis2-sre/im-manager/pkg/inttest"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -35,8 +38,8 @@ func TestBackupServiceIntegration(t *testing.T) {
 	require.NoError(t, minioClient.MakeBucket(ctx, minioBucket, minio.MakeBucketOptions{}))
 
 	testFiles := map[string][]byte{
-		"apps/app1/manifest.json": []byte(`{"name":"app1"}`),
-		"userAvatar/uid1":         []byte("avatar-content"),
+		"apps/app1/manifest.webapp": []byte(`{"name":"app1"}`),
+		"userAvatar/uid1":           []byte("avatar-content"),
 	}
 	for name, content := range testFiles {
 		_, err := minioClient.PutObject(ctx, minioBucket, name, bytes.NewReader(content), int64(len(content)), minio.PutObjectOptions{})
@@ -49,7 +52,7 @@ func TestBackupServiceIntegration(t *testing.T) {
 	s3Test := inttest.SetupS3(t, s3Dir)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	source := NewMinioBackupSource(logger, minioClient, minioBucket)
+	source := NewMinioBackupSource(logger, minioClient, minioBucket, "apps/")
 	backupService := NewBackupService(logger, source, s3Test.Client)
 
 	s3Key := "group/save-name-fs.tar.gz"
@@ -58,22 +61,8 @@ func TestBackupServiceIntegration(t *testing.T) {
 	tarContent := s3Test.GetObject(t, s3Bucket, s3Key)
 	entries := extractTarGz(t, tarContent)
 
-	var paths []string
-	for p := range entries {
-		paths = append(paths, p)
-	}
-	sort.Strings(paths)
-
-	var expected []string
-	for p := range testFiles {
-		expected = append(expected, p)
-	}
-	sort.Strings(expected)
-
-	assert.Equal(t, expected, paths)
-	for name, content := range testFiles {
-		assert.Equal(t, content, entries[name], "content mismatch for %s", name)
-	}
+	assert.Equal(t, []string{"userAvatar/uid1"}, sortedKeys(entries), "apps/ should be excluded from backup")
+	assert.Equal(t, testFiles["userAvatar/uid1"], entries["userAvatar/uid1"])
 }
 
 func setupMinio(t *testing.T, ctx context.Context) (*minioContainer.MinioContainer, *minio.Client) {
@@ -90,6 +79,74 @@ func setupMinio(t *testing.T, ctx context.Context) (*minioContainer.MinioContain
 	require.NoError(t, err)
 
 	return container, minioClient
+}
+
+func TestPerformBackupAbortsOnSourceError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	source := &errorAfterFirstObjectSource{content: []byte("hello")}
+	client := &fakeS3BackupClient{}
+	svc := NewBackupService(logger, source, client)
+
+	err := svc.PerformBackup(context.Background(), "bucket", "key")
+
+	require.Error(t, err)
+	assert.False(t, client.completed, "CompleteMultipartUpload should not be called after a source error")
+	assert.True(t, client.aborted, "AbortMultipartUpload should be called after a source error")
+}
+
+// errorAfterFirstObjectSource returns content for the first object and an error for all subsequent ones.
+type errorAfterFirstObjectSource struct {
+	content []byte
+	seen    int
+}
+
+func (s *errorAfterFirstObjectSource) List(_ context.Context) (<-chan BackupObject, error) {
+	ch := make(chan BackupObject, 2)
+	ch <- BackupObject{Path: "file1.txt", Size: int64(len(s.content))}
+	ch <- BackupObject{Path: "file2.txt", Size: int64(len(s.content))}
+	close(ch)
+	return ch, nil
+}
+
+func (s *errorAfterFirstObjectSource) Get(_ context.Context, path string) (io.ReadCloser, error) {
+	s.seen++
+	if s.seen > 1 {
+		return nil, fmt.Errorf("simulated error reading %q", path)
+	}
+	return io.NopCloser(bytes.NewReader(s.content)), nil
+}
+
+// fakeS3BackupClient tracks whether CompleteMultipartUpload or AbortMultipartUpload was called.
+type fakeS3BackupClient struct {
+	completed bool
+	aborted   bool
+}
+
+func (f *fakeS3BackupClient) CreateMultipartUpload(_ context.Context, _ *s3.CreateMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error) {
+	return &s3.CreateMultipartUploadOutput{UploadId: aws.String("upload-id")}, nil
+}
+
+func (f *fakeS3BackupClient) UploadPart(_ context.Context, _ *s3.UploadPartInput, _ ...func(*s3.Options)) (*s3.UploadPartOutput, error) {
+	return &s3.UploadPartOutput{ETag: aws.String("etag")}, nil
+}
+
+func (f *fakeS3BackupClient) CompleteMultipartUpload(_ context.Context, _ *s3.CompleteMultipartUploadInput, _ ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error) {
+	f.completed = true
+	return &s3.CompleteMultipartUploadOutput{}, nil
+}
+
+func (f *fakeS3BackupClient) AbortMultipartUpload(_ context.Context, _ *s3.AbortMultipartUploadInput, _ ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error) {
+	f.aborted = true
+	return &s3.AbortMultipartUploadOutput{}, nil
+}
+
+func sortedKeys(m map[string][]byte) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func extractTarGz(t *testing.T, data []byte) map[string][]byte {

--- a/pkg/instance/minioBackupSource.go
+++ b/pkg/instance/minioBackupSource.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/minio/minio-go/v7"
 	"golang.org/x/sync/errgroup"
 )
 
-func NewMinioBackupSource(logger *slog.Logger, client MinioClient, bucket string) *MinioBackupSource {
-	return &MinioBackupSource{logger, client, bucket}
+func NewMinioBackupSource(logger *slog.Logger, client MinioClient, bucket string, excludePrefixes ...string) *MinioBackupSource {
+	return &MinioBackupSource{logger, client, bucket, excludePrefixes}
 }
 
 // MinioClient defines the methods we need from MinIO client
@@ -22,9 +23,10 @@ type MinioClient interface {
 
 // MinioBackupSource implements BackupSource for MinIO
 type MinioBackupSource struct {
-	logger *slog.Logger
-	client MinioClient
-	bucket string
+	logger          *slog.Logger
+	client          MinioClient
+	bucket          string
+	excludePrefixes []string
 }
 
 // List implements BackupSource interface
@@ -40,6 +42,17 @@ func (m *MinioBackupSource) List(ctx context.Context) (<-chan BackupObject, erro
 		for obj := range objectCh {
 			if obj.Err != nil {
 				return fmt.Errorf("list objects: %v", obj.Err)
+			}
+
+			excluded := false
+			for _, prefix := range m.excludePrefixes {
+				if strings.HasPrefix(obj.Key, prefix) {
+					excluded = true
+					break
+				}
+			}
+			if excluded {
+				continue
 			}
 
 			select {

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -880,7 +880,7 @@ func (s Service) FilestoreBackup(ctx context.Context, instance *model.Deployment
 		return fmt.Errorf("MinIO connection test failed: %v", err)
 	}
 
-	source := NewMinioBackupSource(s.logger, minioClient, "dhis2")
+	source := NewMinioBackupSource(s.logger, minioClient, "dhis2", "apps/")
 	backupService := NewBackupService(s.logger, source, s.s3Client)
 
 	baseName := name


### PR DESCRIPTION
DHIS2 bundles ~30 core apps into MinIO under `apps/` on every startup. These are not user data; DHIS2 regenerates them from the WAR on each boot. Including `apps/` in filestore backups caused the filestore to grow to hundreds of MB across backup/restore cycles: `mc mirror` deposited old app directories alongside fresh ones, DHIS2 logged "Could not find manifest file" errors for any restored directory it did not recognise, then re-bundled all apps under new UIDs, leaving the old directories stranded.

Fix: add `excludePrefixes` support to `MinioBackupSource` and exclude `apps/` from `FilestoreBackup`.

Also fixes two latent bugs in `backupService.go`: pipe writer now calls `CloseWithError` so tar stream errors propagate to the S3 upload goroutine and trigger an abort (previously a clean EOF was sent on error), and `streamToS3WithMultipart` uses a named return so the deferred cleanup actually sees the return error (loop variable shadowing made it always nil). A unit test is added to prove the abort behaviour; the integration test is updated to verify `apps/` is excluded.

Closes DEVOPS-679