### PR TITLE
fix: gate save-as on instance group instead of source database row

### DIFF
--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -181,27 +181,14 @@ func (h Handler) SaveAs(c *gin.Context) {
 		return
 	}
 
-	parameter := "DATABASE_ID"
-	databaseId, exists := instance.Parameters[parameter]
-	if !exists {
-		_ = c.Error(fmt.Errorf("parameter %q not found", parameter))
-	}
-
-	database, err := h.databaseService.FindByIdentifier(ctx, databaseId.Value)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-
-	err = h.canAccess(c, database)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-
 	user, err := handler.GetUserFromContext(ctx)
 	if err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	if !handler.CanAccessGroup(user, instance.GroupName) {
+		_ = c.Error(errdef.NewForbidden("access denied"))
 		return
 	}
 


### PR DESCRIPTION
Saving the tracker-config instance failed with a 404: `database not found by id: 439`. The save-as handler looked up the instance's `DATABASE_ID` (439) purely to run a permission check, but that database row had been deleted, so the whole request 404'd even though the data to copy lives in the running pod.

Save-as dumps from the running instance pod via pg_dump and writes a brand new database row; it never reads the source row. The only use of the source row was the access check. This changes the gate to `CanAccessGroup(user, instance.GroupName)`, which has identical permission semantics (the source database lives in the instance's group) but no longer breaks when `DATABASE_ID` points at a deleted row.

Note: the regular Save handler still legitimately uses the source row and is unchanged. The underlying cause of the orphaned `DATABASE_ID` (a database deleted while its instance lives on) is left for a follow-up.