### PR TITLE
fix: close S3 object body after download

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -153,6 +153,7 @@ func (s S3Client) Download(ctx context.Context, bucket string, key string, dst i
 		}
 		return fmt.Errorf("error downloading object from bucket %q using key %q: %s", bucket, key, err)
 	}
+	defer object.Body.Close()
 
 	cb(*object.ContentLength)
 


### PR DESCRIPTION
Download retrieved the S3 GetObject response but never closed object.Body, leaking the underlying HTTP connection and file descriptor on every database download. Under sustained traffic this exhausts file descriptors and the process starts failing with too many open files.