### PR TITLE
fix: scope refresh token sign-out to the exact user id

### DIFF
--- a/pkg/token/repository.go
+++ b/pkg/token/repository.go
@@ -43,7 +43,7 @@ func (r redisTokenRepository) DeleteRefreshToken(userId uint, previousTokenId st
 }
 
 func (r redisTokenRepository) DeleteRefreshTokens(userId uint) error {
-	pattern := fmt.Sprintf("%d*", userId)
+	pattern := fmt.Sprintf("%d:*", userId)
 
 	iterator := r.redis.Scan(0, pattern, 5).Iterator()
 	failCount := 0
@@ -55,11 +55,11 @@ func (r redisTokenRepository) DeleteRefreshTokens(userId uint) error {
 	}
 
 	if err := iterator.Err(); err != nil {
-		return fmt.Errorf("failed to delete refresh token: %s", iterator.Val())
+		return fmt.Errorf("failed to scan refresh tokens for userId %d: %s", userId, err)
 	}
 
 	if failCount > 0 {
-		return fmt.Errorf("failed to delete refresh token: %s", iterator.Val())
+		return fmt.Errorf("failed to delete %d refresh tokens for userId %d", failCount, userId)
 	}
 
 	return nil

--- a/pkg/token/repository_integration_test.go
+++ b/pkg/token/repository_integration_test.go
@@ -1,0 +1,23 @@
+package token_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dhis2-sre/im-manager/pkg/inttest"
+	"github.com/dhis2-sre/im-manager/pkg/token"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteRefreshTokensOnlyDeletesTokensOfGivenUser(t *testing.T) {
+	redis := inttest.SetupRedis(t)
+	repository := token.NewRepository(redis)
+
+	require.NoError(t, repository.SetRefreshToken(1, "token-user-1", time.Minute))
+	require.NoError(t, repository.SetRefreshToken(10, "token-user-10", time.Minute))
+
+	require.NoError(t, repository.DeleteRefreshTokens(1))
+
+	require.Error(t, repository.DeleteRefreshToken(1, "token-user-1"), "user 1's refresh token should have been deleted")
+	require.NoError(t, repository.DeleteRefreshToken(10, "token-user-10"), "user 10's refresh token should still exist")
+}


### PR DESCRIPTION
DeleteRefreshTokens scanned Redis with the pattern userId* but keys are stored as userId:tokenId, so signing out user 1 also deleted the refresh tokens of users 10, 11, 123 and so on, forcing them to log in again. Scope the pattern to userId:* and report the actual error instead of the last scanned key. Adds an integration test verifying another user's token survives a sign-out.