### PR TITLE
feat: add generate-env.sh and 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,16 @@
 ENVIRONMENT=dev
-# Can be either "feature", "dev" or "prod"
-CLASSIFICATION=dev
+# Can be either "feature", "dev", "prod" or "local"
+CLASSIFICATION=local
 
 # API_HOSTNAME and UI_URL are computed in .envrc based on CLASSIFICATION
 DEFAULT_TTL=172800
 PASSWORD_TOKEN_TTL=900
 
-CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,https://$UI_URL
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173,$UI_URL
 
 PORT=8080
 
 BASE_PATH=
-
-SMTP_HOST=email-smtp.eu-west-1.amazonaws.com
-SMTP_PORT=587
-SMTP_USERNAME=<smtp-username>
-SMTP_PASSWORD=<smtp-password>
 
 JAEGER_HOST=jaeger
 JAEGER_PORT=14269
@@ -25,9 +20,6 @@ DATABASE_PORT=5432
 DATABASE_USERNAME=instance-manager
 DATABASE_PASSWORD=instance-manager
 DATABASE_NAME=instance-manager
-
-AWS_ACCESS_KEY_ID=<aws-access-key-id>
-AWS_SECRET_ACCESS_KEY=<aws-secret-access-key>
 
 S3_BUCKET=im-databases-$CLASSIFICATION
 S3_REGION=eu-west-1
@@ -52,15 +44,12 @@ INSTANCE_PARAMETER_ENCRYPTION_KEY=this-is-not-secure-please-change
 
 INSTANCE_SERVICE_HOST=im-manager:8080
 
-DOCKER_HUB_USERNAME=<docker-hub-username>
-DOCKER_HUB_PASSWORD=<docker-hub-password>
-
 REDIS_HOST=redis
 REDIS_PORT=6379
 
 # Key needs to be "inlined" with literal newline characters replaced by \n
 # Key can be generated using "make keys"
-#PRIVATE_KEY=""
+PRIVATE_KEY=""
 
 REFRESH_TOKEN_SECRET_KEY=some-secret-key
 
@@ -91,18 +80,40 @@ GROUP_NAMES=whoami
 GROUP_NAMESPACES=whoami
 GROUP_HOSTNAMES=whoami.im.c.127.0.0.1.nip.io
 
-ADMIN_USER_EMAIL=andreas@dhis2.org
+ADMIN_USER_EMAIL=im-admin@dhis2.org
 ADMIN_USER_PASSWORD=somepassword
 
 E2E_TEST_USER_EMAIL=im-e2e-test@dhis2.org
 E2E_TEST_USER_PASSWORD=somepassword
 
-# Google SSO. GOOGLE_CALLBACK_URL must match the redirect URI registered in the Google Cloud Console.
 # SESSION_SECRET is used to sign the short-lived OAuth state cookie; any random string works.
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=http://localhost:8080/auth/google/callback
 SESSION_SECRET=some-session-secret
 
 LOG_PRETTY_PRINT=false
 DATABASE_LOG_QUERIES=false
+
+# ---- Requires manual configuration ----
+
+# Required for image listing - IM authenticates against Docker Hub per-request to fetch available DHIS2 image tags. IM will start without valid credentials but listing images will fail.
+DOCKER_HUB_USERNAME=<docker-hub-username>
+DOCKER_HUB_PASSWORD=<docker-hub-password>
+
+# Optional - needed for sending emails (password reset, user invitations).
+# Without this, email-based flows will fail silently. In practice, this means only the admin user will work and new users would have to be validated manually.
+SMTP_HOST=email-smtp.eu-west-1.amazonaws.com
+SMTP_PORT=587
+SMTP_USERNAME=<smtp-username>
+SMTP_PASSWORD=<smtp-password>
+
+# Optional - needed for seeding instances from S3-hosted database dumps.
+# Local MinIO is used for storage in dev; these are only required when an instance is configured to use S3 for storage.
+AWS_ACCESS_KEY_ID=<aws-access-key-id>
+AWS_SECRET_ACCESS_KEY=<aws-secret-access-key>
+
+# Optional - only needed for Google SSO login. Regular email/password login works without this.
+# Register credentials and the callback URL at https://console.cloud.google.com
+# GOOGLE_CALLBACK_URL must match the redirect URI registered there exactly.
+# For local k3s: http://api.im.127-0-0-1.nip.io/auth/google/callback
+GOOGLE_CLIENT_ID=<google-client-id>
+GOOGLE_CLIENT_SECRET=<google-client-secret>
+GOOGLE_CALLBACK_URL=<google-callback-url>

