### PR TITLE
fix: delete minio PVC when its instance is destroyed

### DIFF
--- a/pkg/instance/kubernetes.go
+++ b/pkg/instance/kubernetes.go
@@ -442,6 +442,7 @@ func (ks kubernetesService) deletePersistentVolumeClaim(instance *model.Deployme
 		"dhis2":      {"app.kubernetes.io/instance=%s-database", "app.kubernetes.io/instance=%s-redis"},
 		"dhis2-core": {"app.kubernetes.io/instance=%s", "app.kubernetes.io/instance=%s-minio"},
 		"dhis2-db":   {"app.kubernetes.io/instance=%s-database"},
+		"minio":      {"app.kubernetes.io/instance=%s-minio"},
 	}
 
 	labelPatterns := labelMap[instance.StackName]

--- a/pkg/instance/kubernetes_test.go
+++ b/pkg/instance/kubernetes_test.go
@@ -53,6 +53,13 @@ func TestDeletePersistentVolumeClaim(t *testing.T) {
 			wantDeleted: 2,
 		},
 		{
+			stack: "minio",
+			pvcs: []*v1.PersistentVolumeClaim{
+				labeledPVC(namespace, "data-minio-0", uniqueName+"-minio"),
+			},
+			wantDeleted: 1,
+		},
+		{
 			stack:       "whoami-go",
 			pvcs:        nil,
 			wantDeleted: 0,


### PR DESCRIPTION
The PVC cleanup label map in deletePersistentVolumeClaim had no entry for the minio stack, so destroying a minio instance on its own never deleted its PVC. That leaked the underlying cloud volume every time, which is how we ended up with 31 orphaned Hetzner volumes (550 GB) and eventually hit the account's volume limit, causing new instances to get stuck Pending. This adds the missing minio entry and a test case covering it.