### PR TITLE
fix: reject deleting a locked database before removing its S3 object

### DIFF
--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -294,6 +294,12 @@ func TestDatabaseHandler(t *testing.T) {
 		client.PostJSON(t, "/databases/"+databaseID+"/lock", body, &model.Lock{})
 		// Attempt delete but expect a bad request response
 		client.Do(t, http.MethodDelete, "/databases/"+databaseID, nil, http.StatusBadRequest, inttest.WithAuthToken("sometoken"))
+		// The rejected delete must not have removed the underlying S3 object
+		_, err = s3.Client.GetObject(context.TODO(), &awss3.GetObjectInput{
+			Bucket: aws.String(s3Bucket),
+			Key:    aws.String("packages/path/rename.extension"),
+		})
+		require.NoErrorf(t, err, "delete of a locked database must not delete its S3 object")
 		// Unlock database
 		client.Delete(t, "/databases/"+databaseID+"/lock")
 
@@ -306,7 +312,7 @@ func TestDatabaseHandler(t *testing.T) {
 
 		_, err = s3.Client.GetObject(context.TODO(), &awss3.GetObjectInput{
 			Bucket: aws.String(s3Bucket),
-			Key:    aws.String("packages/path/name.extension"),
+			Key:    aws.String("packages/path/rename.extension"),
 		})
 		var e *types.NoSuchKey
 		require.ErrorAsf(t, err, &e, "DELETE \"/databases/%s\" failed: DB should be deleted from S3", databaseID)

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -242,6 +242,10 @@ func (s Service) Delete(ctx context.Context, id uint) error {
 		return err
 	}
 
+	if d.Lock != nil {
+		return errdef.NewBadRequest("database is locked")
+	}
+
 	u, err := url.Parse(d.Url)
 	if err != nil {
 		return err


### PR DESCRIPTION
Database.Delete removed the S3 object before repository.Delete ran its "database is locked" check. Deleting a locked database therefore destroyed the underlying dump in S3 and then returned a 400, leaving an orphaned, still-locked record pointing at a missing object. The lock is now checked in the service before any storage deletion, so a locked database delete is rejected without side effects. The existing delete test asserted against a stale S3 key (the database had been renamed earlier in the test), so it never actually verified the object; it now checks the real key and confirms the object survives a rejected delete and is removed on a successful one.