### PR TITLE
fix: dump DB without --clean [DEVOPS-713]

### DIFF
--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -747,6 +747,10 @@ func newPgDumpConfig(instance *model.DeploymentInstance, stack *model.Stack) (*p
 		return nil, err
 	}
 
+	// Restores target a freshly created, empty database, so replace the
+	// default arguments without the --clean option.
+	dump.Options = []string{"--no-owner", "--no-acl", "--blob"}
+
 	// TODO: This is very DHIS2 specific... More stack meta data?
 	dump.IgnoreTableData = []string{"analytics*", "_*"}
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -297,9 +297,7 @@ definitions:
                 type: integer
                 x-go-name: Expiration
             uuid:
-                format: uuid
-                type: string
-                x-go-name: UUID
+                $ref: '#/definitions/UUID'
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
     FileHeader:
@@ -596,6 +594,15 @@ definitions:
                 x-go-name: Sensitive
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
+    UUID:
+        description: |-
+            A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
+            4122.
+        items:
+            format: uint8
+            type: integer
+        type: array
+        x-go-package: github.com/google/uuid
     UpdateClusterRequest:
         properties:
             KubernetesConfiguration:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -297,7 +297,9 @@ definitions:
                 type: integer
                 x-go-name: Expiration
             uuid:
-                $ref: '#/definitions/UUID'
+                format: uuid
+                type: string
+                x-go-name: UUID
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
     FileHeader:
@@ -594,15 +596,6 @@ definitions:
                 x-go-name: Sensitive
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
-    UUID:
-        description: |-
-            A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
-            4122.
-        items:
-            format: uint8
-            type: integer
-        type: array
-        x-go-package: github.com/google/uuid
     UpdateClusterRequest:
         properties:
             KubernetesConfiguration:


### PR DESCRIPTION
Following up on an older slack discussion where we agreed to remove the --clean argument from the DB dumps.
(https://dhis2.slack.com/archives/C1XTS67ME/p1767794516695879)

Note: the pre-commit checks forced me to commit the Swagger update.