### PR TITLE
docs: drop v prefix from release tag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Example
 
 ```shell
 git tag --sort=-creatordate | head --lines=1              # Get the latest tag
-git tag v0.53.0                                           # Use whichever tag you want to release
+git tag 0.53.0                                            # Use whichever tag you want to release
 make change-log
 git commit CHANGELOG.md -m "chore: generate change log"
 git push


### PR DESCRIPTION
Update the README release example to the bare tag scheme (no v prefix), matching the already-merged workflow changes and dhis2-sre/gha-workflows#112.