### PR TITLE
fix: clear apps/ from MinIO before seeding to prevent accumulation

### DIFF
--- a/stacks/minio/seed-minio.sh
+++ b/stacks/minio/seed-minio.sh
@@ -57,6 +57,7 @@ else
     gunzip -c "$tmp_file" | tar xf - -C "$tmp_dir"
     chmod -R u+rwx,go+rx "$tmp_dir"
 
+    mc rm --recursive --force --quiet local/dhis2/apps/ || true
     mc mirror "$tmp_dir"/ local/dhis2/
 
     echo "Seeded from $FILESTORE_DOWNLOAD_URL" | mc pipe $seed_file


### PR DESCRIPTION
DHIS2 re-bundles its core apps into `apps/<name>_<uid>/` in MinIO on every startup. Because `mc mirror` is additive, old app directories from a previous backup accumulate alongside newly-created ones on each restore cycle, causing the filestore to grow unboundedly (reported at 600MB+).

The fix deletes `apps/` from MinIO before running `mc mirror`, so each restore starts clean. User-installed apps are preserved because they are included in the filestore backup.