### PR TITLE
refactor: move Stack out of pkg/model into pkg/stack

### DIFF
--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/instance"
 	"github.com/dhis2-sre/im-manager/pkg/inttest"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"github.com/dhis2-sre/im-manager/pkg/storage"
 	userpkg "github.com/dhis2-sre/im-manager/pkg/user"
 	"github.com/gin-gonic/gin"
@@ -348,7 +349,7 @@ func TestSaveLockedUnlocksOnDumpFailure(t *testing.T) {
 	require.False(t, wasLocked)
 
 	// The instance has no database parameters, so the dump fails before touching pods or S3.
-	_, err = databaseService.SaveLocked(ctx, locked, instance, &model.Stack{}, wasLocked)
+	_, err = databaseService.SaveLocked(ctx, locked, instance, &stack.Stack{}, wasLocked)
 	require.Error(t, err)
 
 	reloaded, err := databaseService.FindById(ctx, locked.ID)
@@ -407,7 +408,7 @@ func (is instanceService) UpdateInstanceParameters(ctx context.Context, deployme
 
 type stackService struct{}
 
-func (ss stackService) Find(name string) (*model.Stack, error) {
+func (ss stackService) Find(name string) (*stack.Stack, error) {
 	return nil, nil
 }
 

--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dhis2-sre/im-manager/internal/handler"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -45,12 +46,12 @@ type instanceService interface {
 }
 
 type stackService interface {
-	Find(name string) (*model.Stack, error)
+	Find(name string) (*stack.Stack, error)
 }
 
 type deploymentService interface {
-	SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error)
-	Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance) error
+	SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error)
+	Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance) error
 }
 
 // Upload database

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"github.com/dhis2-sre/im-manager/pkg/storage"
 
 	pg "github.com/habx/pg-commands"
