### PR TITLE
chore: bump default dhis2-core chart version to 0.34.11

### DIFF
--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -306,7 +306,7 @@ var dhis2CoreDefaults = struct {
 	googleAuthClientEmail        string
 	googleAuthClientId           string
 }{
-	chartVersion:                 "0.34.9",
+	chartVersion:                 "0.34.11",
 	storageType:                  minIOStorage,
 	sameSiteCookies:              lax,
 	filesystemVolumeSize:         "8Gi",


### PR DESCRIPTION
Bump the default `dhis2-core` chart version from 0.34.9 to 0.34.11 so new instances pick up the Google Earth Engine private key fix (dhis2-sre/dhis2-core-chart#84).