### PR TITLE
fix: surface MinIO listing errors from backup source

### DIFF
--- a/pkg/instance/minioBackupSource.go
+++ b/pkg/instance/minioBackupSource.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 
 	"github.com/minio/minio-go/v7"
-	"golang.org/x/sync/errgroup"
 )
 
 func NewMinioBackupSource(logger *slog.Logger, client MinioClient, bucket string) *MinioBackupSource {
@@ -30,27 +29,28 @@ type MinioBackupSource struct {
 // List implements BackupSource interface
 func (m *MinioBackupSource) List(ctx context.Context) (<-chan BackupObject, error) {
 	ch := make(chan BackupObject)
-	g, ctx := errgroup.WithContext(ctx)
 
-	g.Go(func() error {
+	go func() {
 		defer close(ch)
 
 		objectCh := m.client.ListObjects(ctx, m.bucket, minio.ListObjectsOptions{Recursive: true})
 
 		for obj := range objectCh {
 			if obj.Err != nil {
-				return fmt.Errorf("list objects: %v", obj.Err)
+				select {
+				case <-ctx.Done():
+				case ch <- BackupObject{Err: fmt.Errorf("list objects: %v", obj.Err)}:
+				}
+				return
 			}
 
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return
 			case ch <- BackupObject{Path: obj.Key, Size: obj.Size, LastModified: obj.LastModified}:
 			}
 		}
-
-		return nil
-	})
+	}()
 
 	return ch, nil
 }

--- a/pkg/instance/minioBackupSource_test.go
+++ b/pkg/instance/minioBackupSource_test.go
@@ -1,0 +1,54 @@
+package instance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMinioClient struct {
+	objects []minio.ObjectInfo
+}
+
+func (f fakeMinioClient) ListObjects(ctx context.Context, bucketName string, opts minio.ListObjectsOptions) <-chan minio.ObjectInfo {
+	ch := make(chan minio.ObjectInfo, len(f.objects))
+	for _, obj := range f.objects {
+		ch <- obj
+	}
+	close(ch)
+	return ch
+}
+
+func (f fakeMinioClient) GetObject(ctx context.Context, bucketName, objectName string, opts minio.GetObjectOptions) (*minio.Object, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestMinioBackupSourceListSurfacesListingError(t *testing.T) {
+	client := fakeMinioClient{
+		objects: []minio.ObjectInfo{
+			{Key: "apps/app1/manifest.json"},
+			{Err: errors.New("connection reset")},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	source := NewMinioBackupSource(logger, client, "dhis2")
+
+	ch, err := source.List(context.Background())
+	require.NoError(t, err)
+
+	var received []BackupObject
+	for obj := range ch {
+		received = append(received, obj)
+	}
+
+	require.Len(t, received, 2)
+	assert.Equal(t, "apps/app1/manifest.json", received[0].Path)
+	require.Error(t, received[1].Err)
+	assert.ErrorContains(t, received[1].Err, "connection reset")
+}


### PR DESCRIPTION
MinioBackupSource.List started an errgroup goroutine but discarded the group without ever calling Wait, so a ListObjects failure mid-stream was silently dropped: the channel just closed and the backup proceeded as if the listing had completed, producing a backup that is missing objects with no error reported. BackupService already checks BackupObject.Err on every item it reads from the channel, so the fix sends the listing error through the channel via that existing field instead of returning it from an unawaited goroutine. Adds a unit test with a fake MinioClient that fails mid-listing.