@@ -453,7 +454,7 @@ func (s Service) EnsureLocked(ctx context.Context, database *model.Database, ins
 // SaveLocked overwrites the given locked database with a fresh dump from the instance: it dumps
 // into a temporary record, moves the dump over the original in S3 and re-points the record to the
 // original name and id. It blocks until done and returns the finalized record.
-func (s Service) SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, wasLocked bool) (*model.Database, error) {
+func (s Service) SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, wasLocked bool) (*model.Database, error) {
 	if !wasLocked {
 		defer func() {
 			err := s.repository.Unlock(ctx, database.ID)
@@ -562,7 +563,7 @@ func (s Service) CreateDatabase(ctx context.Context, userId uint, groupName, nam
 // Dump streams a pg_dump of the instance's database into S3 and updates the given record with the
 // resulting url and size. It blocks until the dump completes and publishes database-save events
 // along the way.
-func (s Service) Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, format string) (*model.Database, error) {
+func (s Service) Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, format string) (*model.Database, error) {
 	publish := func(status, errMsg string, size int64) {
 		s.publisher.Publish(ctx, userId, database.GroupName, kindDatabaseSave, newDatabaseEvent(database, status, errMsg, size))
 	}
@@ -672,7 +673,7 @@ func (s Service) logError(ctx context.Context, err error) {
 	s.logger.ErrorContext(ctx, "Failed to SaveAs DB", "error", err)
 }
 
-func newPgDumpConfig(instance *model.DeploymentInstance, stack *model.Stack) (*pg.Dump, error) {
+func newPgDumpConfig(instance *model.DeploymentInstance, stack *stack.Stack) (*pg.Dump, error) {
 	errorMessage := "can't find parameter: %s"
 
 	databaseName, exists := instance.Parameters["DATABASE_NAME"]

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dhis2-sre/im-manager/pkg/instance"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"github.com/dhis2-sre/im-manager/pkg/token"
 )
 
@@ -36,9 +37,9 @@ type databaseService interface {
 	FindById(ctx context.Context, id uint) (*model.Database, error)
 	CreateExternalDownload(ctx context.Context, databaseID uint, expiration uint) (*model.ExternalDownload, error)
 	CreateDatabase(ctx context.Context, userId uint, groupName, name string) (*model.Database, error)
-	Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, format string) (*model.Database, error)
+	Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, format string) (*model.Database, error)
 	EnsureLocked(ctx context.Context, database *model.Database, instanceId, userId uint) (*model.Database, bool, error)
-	SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, wasLocked bool) (*model.Database, error)
+	SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, wasLocked bool) (*model.Database, error)
 }
 
 // Publisher publishes notifications for async cross-service operations.
@@ -157,7 +158,7 @@ func findInstanceById(instances []*model.DeploymentInstance, id uint) (*model.De
 
 // SaveAs dumps the instance's database into a new record. The record is returned right away
 // while the dump and the filestore backup of the dhis2-core sibling run in the background.
-func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error) {
+func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error) {
 	created, err := s.databaseService.CreateDatabase(ctx, userId, instance.GroupName, name)
 	if err != nil {
 		return nil, err
@@ -179,7 +180,7 @@ func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.Deploy
 
 // Save overwrites the instance's source database with a fresh dump. The lock check runs before
 // returning; the dump, finalization and filestore backup run in the background.
-func (s Service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, coreInstance *model.DeploymentInstance) error {
+func (s Service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance) error {
 	locked, wasLocked, err := s.databaseService.EnsureLocked(ctx, database, instance.ID, userId)
 	if err != nil {
 		return err

--- a/pkg/deployment/service_test.go
+++ b/pkg/deployment/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 )
 
 // fakeDatabaseService resolves database records by id and mints deterministic download links.
@@ -33,7 +34,7 @@ func (f fakeDatabaseService) CreateDatabase(ctx context.Context, userId uint, gr
 	panic("not used")
 }
 
-func (f fakeDatabaseService) Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, format string) (*model.Database, error) {
+func (f fakeDatabaseService) Dump(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, format string) (*model.Database, error) {
 	panic("not used")
 }
 
@@ -41,7 +42,7 @@ func (f fakeDatabaseService) EnsureLocked(ctx context.Context, database *model.D
 	panic("not used")
 }
 
-func (f fakeDatabaseService) SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *model.Stack, wasLocked bool) (*model.Database, error) {
+func (f fakeDatabaseService) SaveLocked(ctx context.Context, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, wasLocked bool) (*model.Database, error) {
 	panic("not used")
 }
 

--- a/pkg/instance/helmfile.go
+++ b/pkg/instance/helmfile.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 )
 
 //goland:noinspection GoExportedFuncWithUnexportedType
@@ -57,7 +58,7 @@ type helmfileService struct {
 }
 
 type stackService interface {
-	Find(name string) (*model.Stack, error)
+	Find(name string) (*stack.Stack, error)
 }
 
 func (h helmfileService) sync(ctx context.Context, token string, instance *model.DeploymentInstance, group *model.Group, ttl uint, extraEnv map[string]string) (*exec.Cmd, error) {

--- a/pkg/instance/repository.go
+++ b/pkg/instance/repository.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"gorm.io/gorm"
 )
 
@@ -115,7 +116,7 @@ func (r repository) FindDeploymentInstanceById(ctx context.Context, id uint) (*m
 	return instance, nil
 }
 
-func (r repository) DecryptDeploymentInstance(deploymentInstance *model.DeploymentInstance, stack *model.Stack) (*model.DeploymentInstance, error) {
+func (r repository) DecryptDeploymentInstance(deploymentInstance *model.DeploymentInstance, stack *stack.Stack) (*model.DeploymentInstance, error) {
 	err := decryptParameters(r.instanceParameterEncryptionKey, deploymentInstance, stack)
 	if err != nil {
 		return nil, err
@@ -124,7 +125,7 @@ func (r repository) DecryptDeploymentInstance(deploymentInstance *model.Deployme
 	return deploymentInstance, nil
 }
 
-func (r repository) DecryptDeployment(deployment *model.Deployment, stacksByName map[string]*model.Stack) (*model.Deployment, error) {
+func (r repository) DecryptDeployment(deployment *model.Deployment, stacksByName map[string]*stack.Stack) (*model.Deployment, error) {
 	for _, instance := range deployment.Instances {
 		err := decryptParameters(r.instanceParameterEncryptionKey, instance, stacksByName[instance.StackName])
 		if err != nil {
@@ -135,7 +136,7 @@ func (r repository) DecryptDeployment(deployment *model.Deployment, stacksByName
 	return deployment, nil
 }
 
-func (r repository) SaveInstance(ctx context.Context, instance *model.DeploymentInstance, stack *model.Stack) error {
+func (r repository) SaveInstance(ctx context.Context, instance *model.DeploymentInstance, stack *stack.Stack) error {
 	// only use ctx for values (logging) and not cancellation signals on cud operations for now. ctx
 	// cancellation can lead to rollbacks which we should decide individually.
 	ctx = context.WithoutCancel(ctx)
@@ -243,7 +244,7 @@ func (r repository) FindAllDeployments(ctx context.Context) ([]model.Deployment,
 	return deployments, err
 }
 
-func encryptParameters(key string, instance *model.DeploymentInstance, stack *model.Stack) error {
+func encryptParameters(key string, instance *model.DeploymentInstance, stack *stack.Stack) error {
 	for i, parameter := range instance.Parameters {
 		if !stack.Parameters[parameter.ParameterName].Sensitive {
 			continue
@@ -259,7 +260,7 @@ func encryptParameters(key string, instance *model.DeploymentInstance, stack *mo
 	return nil
 }
 
-func decryptParameters(key string, instance *model.DeploymentInstance, stack *model.Stack) error {
+func decryptParameters(key string, instance *model.DeploymentInstance, stack *stack.Stack) error {
 	for i, parameter := range instance.Parameters {
 		if !stack.Parameters[parameter.ParameterName].Sensitive {
 			continue

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -127,7 +127,7 @@ func (s Service) FindDecryptedDeploymentById(ctx context.Context, id uint) (*mod
 }
 
 func (s Service) decryptDeployment(deployment *model.Deployment) (*model.Deployment, error) {
-	var stacksByName = map[string]*model.Stack{}
+	var stacksByName = map[string]*stack.Stack{}
 	for _, instance := range deployment.Instances {
 		stack, err := s.stackService.Find(instance.StackName)
 		if err != nil {
@@ -331,7 +331,7 @@ func (s Service) resolveParameters(deployment *model.Deployment) error {
 	return nil
 }
 
-func validateParameters(instanceParameters model.DeploymentInstanceParameters, stack *model.Stack) error {
+func validateParameters(instanceParameters model.DeploymentInstanceParameters, stack *stack.Stack) error {
 	var errs []error
 	for name, parameter := range instanceParameters {
 		stackParameter := stack.Parameters[name]
@@ -345,7 +345,7 @@ func validateParameters(instanceParameters model.DeploymentInstanceParameters, s
 	return errors.Join(errs...)
 }
 
-func resolveConsumedParameters(deployment *model.Deployment, instance *model.DeploymentInstance, stack *model.Stack) error {
+func resolveConsumedParameters(deployment *model.Deployment, instance *model.DeploymentInstance, stack *stack.Stack) error {
 	for name, parameter := range instance.Parameters {
 		stackParameter := stack.Parameters[name]
 		if !stackParameter.Consumed {
@@ -388,7 +388,7 @@ func findInstanceByStackName(name string, deployment *model.Deployment) *model.D
 	return nil
 }
 
-func rejectNonExistingParameters(instanceParameters model.DeploymentInstanceParameters, stack *model.Stack) error {
+func rejectNonExistingParameters(instanceParameters model.DeploymentInstanceParameters, stack *stack.Stack) error {
 	var errs []error
 	for name := range instanceParameters {
 		if _, ok := stack.Parameters[name]; !ok {
@@ -398,7 +398,7 @@ func rejectNonExistingParameters(instanceParameters model.DeploymentInstancePara
 	return errors.Join(errs...)
 }
 
-func addDefaultParameterValues(instanceParameters model.DeploymentInstanceParameters, stack *model.Stack) {
+func addDefaultParameterValues(instanceParameters model.DeploymentInstanceParameters, stack *stack.Stack) {
 	for name, stackParameter := range stack.Parameters {
 		if _, ok := instanceParameters[name]; !ok {
 			instanceParameter := model.DeploymentInstanceParameter{
@@ -614,18 +614,18 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 		return err
 	}
 
-	stack, err := s.stackService.Find(instance.StackName)
+	instanceStack, err := s.stackService.Find(instance.StackName)
 	if err != nil {
 		return err
 	}
 
-	switch stack.KubernetesResource {
-	case model.StatefulSetResource:
+	switch instanceStack.KubernetesResource {
+	case stack.StatefulSetResource:
 		return ks.RestartStatefulSet(instance, typeSelector)
-	case model.DeploymentResource:
+	case stack.DeploymentResource:
 		return ks.RestartDeployment(instance, typeSelector)
 	default:
-		return fmt.Errorf("kubernetes resource not supported: %s", stack.KubernetesResource)
+		return fmt.Errorf("kubernetes resource not supported: %s", instanceStack.KubernetesResource)
 	}
 }
 

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestResolveParameters(t *testing.T) {
 	t.Run("PreventUserFromOverwritingConsumedParameters", func(t *testing.T) {
-		s := model.Stack{
+		s := stack.Stack{
 			Name: "stack",
-			Parameters: map[string]model.StackParameter{
+			Parameters: map[string]stack.StackParameter{
 				"parameter": {
 					Consumed: true,
 				},
@@ -42,9 +42,9 @@ func TestResolveParameters(t *testing.T) {
 	})
 
 	t.Run("RejectNonExistingParameter", func(t *testing.T) {
-		s := model.Stack{
+		s := stack.Stack{
 			Name:       "name-a",
-			Parameters: map[string]model.StackParameter{},
+			Parameters: map[string]stack.StackParameter{},
 		}
 		stacks := stack.Stacks{
 			"name-a": s,
@@ -72,9 +72,9 @@ func TestResolveParameters(t *testing.T) {
 	t.Run("ResolveParameters", func(t *testing.T) {
 		defaultValue1 := "default value used"
 		defaultValue2 := "default value not user"
-		stackA := model.Stack{
+		stackA := stack.Stack{
 			Name: "stack-a",
-			Parameters: map[string]model.StackParameter{
+			Parameters: map[string]stack.StackParameter{
 				"parameter-a": {
 					DefaultValue: &defaultValue1,
 				},
@@ -133,17 +133,17 @@ func TestResolveParameters(t *testing.T) {
 	})
 
 	t.Run("RequiredInstanceNotInDeployment", func(t *testing.T) {
-		stackA := model.Stack{
+		stackA := stack.Stack{
 			Name: "stack-a",
 		}
-		stackB := model.Stack{
+		stackB := stack.Stack{
 			Name: "stack-b",
-			Parameters: map[string]model.StackParameter{
+			Parameters: map[string]stack.StackParameter{
 				"parameter": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{stackA},
+			Requires: []stack.Stack{stackA},
 		}
 		stacks := stack.Stacks{
 			"stack-a": stackA,
@@ -167,22 +167,22 @@ func TestResolveParameters(t *testing.T) {
 	})
 
 	t.Run("ResolveParameterUsingProvider", func(t *testing.T) {
-		stackA := model.Stack{
+		stackA := stack.Stack{
 			Name: "stack-a",
-			ParameterProviders: model.ParameterProviders{
-				"provider-parameter": model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+			ParameterProviders: stack.ParameterProviders{
+				"provider-parameter": stack.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 					return fmt.Sprintf("%s-%s", instance.Name, instance.GroupName), nil
 				}),
 			},
 		}
-		stackB := model.Stack{
+		stackB := stack.Stack{
 			Name: "stack-b",
-			Parameters: map[string]model.StackParameter{
+			Parameters: map[string]stack.StackParameter{
 				"provider-parameter": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{stackA},
+			Requires: []stack.Stack{stackA},
 		}
 		stacks := stack.Stacks{
 			"stack-a": stackA,

--- a/pkg/stack/chap.go
+++ b/pkg/stack/chap.go
@@ -7,27 +7,27 @@ import (
 )
 
 // Stack representing ../../stacks/chap-db/helmfile.yaml.gotmpl
-var ChapDB = model.Stack{
+var ChapDB = Stack{
 	Name: "chap-db",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"DATABASE_SIZE":     {Priority: 1, DisplayName: "Database Size", DefaultValue: &chapDBDefaults.dbSize},
 		"DATABASE_NAME":     {Priority: 2, DisplayName: "Database Name", DefaultValue: &chapDBDefaults.dbName},
 		"DATABASE_PASSWORD": {Priority: 3, DisplayName: "Database Password", DefaultValue: &chapDBDefaults.dbPassword, Sensitive: true},
 		"DATABASE_VERSION":  {Priority: 4, DisplayName: "Database Version", DefaultValue: &chapDBDefaults.dbVersion},
 		"CHART_VERSION":     {Priority: 5, DisplayName: "Chart Version", DefaultValue: &chapDBDefaults.chartVersion},
 	},
-	ParameterProviders: model.ParameterProviders{
+	ParameterProviders: ParameterProviders{
 		"DATABASE_HOSTNAME": chapDBHostnameProvider,
 		"DATABASE_SECRET":   chapDBSecretProvider,
 	},
-	KubernetesResource: model.StatefulSetResource,
+	KubernetesResource: StatefulSetResource,
 }
 
-var chapDBHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var chapDBHostnameProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-%d-chap-db-postgres-rw.%s.svc", instance.Name, instance.Group.ID, instance.Group.Namespace), nil
 })
 
-var chapDBSecretProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var chapDBSecretProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-%d-chap-db-postgres", instance.Name, instance.Group.ID), nil
 })
 
@@ -46,25 +46,25 @@ var chapDBDefaults = struct {
 }
 
 // Stack representing ../../stacks/chap-valkey/helmfile.yaml.gotmpl
-var ChapValkey = model.Stack{
+var ChapValkey = Stack{
 	Name: "chap-valkey",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"REDIS_STORAGE_SIZE": {Priority: 1, DisplayName: "Redis Storage Size", DefaultValue: &chapValkeyDefaults.storageSize},
 		"REDIS_PASSWORD":     {Priority: 2, DisplayName: "Redis Password", DefaultValue: &chapValkeyDefaults.password, Sensitive: true},
 		"CHART_VERSION":      {Priority: 3, DisplayName: "Chart Version", DefaultValue: &chapValkeyDefaults.chartVersion},
 	},
-	ParameterProviders: model.ParameterProviders{
+	ParameterProviders: ParameterProviders{
 		"REDIS_HOST":   chapValkeyHostnameProvider,
 		"REDIS_SECRET": chapValkeySecretProvider,
 	},
-	KubernetesResource: model.StatefulSetResource,
+	KubernetesResource: StatefulSetResource,
 }
 
-var chapValkeyHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var chapValkeyHostnameProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-%d-chap-valkey.%s.svc", instance.Name, instance.Group.ID, instance.Group.Namespace), nil
 })
 
-var chapValkeySecretProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var chapValkeySecretProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-%d-chap-valkey-auth", instance.Name, instance.Group.ID), nil
 })
 
@@ -79,9 +79,9 @@ var chapValkeyDefaults = struct {
 }
 
 // Stack representing ../../stacks/chap-worker/helmfile.yaml.gotmpl
-var ChapWorker = model.Stack{
+var ChapWorker = Stack{
 	Name: "chap-worker",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"IMAGE_TAG":         {Priority: 1, DisplayName: "Image Tag", DefaultValue: &chapWorkerDefaults.imageTag},
 		"IMAGE_PULL_POLICY": {Priority: 2, DisplayName: "Image Pull Policy", DefaultValue: &chapWorkerDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"CHART_VERSION":     {Priority: 3, DisplayName: "Chart Version", DefaultValue: &chapWorkerDefaults.chartVersion},
@@ -91,8 +91,8 @@ var ChapWorker = model.Stack{
 		"REDIS_HOST":        {Priority: 0, DisplayName: "Redis Host", Consumed: true},
 		"REDIS_SECRET":      {Priority: 0, DisplayName: "Redis Secret", Consumed: true},
 	},
-	Requires:           []model.Stack{ChapDB, ChapValkey},
-	KubernetesResource: model.DeploymentResource,
+	Requires:           []Stack{ChapDB, ChapValkey},
+	KubernetesResource: DeploymentResource,
 }
 
 var chapWorkerDefaults = struct {
@@ -106,9 +106,9 @@ var chapWorkerDefaults = struct {
 }
 
 // Stack representing ../../stacks/chap-core/helmfile.yaml.gotmpl
-var ChapCore = model.Stack{
+var ChapCore = Stack{
 	Name: "chap-core",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"IMAGE_TAG":                          {Priority: 1, DisplayName: "Image Tag", DefaultValue: &chapCoreDefaults.imageTag},
 		"IMAGE_PULL_POLICY":                  {Priority: 2, DisplayName: "Image Pull Policy", DefaultValue: &chapCoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"CHART_VERSION":                      {Priority: 3, DisplayName: "Chart Version", DefaultValue: &chapCoreDefaults.chartVersion},
@@ -122,9 +122,9 @@ var ChapCore = model.Stack{
 		"REDIS_HOST":                         {Priority: 0, DisplayName: "Redis Host", Consumed: true},
 		"REDIS_SECRET":                       {Priority: 0, DisplayName: "Redis Secret", Consumed: true},
 	},
-	Requires:           []model.Stack{ChapDB, ChapValkey},
-	Companions:         []model.Stack{ChapWorker},
-	KubernetesResource: model.DeploymentResource,
+	Requires:           []Stack{ChapDB, ChapValkey},
+	Companions:         []Stack{ChapWorker},
+	KubernetesResource: DeploymentResource,
 }
 
 var chapCoreDefaults = struct {

--- a/pkg/stack/docs.go
+++ b/pkg/stack/docs.go
@@ -10,11 +10,11 @@ type _ struct {
 // swagger:response Stack
 type StackBody struct {
 	//in: body
-	Body Stack
+	Body StackResponse
 }
 
 // swagger:response Stacks
 type StacksBody struct {
 	//in: body
-	Body []Stack
+	Body []StackResponse
 }

--- a/pkg/stack/handler.go
+++ b/pkg/stack/handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
-	"github.com/dhis2-sre/im-manager/pkg/model"
 
 	"github.com/gin-gonic/gin"
 )
@@ -53,16 +52,16 @@ func (h Handler) Find(c *gin.Context) {
 	c.JSON(http.StatusOK, toResponseStack(*stack))
 }
 
-func toResponseStack(stack model.Stack) Stack {
-	s := Stack{Name: stack.Name}
+func toResponseStack(stack Stack) StackResponse {
+	s := StackResponse{Name: stack.Name}
 
-	s.Requires = make([]Stack, len(stack.Requires))
+	s.Requires = make([]StackResponse, len(stack.Requires))
 	for i, require := range stack.Requires {
-		s.Requires[i] = Stack{Name: require.Name}
+		s.Requires[i] = StackResponse{Name: require.Name}
 	}
 
 	for parameterName, parameter := range stack.Parameters {
-		s.Parameters = append(s.Parameters, StackParameter{
+		s.Parameters = append(s.Parameters, StackParameterResponse{
 			ParameterName: parameterName,
 			DisplayName:   parameter.DisplayName,
 			DefaultValue:  parameter.DefaultValue,
@@ -76,7 +75,7 @@ func toResponseStack(stack model.Stack) Stack {
 }
 
 // swagger:model StackParameter
-type StackParameter struct {
+type StackParameterResponse struct {
 	ParameterName string  `json:"parameterName"`
 	DisplayName   string  `json:"displayName"`
 	DefaultValue  *string `json:"defaultValue,omitempty"`
@@ -86,10 +85,10 @@ type StackParameter struct {
 }
 
 // swagger:model Stack
-type Stack struct {
-	Name       string           `json:"name"`
-	Parameters []StackParameter `json:"parameters,omitempty"`
-	Requires   []Stack          `json:"requires,omitempty"`
+type StackResponse struct {
+	Name       string                   `json:"name"`
+	Parameters []StackParameterResponse `json:"parameters,omitempty"`
+	Requires   []StackResponse          `json:"requires,omitempty"`
 }
 
 // FindAll stack
@@ -115,7 +114,7 @@ func (h Handler) FindAll(c *gin.Context) {
 		return
 	}
 
-	response := make([]Stack, len(stacks))
+	response := make([]StackResponse, len(stacks))
 	for i, stack := range stacks {
 		response[i] = toResponseStack(stack)
 	}

--- a/pkg/stack/service.go
+++ b/pkg/stack/service.go
@@ -2,7 +2,6 @@ package stack
 
 import (
 	"github.com/dhis2-sre/im-manager/internal/errdef"
-	"github.com/dhis2-sre/im-manager/pkg/model"
 	"golang.org/x/exp/maps"
 )
 
@@ -14,7 +13,7 @@ type Service struct {
 	stacks Stacks
 }
 
-func (s Service) Find(name string) (*model.Stack, error) {
+func (s Service) Find(name string) (*Stack, error) {
 	stack, ok := s.stacks[name]
 	if !ok {
 		return nil, errdef.NewNotFound("stack not found: %s", name)
@@ -22,6 +21,6 @@ func (s Service) Find(name string) (*model.Stack, error) {
 	return &stack, nil
 }
 
-func (s Service) FindAll() ([]model.Stack, error) {
+func (s Service) FindAll() ([]Stack, error) {
 	return maps.Values(s.stacks), nil
 }

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -19,10 +19,10 @@ import (
 )
 
 // Stacks represents all deployable stacks.
-type Stacks map[string]model.Stack
+type Stacks map[string]Stack
 
 // New creates stacks ensuring consumed parameters are provided by required stacks.
-func New(stacks ...model.Stack) (Stacks, error) {
+func New(stacks ...Stack) (Stacks, error) {
 	_, err := ValidateNoCycles(stacks)
 	if err != nil {
 		return nil, err
@@ -44,8 +44,8 @@ func New(stacks ...model.Stack) (Stacks, error) {
 // graph via the required stacks forming a directed edge from the stack to the required stack.
 // Stacks with cycles would lead to undeployable instances. There would not be an order (no solution
 // to topological sort) in which we could deploy instances in.
-func ValidateNoCycles(stacks []model.Stack) (graph.Graph[string, model.Stack], error) {
-	g := graph.New(func(stack model.Stack) string {
+func ValidateNoCycles(stacks []Stack) (graph.Graph[string, Stack], error) {
+	g := graph.New(func(stack Stack) string {
 		return stack.Name
 	}, graph.Directed(), graph.PreventCycles())
 
@@ -75,7 +75,7 @@ func ValidateNoCycles(stacks []model.Stack) (graph.Graph[string, model.Stack], e
 
 // ValidateConsumedParameters validates all consumed parameters are provided by exactly one of the
 // required stacks. Required stacks need to provide at least one consumed parameter.
-func ValidateConsumedParameters(stacks []model.Stack) error {
+func ValidateConsumedParameters(stacks []Stack) error {
 	var errs []error
 	for _, stack := range stacks { // validate each stacks consumed parameters are provided by its required stacks
 		requiredStacks := make(map[string]int)
@@ -136,11 +136,11 @@ const ifNotPresent = "IfNotPresent"
 const always = "Always"
 
 // Stack representing ../../stacks/dhis2-db/helmfile.yaml.gotmpl
-var DHIS2DB = model.Stack{
+var DHIS2DB = Stack{
 	// TODO: Remove HostnamePattern once stacks 2.0 are the default
 	HostnamePattern: "%s-database-postgresql.%s.svc",
 	Name:            "dhis2-db",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"DATABASE_ID":               {Priority: 1, DisplayName: "Database"},
 		"DATABASE_SIZE":             {Priority: 2, DisplayName: "Database Size", DefaultValue: &dhis2DBDefaults.dbSize},
 		"DATABASE_NAME":             {Priority: 3, DisplayName: "Database Name", DefaultValue: &dhis2DBDefaults.dbName},
@@ -151,14 +151,14 @@ var DHIS2DB = model.Stack{
 		"RESOURCES_REQUESTS_MEMORY": {Priority: 8, DisplayName: "Resources Requests Memory", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
 		"CHART_VERSION":             {Priority: 9, DisplayName: "Chart Version", DefaultValue: &dhis2DBDefaults.chartVersion},
 	},
-	ParameterProviders: model.ParameterProviders{
+	ParameterProviders: ParameterProviders{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
-	KubernetesResource: model.StatefulSetResource,
+	KubernetesResource: StatefulSetResource,
 }
 
 // Provides the PostgreSQL hostname of an instance.
-var postgresHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var postgresHostnameProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-%d-database-postgresql.%s.svc", instance.Name, instance.Group.ID, instance.Group.Namespace), nil
 })
 
@@ -184,27 +184,27 @@ var dhis2DBDefaults = struct {
 }
 
 // Stack representing ../../stacks/minio/helmfile.yaml.gotmpl
-var MINIO = model.Stack{
+var MINIO = Stack{
 	Name: "minio",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"MINIO_STORAGE_SIZE":  {Priority: 1, DisplayName: "Storage Size", DefaultValue: &minIODefaults.storageSize},
 		"MINIO_CHART_VERSION": {Priority: 2, DisplayName: "Chart Version", DefaultValue: &minIODefaults.chartVersion},
 		"IMAGE_PULL_POLICY":   {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &minIODefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"DATABASE_ID":         {Priority: 0, DisplayName: "Database", Consumed: true},
 	},
-	ParameterProviders: model.ParameterProviders{
+	ParameterProviders: ParameterProviders{
 		"MINIO_HOSTNAME": minioHostnameProvider,
 	},
-	Requires:           []model.Stack{DHIS2DB},
-	KubernetesResource: model.DeploymentResource,
+	Requires:           []Stack{DHIS2DB},
+	KubernetesResource: DeploymentResource,
 }
 
 // Provides the Minio hostname of an instance.
-var minioHostnameProvider = model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+var minioHostnameProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 	return fmt.Sprintf("%s-minio.%s.svc", instance.Name, instance.Group.Namespace), nil
 })
 
-var storageCompanionProvider = model.RequireCompanionFunc(func(parameter model.DeploymentInstanceParameter) (*model.Stack, error) {
+var storageCompanionProvider = RequireCompanionFunc(func(parameter model.DeploymentInstanceParameter) (*Stack, error) {
 	if parameter.Value == minIOStorage {
 		return &MINIO, nil
 	}
@@ -222,9 +222,9 @@ var minIODefaults = struct {
 }
 
 // Stack representing ../../stacks/dhis2-core/helmfile.yaml.gotmpl
-var DHIS2Core = model.Stack{
+var DHIS2Core = Stack{
 	Name: "dhis2-core",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", DefaultValue: &dhis2CoreDefaults.imageTag},
 		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", DefaultValue: &dhis2CoreDefaults.imageRepository},
 		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
@@ -262,14 +262,14 @@ var DHIS2Core = model.Stack{
 		"DATABASE_PASSWORD":               {Priority: 0, DisplayName: "Database Password", Consumed: true, Sensitive: true},
 		"DATABASE_USERNAME":               {Priority: 0, DisplayName: "Database Username", Consumed: true, Sensitive: true},
 	},
-	Requires: []model.Stack{
+	Requires: []Stack{
 		DHIS2DB,
 	},
-	Companions: []model.Stack{
+	Companions: []Stack{
 		MINIO,
 		ChapCore,
 	},
-	KubernetesResource: model.DeploymentResource,
+	KubernetesResource: DeploymentResource,
 }
 
 var dhis2CoreDefaults = struct {
@@ -341,11 +341,11 @@ var dhis2CoreDefaults = struct {
 }
 
 // Stack representing ../../stacks/dhis2/helmfile.yaml.gotmpl
-var DHIS2 = model.Stack{
+var DHIS2 = Stack{
 	// TODO: Remove HostnamePattern once stacks 2.0 are the default
 	HostnamePattern: "%s-database-postgresql.%s.svc",
 	Name:            "dhis2",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", DefaultValue: &dhis2CoreDefaults.imageTag},
 		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", DefaultValue: &dhis2CoreDefaults.imageRepository},
 		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
@@ -377,7 +377,7 @@ var DHIS2 = model.Stack{
 		"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 0, DisplayName: "Google auth client email", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
 		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 0, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
 	},
-	ParameterProviders: model.ParameterProviders{
+	ParameterProviders: ParameterProviders{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 }
@@ -389,9 +389,9 @@ var dhis2Defaults = struct {
 }
 
 // Stack representing ../../stacks/pgadmin/helmfile.yaml.gotmpl
-var PgAdmin = model.Stack{
+var PgAdmin = Stack{
 	Name: "pgadmin",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"PGADMIN_USERNAME":  {Priority: 1, DisplayName: "pgAdmin Username", Sensitive: true},
 		"PGADMIN_PASSWORD":  {Priority: 2, DisplayName: "pgAdmin Password", Sensitive: true},
 		"CHART_VERSION":     {Priority: 3, DisplayName: "Chart Version", DefaultValue: &pgAdminDefaults.chartVersion},
@@ -399,10 +399,10 @@ var PgAdmin = model.Stack{
 		"DATABASE_NAME":     {Priority: 0, DisplayName: "Database Name", Consumed: true},
 		"DATABASE_USERNAME": {Priority: 0, DisplayName: "Database Username", Consumed: true, Sensitive: true},
 	},
-	Requires: []model.Stack{
+	Requires: []Stack{
 		DHIS2DB,
 	},
-	KubernetesResource: model.StatefulSetResource,
+	KubernetesResource: StatefulSetResource,
 }
 
 var pgAdminDefaults = struct {
@@ -412,16 +412,16 @@ var pgAdminDefaults = struct {
 }
 
 // Stack representing ../../stacks/whoami-go/helmfile.yaml.gotmpl
-var WhoamiGo = model.Stack{
+var WhoamiGo = Stack{
 	Name: "whoami-go",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"IMAGE_TAG":         {Priority: 1, DisplayName: "Image Tag", DefaultValue: &whoamiGoDefaults.imageTag},
 		"IMAGE_REPOSITORY":  {Priority: 2, DisplayName: "Image Repository", DefaultValue: &whoamiGoDefaults.imageRepository},
 		"IMAGE_PULL_POLICY": {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &whoamiGoDefaults.imagePullPolicy, Validator: imagePullPolicy},
 		"REPLICA_COUNT":     {Priority: 4, DisplayName: "Replica Count", DefaultValue: &whoamiGoDefaults.replicaCount},
 		"CHART_VERSION":     {Priority: 5, DisplayName: "Chart Version", DefaultValue: &whoamiGoDefaults.chartVersion},
 	},
-	KubernetesResource: model.DeploymentResource,
+	KubernetesResource: DeploymentResource,
 }
 
 var whoamiGoDefaults = struct {
@@ -439,9 +439,9 @@ var whoamiGoDefaults = struct {
 }
 
 // Stack representing ../../stacks/im-job-runner/helmfile.yaml.gotmpl
-var IMJobRunner = model.Stack{
+var IMJobRunner = Stack{
 	Name: "im-job-runner",
-	Parameters: model.StackParameters{
+	Parameters: StackParameters{
 		"COMMAND":                 {Priority: 0, DisplayName: "Command"},
 		"PAYLOAD":                 {Priority: 0, DisplayName: "Payload", DefaultValue: &imJobRunnerDefaults.payload},
 		"DHIS2_DATABASE_DATABASE": {Priority: 0, DisplayName: "DHIS2 Database Name", DefaultValue: &dhis2DBDefaults.dbName},

--- a/pkg/stack/stack_definitions_test.go
+++ b/pkg/stack/stack_definitions_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
 // assert every stack defined in Go has a helmfile
@@ -21,17 +19,17 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 	helmfileStacks, err := parseStacks("../../stacks")
 	require.NoError(t, err)
 
-	helmfileParameters := make(map[string]model.StackParameters, len(helmfileStacks))
+	helmfileParameters := make(map[string]StackParameters, len(helmfileStacks))
 	for stackName, helmfileStack := range helmfileStacks {
 		consumedParameter := make(map[string]struct{})
 		for _, p := range helmfileStack.consumedParameters {
 			consumedParameter[p] = struct{}{}
 		}
 
-		parameters := make(model.StackParameters)
+		parameters := make(StackParameters)
 		for name, value := range helmfileStack.parameters {
 			_, consumed := consumedParameter[name]
-			parameters[name] = model.StackParameter{DefaultValue: value, Consumed: consumed}
+			parameters[name] = StackParameter{DefaultValue: value, Consumed: consumed}
 		}
 		helmfileParameters[stackName] = parameters
 	}
@@ -39,7 +37,7 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 	// helmfileParameters will not contain Go Validator or Provider functions. We therefore need to
 	// create a map of stack name to parameters with parameters only containing. DefaultValue and
 	// Consumed as we cannot ignore fields in the assertions we use.
-	stacks := map[string]model.StackParameters{
+	stacks := map[string]StackParameters{
 		"dhis2-db":      DHIS2DB.Parameters,
 		"dhis2-core":    DHIS2Core.Parameters,
 		"dhis2":         DHIS2.Parameters,
@@ -52,12 +50,12 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 		"chap-worker":   ChapWorker.Parameters,
 		"chap-core":     ChapCore.Parameters,
 	}
-	stackDefinitions := make(map[string]model.StackParameters)
+	stackDefinitions := make(map[string]StackParameters)
 	for stackName, stackParameters := range stacks {
-		stackDefinitionParameters := make(map[string]model.StackParameter, len(stackParameters))
+		stackDefinitionParameters := make(map[string]StackParameter, len(stackParameters))
 		for parameterName, parameter := range stackParameters {
 			// DefaultValue is nil since it's no longer in the helmfile and therefor we don't have anything to compare it to
-			stackDefinitionParameters[parameterName] = model.StackParameter{DefaultValue: nil, Consumed: parameter.Consumed}
+			stackDefinitionParameters[parameterName] = StackParameter{DefaultValue: nil, Consumed: parameter.Consumed}
 		}
 		stackDefinitions[stackName] = stackDefinitionParameters
 	}

--- a/pkg/stack/stack_integration_test.go
+++ b/pkg/stack/stack_integration_test.go
@@ -34,7 +34,7 @@ func TestStackHandler(t *testing.T) {
 	t.Run("GetStack", func(t *testing.T) {
 		t.Parallel()
 
-		var dhis2 stack.Stack
+		var dhis2 stack.StackResponse
 		client.GetJSON(t, "/stacks/dhis2", &dhis2)
 
 		assert.Equal(t, "dhis2", dhis2.Name)
@@ -44,7 +44,7 @@ func TestStackHandler(t *testing.T) {
 	t.Run("GetAllStacks", func(t *testing.T) {
 		t.Parallel()
 
-		var stacks []stack.Stack
+		var stacks []stack.StackResponse
 		client.GetJSON(t, "/stacks", &stacks)
 
 		assert.NotEmpty(t, stacks)

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -10,29 +10,29 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	provider := model.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+	provider := stack.ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
 		return "1", nil
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"b_param": {},
 			},
-			ParameterProviders: model.ParameterProviders{
+			ParameterProviders: stack.ParameterProviders{
 				"b_param_provided": provider,
 			},
 		}
-		c := model.Stack{
+		c := stack.Stack{
 			Name: "c",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
@@ -40,7 +40,7 @@ func TestNew(t *testing.T) {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a, b},
+			Requires: []stack.Stack{a, b},
 		}
 
 		stacks, err := stack.New(a, b, c)
@@ -52,26 +52,26 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStacksIfTheyHaveACycle", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 				"b_param": {
 					Consumed: true,
 				},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"b_param": {},
 				"a_param": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
-		a.Requires = []model.Stack{b}
+		a.Requires = []stack.Stack{b}
 
 		_, err := stack.New(a, b)
 
@@ -79,13 +79,13 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStacksIfAStackHasASelfReferenceCycle", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		a.Requires = []model.Stack{a}
+		a.Requires = []stack.Stack{a}
 
 		_, err := stack.New(a)
 
@@ -93,15 +93,15 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfConsumedParameterIsNotProvidedByRequiredStack", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			ParameterProviders: model.ParameterProviders{
+			ParameterProviders: stack.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
@@ -109,7 +109,7 @@ func TestNew(t *testing.T) {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
 
 		_, err := stack.New(a, b)
@@ -118,15 +118,15 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfConsumedParameterIsNotProvidedByProvider", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
@@ -134,7 +134,7 @@ func TestNew(t *testing.T) {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
 
 		_, err := stack.New(a, b)
@@ -143,25 +143,25 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfConsumedParameterIsPointingToAnAlreadyConsumedParameter", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {Consumed: true},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
-		c := model.Stack{
+		c := stack.Stack{
 			Name: "c",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {Consumed: true},
 			},
-			Requires: []model.Stack{b},
+			Requires: []stack.Stack{b},
 		}
 
 		_, err := stack.New(a, c, b)
@@ -170,26 +170,26 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfThereAreMultipleStacksProvidingTheSameConsumedParameter", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			ParameterProviders: model.ParameterProviders{
+			ParameterProviders: stack.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			ParameterProviders: model.ParameterProviders{
+			ParameterProviders: stack.ParameterProviders{
 				"a_param_provided": provider,
 			},
 		}
-		c := model.Stack{
+		c := stack.Stack{
 			Name: "c",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param_provided": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a, b},
+			Requires: []stack.Stack{a, b},
 		}
 
 		_, err := stack.New(a, b, c)
@@ -198,26 +198,26 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfThereAreMultipleProvidersForOneConsumedParameter", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		c := model.Stack{
+		c := stack.Stack{
 			Name: "c",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a, b},
+			Requires: []stack.Stack{a, b},
 		}
 
 		_, err := stack.New(a, b, c)
@@ -226,23 +226,23 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfARequiredStackProvidesTheSameConsumedParameterTwice", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
-			ParameterProviders: model.ParameterProviders{
+			ParameterProviders: stack.ParameterProviders{
 				"a_param": provider,
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
 
 		_, err := stack.New(a, b)
@@ -251,20 +251,20 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfItContainsDuplicateRequiredStacks", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {
 					Consumed: true,
 				},
 			},
-			Requires: []model.Stack{a, a},
+			Requires: []stack.Stack{a, a},
 		}
 
 		_, err := stack.New(a, b)
@@ -273,19 +273,19 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("FailGivenStackIfARequiredStackDoesNotProvideAnyOfItsConsumedParameters", func(t *testing.T) {
-		a := model.Stack{
+		a := stack.Stack{
 			Name: "a",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"a_param": {},
 			},
 		}
-		b := model.Stack{
+		b := stack.Stack{
 			Name: "b",
-			Parameters: model.StackParameters{
+			Parameters: stack.StackParameters{
 				"b_param_1": {},
 				"b_param_2": {},
 			},
-			Requires: []model.Stack{a},
+			Requires: []stack.Stack{a},
 		}
 
 		_, err := stack.New(a, b)

--- a/pkg/stack/types.go
+++ b/pkg/stack/types.go
@@ -1,4 +1,6 @@
-package model
+package stack
+
+import "github.com/dhis2-sre/im-manager/pkg/model"
 
 type KubernetesResource string
 
@@ -44,17 +46,17 @@ type ParameterProviders map[string]ParameterProvider
 
 // ParameterProvider provides a value that can be consumed by a stack as a stack parameter.
 type ParameterProvider interface {
-	Provide(instance DeploymentInstance) (value string, err error)
+	Provide(instance model.DeploymentInstance) (value string, err error)
 }
 
-type ParameterProviderFunc func(instance DeploymentInstance) (string, error)
+type ParameterProviderFunc func(instance model.DeploymentInstance) (string, error)
 
-func (p ParameterProviderFunc) Provide(instance DeploymentInstance) (string, error) {
+func (p ParameterProviderFunc) Provide(instance model.DeploymentInstance) (string, error) {
 	return p(instance)
 }
 
-type RequireCompanionFunc func(instance DeploymentInstanceParameter) (*Stack, error)
+type RequireCompanionFunc func(instance model.DeploymentInstanceParameter) (*Stack, error)
 
-func (r RequireCompanionFunc) Require(parameter DeploymentInstanceParameter) (*Stack, error) {
+func (r RequireCompanionFunc) Require(parameter model.DeploymentInstanceParameter) (*Stack, error) {
 	return r(parameter)
 }

--- a/pkg/storage/migrations/20260515000_reencrypt_cfb_to_gcm.go
+++ b/pkg/storage/migrations/20260515000_reencrypt_cfb_to_gcm.go
@@ -19,7 +19,7 @@ import (
 func reencryptCFBToGCM() *gormigrate.Migration {
 	const gcmPrefix = "v2:"
 
-	allStacks := []model.Stack{
+	allStacks := []stack.Stack{
 		stack.DHIS2DB,
 		stack.MINIO,
 		stack.DHIS2Core,

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -591,6 +591,7 @@ definitions:
                 type: array
                 x-go-name: Requires
         type: object
+        x-go-name: StackResponse
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     StackParameter:
         properties:
@@ -614,6 +615,7 @@ definitions:
                 type: boolean
                 x-go-name: Sensitive
         type: object
+        x-go-name: StackParameterResponse
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     UpdateClusterRequest:
         properties:


### PR DESCRIPTION
Pure relocation, no behavior change. Stack and its definitional companions (StackParameter(s), ParameterProvider(s), RequireCompanionFunc, KubernetesResource) are static hardcoded definitions that are never persisted, unlike the gorm-backed rows in pkg/model, so they move into pkg/stack where they belong.

The stack handler's response DTOs were also named Stack and StackParameter; they become StackResponse and StackParameterResponse. Their swagger:model names (Stack, StackParameter) are kept via annotations, so the API contract is unchanged; the only swagger diff is two cosmetic x-go-name metadata lines.

This is the standalone move that unblocks giving stack.Stack a Components field, so each stack definition can carry its components inline (reworking the name-keyed registry from the component-operations work into fields).

Note: local integration runs hit external-registry network flakes (helm chart CDN / Docker Hub DNS timeouts) unrelated to this structural change; the hermetic suites (stack, database, deployment, storage) and build/vet/swagger are clean. CI runs the integration suite in a cleaner network environment.