### PR TITLE
fix: use named struct fields in swagger:response for go-swagger v0.34.0 compat

### DIFF
--- a/pkg/database/docs.go
+++ b/pkg/database/docs.go
@@ -92,9 +92,9 @@ type _ struct {
 }
 
 // swagger:response DownloadDatabaseResponse
-type _ struct {
+type DownloadDatabaseBody struct {
 	//in: body
-	_ []byte
+	Body []byte
 }
 
 // swagger:parameters createExternalDownloadDatabase
@@ -106,25 +106,25 @@ type _ struct {
 }
 
 // swagger:response CreateExternalDownloadResponse
-type _ struct {
+type CreateExternalDownloadBody struct {
 	//in: body
-	_ model.ExternalDownload
+	Body model.ExternalDownload
 }
 
 // swagger:response Database
-type _ struct {
+type DatabaseBody struct {
 	//in: body
-	_ model.Database
+	Body model.Database
 }
 
 // swagger:response GroupsWithDatabases
-type _ struct {
+type GroupsWithDatabasesBody struct {
 	//in: body
-	_ GroupsWithDatabases
+	Body GroupsWithDatabases
 }
 
 // swagger:response Lock
-type _ struct {
+type LockBody struct {
 	//in: body
-	_ model.Lock
+	Body model.Lock
 }

--- a/pkg/event/docs.go
+++ b/pkg/event/docs.go
@@ -3,7 +3,7 @@ package event
 import "github.com/gin-contrib/sse"
 
 // swagger:response Stream
-type _ struct {
+type StreamBody struct {
 	// in: body
-	_ sse.Event
+	Body sse.Event
 }

--- a/pkg/group/docs.go
+++ b/pkg/group/docs.go
@@ -51,9 +51,9 @@ type _ struct {
 }
 
 // swagger:response ClusterResources
-type _ struct {
+type ClusterResourcesBody struct {
 	// in: body
-	_ instance.ClusterResources
+	Body instance.ClusterResources
 }
 
 // swagger:parameters addClusterToGroup removeClusterFromGroup

--- a/pkg/health/docs.go
+++ b/pkg/health/docs.go
@@ -1,7 +1,7 @@
 package health
 
 // swagger:response Response
-type _ struct {
+type ResponseBody struct {
 	//in: body
-	_ Response
+	Body Response
 }

--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -48,15 +48,15 @@ type _ struct {
 }
 
 // swagger:response InstanceLogsResponse
-type _ struct {
+type InstanceLogsBody struct {
 	// in: body
-	_ string
+	Body string
 }
 
 // swagger:response Status
-type _ struct {
+type StatusBody struct {
 	// in: body
-	_ InstanceStatus
+	Body InstanceStatus
 }
 
 // swagger:parameters instanceNameToId
@@ -71,22 +71,22 @@ type _ struct {
 }
 
 // swagger:response Error
-type _ struct {
+type ErrorBody struct {
 	// The error message
 	// in: body
 	Message string
 }
 
 // swagger:response GroupsWithDeployments
-type _ struct {
+type GroupsWithDeploymentsBody struct {
 	// in: body
-	_ []GroupWithDeployments
+	Body []GroupWithDeployments
 }
 
 // swagger:response GroupsWithPublicInstances
-type _ struct {
+type GroupsWithPublicInstancesBody struct {
 	// in: body
-	_ []GroupWithPublicInstances
+	Body []GroupWithPublicInstances
 }
 
 // swagger:parameters saveDeployment
@@ -106,9 +106,9 @@ type _ struct {
 }
 
 // swagger:response DeploymentInstance
-type _ struct {
+type DeploymentInstanceBody struct {
 	// in: body
-	_ model.DeploymentInstance
+	Body model.DeploymentInstance
 }
 
 // swagger:parameters updateInstance

--- a/pkg/integration/docs.go
+++ b/pkg/integration/docs.go
@@ -12,9 +12,9 @@ type _ struct {
 type Response struct{}
 
 // swagger:response Response
-type _ struct {
+type ResponseBody struct {
 	// in: body
-	_ Response
+	Body Response
 }
 
 // swagger:parameters imageExists

--- a/pkg/notification/docs.go
+++ b/pkg/notification/docs.go
@@ -5,9 +5,9 @@ import (
 )
 
 // swagger:response Notification
-type _ struct {
+type NotificationBody struct {
 	// in: body
-	_ []model.Notification
+	Body []model.Notification
 }
 
 // swagger:parameters markNotificationRead

--- a/pkg/stack/docs.go
+++ b/pkg/stack/docs.go
@@ -8,13 +8,13 @@ type _ struct {
 }
 
 // swagger:response Stack
-type _ struct {
+type StackBody struct {
 	//in: body
-	_ Stack
+	Body Stack
 }
 
 // swagger:response Stacks
-type _ struct {
+type StacksBody struct {
 	//in: body
-	_ []Stack
+	Body []Stack
 }

--- a/pkg/user/docs.go
+++ b/pkg/user/docs.go
@@ -52,10 +52,10 @@ type _ struct {
 }
 
 // swagger:response UsersResponse
-type _ struct {
+type UsersResponseBody struct {
 	// Users list response
 	//in: body
-	_ *[]model.User
+	Body *[]model.User
 }
 
 // swagger:parameters updateUser


### PR DESCRIPTION
go-swagger v0.34.0 no longer picks up blank-identifier body fields (`_ TypeName`) in `swagger:response` structs, causing the pre-commit swagger validation hook to fail in CI. Converted all affected docs.go files to use named structs with a `Body` field, matching the pattern already used by the working `Clusters` response.