### PR TITLE
fix: return not found instead of panicking when required instance is missing

### DIFF
--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -365,7 +365,7 @@ func resolveConsumedParameters(deployment *model.Deployment, instance *model.Dep
 			// consume from instance parameters
 			sourceInstance := findInstanceByStackName(requiredStack.Name, deployment)
 			if sourceInstance == nil {
-				return errdef.NewNotFound("failed to find required instance %q of instance %q", sourceInstance.Name, instance.Name)
+				return errdef.NewNotFound("failed to find required instance %q of instance %q", requiredStack.Name, instance.Name)
 			}
 
 			if sourceInstanceParameter, ok := sourceInstance.Parameters[name]; ok {

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -132,6 +132,40 @@ func TestResolveParameters(t *testing.T) {
 		assert.ElementsMatch(t, want, deployment.Instances)
 	})
 
+	t.Run("RequiredInstanceNotInDeployment", func(t *testing.T) {
+		stackA := model.Stack{
+			Name: "stack-a",
+		}
+		stackB := model.Stack{
+			Name: "stack-b",
+			Parameters: map[string]model.StackParameter{
+				"parameter": {
+					Consumed: true,
+				},
+			},
+			Requires: []model.Stack{stackA},
+		}
+		stacks := stack.Stacks{
+			"stack-a": stackA,
+			"stack-b": stackB,
+		}
+		stackService := stack.NewService(stacks)
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", nil)
+		deployment := &model.Deployment{
+			Instances: []*model.DeploymentInstance{
+				{
+					Name:       "name-b",
+					StackName:  "stack-b",
+					Parameters: map[string]model.DeploymentInstanceParameter{},
+				},
+			},
+		}
+
+		err := service.resolveParameters(deployment)
+
+		require.ErrorContains(t, err, `failed to find required instance "stack-a" of instance "name-b"`)
+	})
+
 	t.Run("ResolveParameterUsingProvider", func(t *testing.T) {
 		stackA := model.Stack{
 			Name: "stack-a",


### PR DESCRIPTION
resolveConsumedParameters dereferenced sourceInstance.Name right after confirming sourceInstance is nil, so deploying an instance whose stack requires a stack not present in the deployment panicked instead of returning 404. Use requiredStack.Name in the error message and add a regression test.