--- a/README.md
+++ b/README.md
@@ -8,45 +8,29 @@ Instance Manager is a web application that manages the lifecycle of DHIS2 instan
 
 If you just want to see what the application looks like you can find some screenshots [here](./docs/screenshots).
 
-### Start local development environment with Docker
+## Quick start
 
-1. Start by copying the `.env.example` file into a new `.env` file:
+### Prerequisites
+
+We use [direnv](https://direnv.net/) to not just automatically load environment variables from `.env` into the current shell session but also to populate some based on others.
+
+Docker and Docker Compose are also required and so are several other tools which can be installed via `make init`.
+
+### Start local environment with k3s clusters
+
+Generate a `.env` with pre-filled secrets and export it
 
 ```shell
-cp .env.example .env
+scripts/generate-env.sh
 ```
 
-2. Create a private key:
+Make sure `CLASSIFICATION=local` is set
 
-```
-make keys
-```
-
-3. Copy the private key contents, with actual newlines replaced by "\n", into the `PRIVATE_KEY` environment variable
-   within the `.env` file:
-   *This should work on macOS to copy the key contents*
-
-```
-cat rsa_private.pem | awk '{printf "%s\\n", $0}' | pbcopy
+```shell
+direnv allow
 ```
 
-4. Initialize the environment and install dev dependencies:
-
-```
-make init
-```
-
-5. Start a development environment:
-
-```
-make dev
-```
-
-### Start local IM with k3s clusters
-
-Brings up IM together with three in-Docker k3s clusters (`dev`, `test`, `prod`) that IM can deploy DHIS2 instances into, fronted by Traefik.
-
-Set `CLASSIFICATION=local` in `.env`, then with `direnv` active:
+Start a local IM instance with k3s clusters (`dev`, `test`, `prod`)
 
 ```shell
 docker compose up

--- a/docker-compose.k3s.yml
+++ b/docker-compose.k3s.yml
@@ -26,7 +26,7 @@ x-register-env: &k3s-register-env
 
 services:
   im-web-client:
-    image: dhis2/im-web-client:local
+    image: dhis2/im-web-client:latest
     environment:
       API_URL: "http://api.im.127-0-0-1.nip.io"
     profiles: [k3s]

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_COMMANDS=("tr" "head" "fold" "shuf" "sed" "chmod" "cp" "openssl" "awk")
+MISSING_COMMANDS=()
+
+for cmd in "${REQUIRED_COMMANDS[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    MISSING_COMMANDS+=("$cmd")
+  fi
+done
+
+if [ ${#MISSING_COMMANDS[@]} -ne 0 ]; then
+  echo "Error: The following required commands are not available:" >&2
+  printf "  - %s\n" "${MISSING_COMMANDS[@]}" >&2
+  echo "" >&2
+  echo "Please install the missing commands and try again." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT_FILE="$PROJECT_ROOT/.env"
+TEMPLATE_FILE="$PROJECT_ROOT/.env.example"
+
+if [ -f "$OUTPUT_FILE" ]; then
+  echo "Error: A '$OUTPUT_FILE' file already exists." >&2
+  exit 1
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+  echo "Error: Template '$TEMPLATE_FILE' not found!" >&2
+  exit 1
+fi
+
+LENGTH=32
+CHARSET='A-Za-z0-9_=.-'
+
+generate_password() {
+  local password=""
+  password+=$(LC_ALL=C tr -dc '[:upper:]' < /dev/urandom | head -c 1)
+  password+=$(LC_ALL=C tr -dc '[:lower:]' < /dev/urandom | head -c 1)
+  password+=$(LC_ALL=C tr -dc '0-9' < /dev/urandom | head -c 1)
+  password+=$(LC_ALL=C tr -dc '_=.-' < /dev/urandom | head -c 1)
+  local remaining=$((LENGTH - 4))
+  password+=$(LC_ALL=C tr -dc "$CHARSET" < /dev/urandom | head -c "$remaining")
+  echo "$password" | fold -w1 | shuf | tr -d '\n'
+}
+
+DATABASE_PASSWORD=$(generate_password)
+MINIO_ROOT_PASSWORD=$(generate_password)
+MINIO_PASSWORD=$(generate_password)
+INSTANCE_PARAMETER_ENCRYPTION_KEY=$(openssl rand -hex 16)
+REFRESH_TOKEN_SECRET_KEY=$(generate_password)
+SESSION_SECRET=$(generate_password)
+ADMIN_USER_PASSWORD=$(generate_password)
+E2E_TEST_USER_PASSWORD=$(generate_password)
+
+# Detect GNU vs BSD sed
+if sed --version >/dev/null 2>&1; then
+  SED_FLAGS=(-i)
+else
+  SED_FLAGS=(-i '')
+fi
+
+cp "$TEMPLATE_FILE" "$OUTPUT_FILE"
+
+update_env_var() {
+  local key="$1"
+  local value="$2"
+  sed "${SED_FLAGS[@]}" "s|^${key}=.*|${key}=${value}|" "$OUTPUT_FILE"
+}
+
+update_env_var "DATABASE_PASSWORD" "$DATABASE_PASSWORD"
+update_env_var "MINIO_ROOT_PASSWORD" "$MINIO_ROOT_PASSWORD"
+update_env_var "MINIO_PASSWORD" "$MINIO_PASSWORD"
+update_env_var "INSTANCE_PARAMETER_ENCRYPTION_KEY" "$INSTANCE_PARAMETER_ENCRYPTION_KEY"
+update_env_var "REFRESH_TOKEN_SECRET_KEY" "$REFRESH_TOKEN_SECRET_KEY"
+update_env_var "SESSION_SECRET" "$SESSION_SECRET"
+update_env_var "ADMIN_USER_PASSWORD" "$ADMIN_USER_PASSWORD"
+update_env_var "E2E_TEST_USER_PASSWORD" "$E2E_TEST_USER_PASSWORD"
+
+# Generate RSA private key with newlines inlined as \n
+PRIVATE_KEY=$(openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 2>/dev/null | awk '{printf "%s\\n", $0}' | sed 's/\\n$//')
+
+# Populate PRIVATE_KEY — use ENVIRON so awk doesn't interpret \n as a newline
+PRIVATE_KEY="$PRIVATE_KEY" awk '/^PRIVATE_KEY=""/ { print "PRIVATE_KEY=\"" ENVIRON["PRIVATE_KEY"] "\""; next } { print }' "$OUTPUT_FILE" \
+  > "${OUTPUT_FILE}.tmp" && mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+
+chmod u+rw,go-rwx "$OUTPUT_FILE"
+
+# Set ADMIN_USER_EMAIL if provided
+if [ -n "${GEN_ADMIN_USER_EMAIL:-}" ]; then
+  update_env_var "ADMIN_USER_EMAIL" "$GEN_ADMIN_USER_EMAIL"
+fi
+
+# Configure SOPS for local dev if age-keygen is available
+if command -v age-keygen >/dev/null 2>&1; then
+  SOPS_AGE_KEY=$(age-keygen 2>/dev/null | grep '^AGE-SECRET-KEY-')
+  sed "${SED_FLAGS[@]}" "s|^#SOPS_AGE_KEY=|SOPS_AGE_KEY=${SOPS_AGE_KEY}|" "$OUTPUT_FILE"
+  sed "${SED_FLAGS[@]}" "s|^SOPS_KMS_ARN=arn:aws:kms:eu-central-1:767224633206:alias/im-nonprod-secrets|#SOPS_KMS_ARN=arn:aws:kms:eu-central-1:767224633206:alias/im-nonprod-secrets|" "$OUTPUT_FILE"
+fi
+
+echo "A new .env has been generated at $OUTPUT_FILE"
+echo ""
+echo "Generated:"
+echo "  - DATABASE_PASSWORD"
+echo "  - MINIO_ROOT_PASSWORD, MINIO_PASSWORD"
+echo "  - INSTANCE_PARAMETER_ENCRYPTION_KEY"
+echo "  - REFRESH_TOKEN_SECRET_KEY, SESSION_SECRET"
+echo "  - ADMIN_USER_PASSWORD, E2E_TEST_USER_PASSWORD"
+echo "  - PRIVATE_KEY (RSA 2048-bit)"
+if command -v age-keygen >/dev/null 2>&1; then
+  echo "  - SOPS_AGE_KEY (age key; SOPS_KMS_ARN commented out)"
+fi
+echo ""
+echo "Still requires manual configuration:"
+echo "  - SMTP_USERNAME, SMTP_PASSWORD"
+echo "  - AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY"
+echo "  - DOCKER_HUB_USERNAME, DOCKER_HUB_PASSWORD"
+echo "  - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET (if using Google SSO)"
+if ! command -v age-keygen >/dev/null 2>&1; then
+  echo "  - SOPS_AGE_KEY or SOPS_KMS_ARN (age-keygen not found)"
+fi


### PR DESCRIPTION
* Add scripts/generate-env.sh to auto-generate .env with random secrets and an RSA key pair. Restructure .env.example to separate auto-generated values from manual ones (Docker Hub, SMTP, AWS, Google SSO), fix CORS_ALLOWED_ORIGINS to not double-prefix $UI_URL with https://.
* Update README.md with a clean quick-start section.