### PR TITLE
feat: component listing endpoint and per-replica restart

### DIFF
--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -12,8 +12,15 @@ type _ struct {
 	// in: query
 	// required: false
 	// type: string
-	// description: restart a specific deployment labeled with im-type=<selector>
+	// description: restart a specific component labeled with im-type=<selector>
 	Selector string `json:"selector"`
+
+	// replica
+	// in: query
+	// required: false
+	// type: string
+	// description: restart a single replica (pod) of the component given by selector
+	Replica string `json:"replica"`
 }
 
 // swagger:parameters instanceLogs
@@ -30,7 +37,7 @@ type _ struct {
 	Selector string `json:"selector"`
 }
 
-// swagger:parameters deleteInstance findById findByIdDecrypted saveInstance pauseInstance resumeInstance resetInstance findDeploymentById deployDeployment deleteDeployment status instanceWithDetails filestoreBackup
+// swagger:parameters deleteInstance findById findByIdDecrypted saveInstance pauseInstance resumeInstance resetInstance findDeploymentById deployDeployment deleteDeployment status instanceWithDetails filestoreBackup instanceComponents
 type _ struct {
 	// in: path
 	// required: true
@@ -57,6 +64,12 @@ type InstanceLogsBody struct {
 type StatusBody struct {
 	// in: body
 	Body InstanceStatus
+}
+
+// swagger:response Components
+type ComponentsBody struct {
+	// in: body
+	Body []ComponentStatus
 }
 
 // swagger:parameters instanceNameToId

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -642,13 +642,75 @@ func (h Handler) Restart(c *gin.Context) {
 	}
 
 	selector := c.Query("selector")
-	err = h.instanceService.Restart(ctx, instance, selector)
+	replica := c.Query("replica")
+	if replica != "" && selector == "" {
+		_ = c.Error(errdef.NewBadRequest("replica requires a component selector"))
+		return
+	}
+
+	err = h.instanceService.Restart(ctx, instance, selector, replica)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
 
 	c.Status(http.StatusAccepted)
+}
+
+// Components instance components
+func (h Handler) Components(c *gin.Context) {
+	// swagger:route GET /instances/{id}/components instanceComponents
+	//
+	// Instance components
+	//
+	// List the components of an instance along with their supported operations and live replicas
+	//
+	// Security:
+	//	oauth2:
+	//
+	// responses:
+	//	200: Components
+	//	401: Error
+	//	403: Error
+	//	404: Error
+	//	415: Error
+	id, ok := handler.GetPathParameter(c, "id")
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+	user, err := handler.GetUserFromContext(ctx)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	instance, err := h.instanceService.FindDecryptedDeploymentInstanceById(ctx, id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	deployment, err := h.instanceService.FindDeploymentById(ctx, instance.DeploymentID)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	canRead := handler.CanReadDeployment(user, deployment)
+	if !canRead {
+		_ = c.Error(errdef.NewUnauthorized("read access denied"))
+		return
+	}
+
+	components, err := h.instanceService.Components(ctx, instance)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, components)
 }
 
 // DeleteDeploymentInstance delete deployment instance by id

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -643,11 +643,6 @@ func (h Handler) Restart(c *gin.Context) {
 
 	selector := c.Query("selector")
 	replica := c.Query("replica")
-	if replica != "" && selector == "" {
-		_ = c.Error(errdef.NewBadRequest("replica requires a component selector"))
-		return
-	}
-
 	err = h.instanceService.Restart(ctx, instance, selector, replica)
 	if err != nil {
 		_ = c.Error(err)
@@ -686,7 +681,7 @@ func (h Handler) Components(c *gin.Context) {
 		return
 	}
 
-	instance, err := h.instanceService.FindDecryptedDeploymentInstanceById(ctx, id)
+	instance, err := h.instanceService.FindDeploymentInstanceById(ctx, id)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -196,6 +197,45 @@ func TestInstanceHandler(t *testing.T) {
 
 		destroyDeployment(t, client, deployment.ID, tokens.AccessToken)
 		k8sClient.AssertPodIsNotRunning(t, deploymentInstance.Group.Namespace, deploymentInstance.Name, 10, deploymentInstance.Group.ID)
+	})
+
+	t.Run("ComponentsAndReplicaRestart", func(t *testing.T) {
+		t.Parallel()
+		deployment := createDeployment(t, client, "components-deployment", tokens.AccessToken)
+		deploymentInstance := createWhoamiInstance(t, client, deployment.ID, tokens.AccessToken)
+
+		deployDeployment(t, client, deployment.ID, tokens.AccessToken)
+		k8sClient.AssertPodIsReady(t, deploymentInstance.Group.Namespace, deploymentInstance.Name, 60, deploymentInstance.Group.ID)
+
+		path := fmt.Sprintf("/instances/%d/components", deploymentInstance.ID)
+		var components []instance.ComponentStatus
+		client.GetJSON(t, path, &components, inttest.WithAuthToken(tokens.AccessToken))
+
+		require.Len(t, components, 1)
+		assert.Equal(t, "whoami", components[0].Name)
+		assert.Equal(t, []kube.Operation{kube.OperationRestart, kube.OperationRestartReplica}, components[0].SupportedOperations)
+		require.Len(t, components[0].Replicas, 1)
+		replica := components[0].Replicas[0]
+		assert.Equal(t, "Running", replica.Phase)
+		assert.True(t, replica.Ready)
+
+		path = fmt.Sprintf("/instances/%d/restart?replica=%s", deploymentInstance.ID, replica.Name)
+		response := client.Do(t, http.MethodPut, path, nil, http.StatusBadRequest, inttest.WithAuthToken(tokens.AccessToken))
+		assert.Contains(t, string(response), "replica requires a component selector")
+
+		path = fmt.Sprintf("/instances/%d/restart?selector=whoami&replica=no-such-pod", deploymentInstance.ID)
+		client.Do(t, http.MethodPut, path, nil, http.StatusNotFound, inttest.WithAuthToken(tokens.AccessToken))
+
+		path = fmt.Sprintf("/instances/%d/restart?selector=whoami&replica=%s", deploymentInstance.ID, replica.Name)
+		client.Do(t, http.MethodPut, path, nil, http.StatusAccepted, inttest.WithAuthToken(tokens.AccessToken))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, err := k8sClient.Client.CoreV1().Pods(deploymentInstance.Group.Namespace).Get(context.Background(), replica.Name, metav1.GetOptions{})
+			assert.Truef(c, k8serrors.IsNotFound(err), "pod %q should be replaced after replica restart, err: %v", replica.Name, err)
+		}, 60*time.Second, 2*time.Second)
+		k8sClient.AssertPodIsReady(t, deploymentInstance.Group.Namespace, deploymentInstance.Name, 60, deploymentInstance.Group.ID)
+
+		destroyDeployment(t, client, deployment.ID, tokens.AccessToken)
 	})
 
 	t.Run("InstanceWithDetailsDeniedForNonMember", func(t *testing.T) {

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -402,7 +402,7 @@ func TestInstanceHandler(t *testing.T) {
 				return false
 			}
 			return d.Url != ""
-		}, 60*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
+		}, 120*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
 
 		var finalDB model.Database
 		err := db.First(&finalDB, savedDB.ID).Error
@@ -436,7 +436,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.Eventually(t, func() bool {
 			content, err := s3.TryGetObject(s3Bucket, "group-name/save-test.sql.gz")
 			return err == nil && len(content) > originalSize
-		}, 60*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
+		}, 120*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
 
 		destroyDeployment(t, client, deployment.ID, tokens.AccessToken)
 	})

--- a/pkg/instance/router.go
+++ b/pkg/instance/router.go
@@ -16,6 +16,7 @@ func Routes(r *gin.Engine, authenticator gin.HandlerFunc, handler Handler) {
 	tokenAuthenticationRouter.PUT("/instances/:id/restart", handler.Restart)
 	tokenAuthenticationRouter.GET("/instances/:id/logs", handler.Logs)
 	tokenAuthenticationRouter.GET("/instances/:id/status", handler.Status)
+	tokenAuthenticationRouter.GET("/instances/:id/components", handler.Components)
 	tokenAuthenticationRouter.GET("/instances/:id/details", handler.InstanceWithDetails)
 
 	tokenAuthenticationRouter.POST("/deployments", handler.SaveDeployment)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -614,7 +614,7 @@ func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance)
 	return ks.Resume(instance)
 }
 
-func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance, componentName string) error {
+func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance, componentName, podName string) error {
 	group, err := s.groupService.Find(ctx, instance.GroupName)
 	if err != nil {
 		return err
@@ -634,6 +634,9 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 	}
 
 	if componentName == "" {
+		if podName != "" {
+			return errdef.NewBadRequest("restarting a replica requires a component selector")
+		}
 		var errs error
 		for _, component := range components {
 			if err := component.Restart(ctx, client, instance); err != nil {
@@ -647,7 +650,49 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 	if err != nil {
 		return err
 	}
+	if podName != "" {
+		return component.RestartReplica(ctx, client, instance, podName)
+	}
 	return component.Restart(ctx, client, instance)
+}
+
+type ComponentStatus struct {
+	Name                string           `json:"name"`
+	SupportedOperations []kube.Operation `json:"supportedOperations"`
+	Replicas            []kube.Replica   `json:"replicas"`
+}
+
+// Components lists the instance's components with their supported operations and live replicas.
+// The instance must be decrypted since capability predicates evaluate real parameter values.
+func (s Service) Components(ctx context.Context, instance *model.DeploymentInstance) ([]ComponentStatus, error) {
+	group, err := s.groupService.Find(ctx, instance.GroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kube.NewClient(group.Cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	components, err := s.stackService.Components(instance.StackName)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make([]ComponentStatus, len(components))
+	for i, component := range components {
+		replicas, err := component.Replicas(ctx, client, instance)
+		if err != nil {
+			return nil, fmt.Errorf("listing replicas of component %q: %w", component.ComponentName(), err)
+		}
+		statuses[i] = ComponentStatus{
+			Name:                component.ComponentName(),
+			SupportedOperations: component.SupportedOperations(instance.Parameters),
+			Replicas:            replicas,
+		}
+	}
+	return statuses, nil
 }
 
 func (s Service) Logs(instance *model.DeploymentInstance, group *model.Group, typeSelector string) (io.ReadCloser, error) {

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -615,6 +615,10 @@ func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance)
 }
 
 func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance, componentName, podName string) error {
+	if podName != "" && componentName == "" {
+		return errdef.NewBadRequest("restarting a replica requires a component selector")
+	}
+
 	group, err := s.groupService.Find(ctx, instance.GroupName)
 	if err != nil {
 		return err
@@ -634,9 +638,6 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 	}
 
 	if componentName == "" {
-		if podName != "" {
-			return errdef.NewBadRequest("restarting a replica requires a component selector")
-		}
 		var errs error
 		for _, component := range components {
 			if err := component.Restart(ctx, client, instance); err != nil {
@@ -663,7 +664,8 @@ type ComponentStatus struct {
 }
 
 // Components lists the instance's components with their supported operations and live replicas.
-// The instance must be decrypted since capability predicates evaluate real parameter values.
+// Parameters are decrypted here since capability predicates evaluate real parameter values, so
+// callers pass the instance as stored.
 func (s Service) Components(ctx context.Context, instance *model.DeploymentInstance) ([]ComponentStatus, error) {
 	group, err := s.groupService.Find(ctx, instance.GroupName)
 	if err != nil {
@@ -675,11 +677,17 @@ func (s Service) Components(ctx context.Context, instance *model.DeploymentInsta
 		return nil, err
 	}
 
-	components, err := s.stackService.Components(instance.StackName)
+	stack, err := s.stackService.Find(instance.StackName)
 	if err != nil {
 		return nil, err
 	}
 
+	instance, err = s.instanceRepository.DecryptDeploymentInstance(instance, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	components := stack.Components
 	statuses := make([]ComponentStatus, len(components))
 	for i, component := range components {
 		replicas, err := component.Replicas(ctx, client, instance)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -597,7 +597,7 @@ func (s Service) Pause(ctx context.Context, instance *model.DeploymentInstance) 
 		return err
 	}
 
-	return ks.Pause(instance)
+	return ks.Pause(ctx, instance)
 }
 
 func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance) error {
@@ -611,7 +611,7 @@ func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance)
 		return err
 	}
 
-	return ks.Resume(instance)
+	return ks.Resume(ctx, instance)
 }
 
 func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance, componentName, podName string) error {

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -43,8 +43,8 @@ type Replica struct {
 }
 
 // Component is a single addressable part of a deployed stack (e.g. dhis2 core, its database).
-// Components are static stack metadata; pkg/stack owns the registry mapping each stack to its
-// components. Each concrete type knows how to restart its own underlying Kubernetes resource.
+// Components are static stack metadata; pkg/stack defines the concrete types, each named for the
+// chart/technology it operates on and implementing Restart against its own Kubernetes resource.
 type Component interface {
 	ComponentName() string
 	Restart(ctx context.Context, client *Client, instance *model.DeploymentInstance) error
@@ -150,24 +150,6 @@ func (b BaseComponent) PVCSelectors(instance *model.DeploymentInstance) []string
 		selectors[i] = fmt.Sprintf(pattern, uniqueName)
 	}
 	return selectors
-}
-
-// DeploymentComponent restarts a workload backed by a Deployment.
-type DeploymentComponent struct {
-	BaseComponent
-}
-
-func (c DeploymentComponent) Restart(_ context.Context, client *Client, instance *model.DeploymentInstance) error {
-	return client.RestartDeployment(instance, c.Name)
-}
-
-// StatefulSetComponent restarts a workload backed by a StatefulSet.
-type StatefulSetComponent struct {
-	BaseComponent
-}
-
-func (c StatefulSetComponent) Restart(_ context.Context, client *Client, instance *model.DeploymentInstance) error {
-	return client.RestartStatefulSet(instance, c.Name)
 }
 
 // FindComponent returns the component with the given name, or a not-found error.

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -3,10 +3,44 @@ package kube
 import (
 	"context"
 	"fmt"
+	"slices"
+	"time"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/dhis2-sre/im-manager/pkg/model"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// Operation is the name of an action a component supports, as exposed to API clients.
+type Operation string
+
+const (
+	OperationRestart         Operation = "restart"
+	OperationRestartReplica  Operation = "restartReplica"
+	OperationFilestoreBackup Operation = "filestoreBackup"
+)
+
+// CapabilityPredicate decides whether a capability applies given the instance's decrypted parameters.
+type CapabilityPredicate func(params model.DeploymentInstanceParameters) bool
+
+// Capability declares an operation a component supports beyond the base set. A nil When means the
+// operation is always supported.
+type Capability struct {
+	Operation Operation
+	When      CapabilityPredicate
+}
+
+// Replica is a live pod backing a component. Replicas are discovered from the cluster on demand
+// and never persisted.
+type Replica struct {
+	Name      string    `json:"name"`
+	Phase     string    `json:"phase"`
+	Ready     bool      `json:"ready"`
+	Restarts  int32     `json:"restarts"`
+	CreatedAt time.Time `json:"createdAt"`
+}
 
 // Component is a single addressable part of a deployed stack (e.g. dhis2 core, its database).
 // Components are static stack metadata; pkg/stack owns the registry mapping each stack to its
@@ -14,18 +48,98 @@ import (
 type Component interface {
 	ComponentName() string
 	Restart(ctx context.Context, client *Client, instance *model.DeploymentInstance) error
+	RestartReplica(ctx context.Context, client *Client, instance *model.DeploymentInstance, podName string) error
+	Replicas(ctx context.Context, client *Client, instance *model.DeploymentInstance) ([]Replica, error)
 	PVCSelectors(instance *model.DeploymentInstance) []string
+	SupportedOperations(params model.DeploymentInstanceParameters) []Operation
 }
 
-// BaseComponent supplies the shared name and PVC-selector formatting; concrete component types
-// embed it and implement Restart.
+// BaseComponent supplies the shared name, capability evaluation, replica discovery and PVC-selector
+// formatting; concrete component types embed it and implement Restart.
 type BaseComponent struct {
-	Name        string
-	PVCPatterns []string
+	Name         string
+	PVCPatterns  []string
+	Capabilities []Capability
 }
 
 func (b BaseComponent) ComponentName() string {
 	return b.Name
+}
+
+// SupportedOperations returns the base operations every component supports plus the capabilities
+// whose predicate passes on the instance's decrypted parameters.
+func (b BaseComponent) SupportedOperations(params model.DeploymentInstanceParameters) []Operation {
+	operations := []Operation{OperationRestart, OperationRestartReplica}
+	for _, capability := range b.Capabilities {
+		if capability.When == nil || capability.When(params) {
+			operations = append(operations, capability.Operation)
+		}
+	}
+	return operations
+}
+
+// Replicas lists the pods currently backing this component in the instance's namespace.
+func (b BaseComponent) Replicas(ctx context.Context, client *Client, instance *model.DeploymentInstance) ([]Replica, error) {
+	pods, err := b.pods(ctx, client, instance)
+	if err != nil {
+		return nil, err
+	}
+
+	replicas := make([]Replica, len(pods))
+	for i, pod := range pods {
+		replicas[i] = newReplica(pod)
+	}
+	return replicas, nil
+}
+
+// RestartReplica deletes the named pod after validating it belongs to this component, letting the
+// owning Deployment/StatefulSet controller recreate it.
+func (b BaseComponent) RestartReplica(ctx context.Context, client *Client, instance *model.DeploymentInstance, podName string) error {
+	pods, err := b.pods(ctx, client, instance)
+	if err != nil {
+		return err
+	}
+
+	if !slices.ContainsFunc(pods, func(pod v1.Pod) bool { return pod.Name == podName }) {
+		return errdef.NewNotFound("pod %q not found for component %q", podName, b.Name)
+	}
+
+	err = client.Clientset.CoreV1().Pods(instance.Group.Namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("error deleting pod %q: %v", podName, err)
+	}
+	return nil
+}
+
+func (b BaseComponent) pods(ctx context.Context, client *Client, instance *model.DeploymentInstance) ([]v1.Pod, error) {
+	selector, err := labelSelector(instance.ID, b.Name)
+	if err != nil {
+		return nil, err
+	}
+	return client.ListPods(ctx, instance.Group.Namespace, selector)
+}
+
+func newReplica(pod v1.Pod) Replica {
+	var restarts int32
+	for _, status := range pod.Status.ContainerStatuses {
+		restarts += status.RestartCount
+	}
+
+	ready := false
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady {
+			ready = condition.Status == v1.ConditionTrue
+			break
+		}
+	}
+
+	return Replica{
+		Name:      pod.Name,
+		Phase:     string(pod.Status.Phase),
+		Ready:     ready,
+		Restarts:  restarts,
+		CreatedAt: pod.CreationTimestamp.Time,
+	}
 }
 
 // PVCSelectors formats each PVC pattern with the instance's "<name>-<groupID>" unique name.

--- a/pkg/kube/component_test.go
+++ b/pkg/kube/component_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -27,30 +26,13 @@ func componentLabels(componentName string) map[string]string {
 	return map[string]string{"im-id": "1", "im-type": componentName}
 }
 
-func TestDeploymentComponentRestartPatchesDeployment(t *testing.T) {
-	instance := componentTestInstance()
-	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "core", Namespace: "ns", Labels: componentLabels("dhis2")}}
-	c := &Client{Clientset: fake.NewSimpleClientset(dep)}
-
-	component := DeploymentComponent{BaseComponent{Name: "dhis2"}}
-	require.NoError(t, component.Restart(context.Background(), c, instance))
-
-	got, err := c.Clientset.AppsV1().Deployments("ns").Get(context.TODO(), "core", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotEmpty(t, got.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"])
+// testComponent is a minimal concrete Component; the real technology-named types live in pkg/stack.
+type testComponent struct {
+	BaseComponent
 }
 
-func TestStatefulSetComponentRestartPatchesStatefulSet(t *testing.T) {
-	instance := componentTestInstance()
-	set := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Labels: componentLabels("db")}}
-	c := &Client{Clientset: fake.NewSimpleClientset(set)}
-
-	component := StatefulSetComponent{BaseComponent{Name: "db"}}
-	require.NoError(t, component.Restart(context.Background(), c, instance))
-
-	got, err := c.Clientset.AppsV1().StatefulSets("ns").Get(context.TODO(), "db", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotEmpty(t, got.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"])
+func (c testComponent) Restart(context.Context, *Client, *model.DeploymentInstance) error {
+	return nil
 }
 
 func TestPVCSelectors(t *testing.T) {
@@ -160,8 +142,8 @@ func TestRestartReplicaMissingPod(t *testing.T) {
 
 func TestFindComponent(t *testing.T) {
 	components := []Component{
-		DeploymentComponent{BaseComponent{Name: "dhis2"}},
-		StatefulSetComponent{BaseComponent{Name: "db"}},
+		testComponent{BaseComponent{Name: "dhis2"}},
+		testComponent{BaseComponent{Name: "db"}},
 	}
 
 	found, err := FindComponent(components, "db")

--- a/pkg/kube/component_test.go
+++ b/pkg/kube/component_test.go
@@ -3,12 +3,14 @@ package kube
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -64,6 +66,96 @@ func TestPVCSelectors(t *testing.T) {
 	}, component.PVCSelectors(instance))
 
 	assert.Empty(t, BaseComponent{}.PVCSelectors(instance))
+}
+
+func componentTestPod(name, componentName string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "ns",
+			Labels:            componentLabels(componentName),
+			CreationTimestamp: metav1.NewTime(time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)),
+		},
+		Status: v1.PodStatus{
+			Phase:             v1.PodRunning,
+			Conditions:        []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			ContainerStatuses: []v1.ContainerStatus{{RestartCount: 2}, {RestartCount: 1}},
+		},
+	}
+}
+
+func TestSupportedOperations(t *testing.T) {
+	assert.Equal(t, []Operation{OperationRestart, OperationRestartReplica},
+		BaseComponent{Name: "db"}.SupportedOperations(nil))
+
+	storageTypeIsFilesystem := func(params model.DeploymentInstanceParameters) bool {
+		return params["STORAGE_TYPE"].Value == "filesystem"
+	}
+	component := BaseComponent{Name: "dhis2", Capabilities: []Capability{
+		{Operation: OperationFilestoreBackup, When: storageTypeIsFilesystem},
+		{Operation: Operation("alwaysOn")},
+	}}
+
+	filesystemParams := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "filesystem"}}
+	assert.Equal(t, []Operation{OperationRestart, OperationRestartReplica, OperationFilestoreBackup, Operation("alwaysOn")},
+		component.SupportedOperations(filesystemParams))
+
+	minioParams := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "minio"}}
+	assert.Equal(t, []Operation{OperationRestart, OperationRestartReplica, Operation("alwaysOn")},
+		component.SupportedOperations(minioParams))
+}
+
+func TestReplicas(t *testing.T) {
+	instance := componentTestInstance()
+	pod := componentTestPod("core-1", "dhis2")
+	notReady := componentTestPod("core-2", "dhis2")
+	notReady.Status.Conditions = []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}
+	evicted := componentTestPod("core-evicted", "dhis2")
+	evicted.Status.Phase = v1.PodFailed
+	evicted.Status.Reason = "Evicted"
+	otherComponent := componentTestPod("db-1", "db")
+	c := &Client{Clientset: fake.NewSimpleClientset(pod, notReady, evicted, otherComponent)}
+
+	replicas, err := BaseComponent{Name: "dhis2"}.Replicas(context.Background(), c, instance)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []Replica{
+		{Name: "core-1", Phase: "Running", Ready: true, Restarts: 3, CreatedAt: pod.CreationTimestamp.Time},
+		{Name: "core-2", Phase: "Running", Ready: false, Restarts: 3, CreatedAt: pod.CreationTimestamp.Time},
+	}, replicas)
+}
+
+func TestRestartReplicaDeletesOwnedPod(t *testing.T) {
+	instance := componentTestInstance()
+	pod := componentTestPod("core-1", "dhis2")
+	c := &Client{Clientset: fake.NewSimpleClientset(pod)}
+
+	require.NoError(t, BaseComponent{Name: "dhis2"}.RestartReplica(context.Background(), c, instance, "core-1"))
+
+	_, err := c.Clientset.CoreV1().Pods("ns").Get(context.TODO(), "core-1", metav1.GetOptions{})
+	assert.Error(t, err)
+}
+
+func TestRestartReplicaRejectsPodOfOtherComponent(t *testing.T) {
+	instance := componentTestInstance()
+	pod := componentTestPod("db-1", "db")
+	c := &Client{Clientset: fake.NewSimpleClientset(pod)}
+
+	err := BaseComponent{Name: "dhis2"}.RestartReplica(context.Background(), c, instance, "db-1")
+	require.Error(t, err)
+	assert.True(t, errdef.IsNotFound(err))
+
+	_, err = c.Clientset.CoreV1().Pods("ns").Get(context.TODO(), "db-1", metav1.GetOptions{})
+	assert.NoError(t, err, "pod of another component must not be deleted")
+}
+
+func TestRestartReplicaMissingPod(t *testing.T) {
+	instance := componentTestInstance()
+	c := &Client{Clientset: fake.NewSimpleClientset()}
+
+	err := BaseComponent{Name: "dhis2"}.RestartReplica(context.Background(), c, instance, "core-1")
+	require.Error(t, err)
+	assert.True(t, errdef.IsNotFound(err))
 }
 
 func TestFindComponent(t *testing.T) {

--- a/pkg/kube/operations.go
+++ b/pkg/kube/operations.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componentName string) error {
+func (c *Client) RestartStatefulSet(ctx context.Context, instance *model.DeploymentInstance, componentName string) error {
 	selector, err := labelSelector(instance.ID, componentName)
 	if err != nil {
 		return err
@@ -22,7 +22,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 	}
 
 	statefulSets := c.Clientset.AppsV1().StatefulSets(instance.Group.Namespace)
-	statefulSetsList, err := statefulSets.List(context.TODO(), listOptions)
+	statefulSetsList, err := statefulSets.List(ctx, listOptions)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 
 	statefulSet := statefulSetsItems[0]
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = statefulSets.Patch(context.TODO(), statefulSet.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	_, err = statefulSets.Patch(ctx, statefulSet.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("error restarting %q: %v", statefulSet.Name, err)
 	}
@@ -45,7 +45,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 	return nil
 }
 
-func (c *Client) RestartDeployment(instance *model.DeploymentInstance, componentName string) error {
+func (c *Client) RestartDeployment(ctx context.Context, instance *model.DeploymentInstance, componentName string) error {
 	selector, err := labelSelector(instance.ID, componentName)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 	}
 
 	deployments := c.Clientset.AppsV1().Deployments(instance.Group.Namespace)
-	deploymentList, err := deployments.List(context.TODO(), listOptions)
+	deploymentList, err := deployments.List(ctx, listOptions)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 
 	deployment := deploymentItems[0]
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = deployments.Patch(context.TODO(), deployment.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	_, err = deployments.Patch(ctx, deployment.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("error restarting %q: %v", deployment.Name, err)
 	}
@@ -78,8 +78,8 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 	return nil
 }
 
-func (c *Client) Pause(instance *model.DeploymentInstance) error {
-	err := c.scale(instance, 0)
+func (c *Client) Pause(ctx context.Context, instance *model.DeploymentInstance) error {
+	err := c.scale(ctx, instance, 0)
 	if err != nil {
 		return fmt.Errorf("failed to pause instance %d: %v", instance.ID, err)
 	}
@@ -87,8 +87,8 @@ func (c *Client) Pause(instance *model.DeploymentInstance) error {
 	return nil
 }
 
-func (c *Client) Resume(instance *model.DeploymentInstance) error {
-	err := c.scale(instance, 1)
+func (c *Client) Resume(ctx context.Context, instance *model.DeploymentInstance) error {
+	err := c.scale(ctx, instance, 1)
 	if err != nil {
 		return fmt.Errorf("failed to resume instance %d: %v", instance.ID, err)
 	}
@@ -124,31 +124,31 @@ func (c *Client) DeletePVCs(ctx context.Context, namespace string, selectors []s
 	return nil
 }
 
-func (c *Client) scale(instance *model.DeploymentInstance, replicas int32) error {
+func (c *Client) scale(ctx context.Context, instance *model.DeploymentInstance, replicas int32) error {
 	labelSelector := fmt.Sprintf("im-id=%d", instance.ID)
 	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
 
 	deployments := c.Clientset.AppsV1().Deployments(instance.Group.Namespace)
-	deploymentList, err := deployments.List(context.TODO(), listOptions)
+	deploymentList, err := deployments.List(ctx, listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding deployments using selector %q: %v", labelSelector, err)
 	}
 
 	for _, d := range deploymentList.Items {
-		_, err = scale(deployments, d.Name, replicas)
+		_, err = scale(ctx, deployments, d.Name, replicas)
 		if err != nil {
 			return err
 		}
 	}
 
 	sets := c.Clientset.AppsV1().StatefulSets(instance.Group.Namespace)
-	setsList, err := sets.List(context.TODO(), listOptions)
+	setsList, err := sets.List(ctx, listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding StatefulSets using selector %q: %v", labelSelector, err)
 	}
 
 	for _, s := range setsList.Items {
-		_, err = scale(sets, s.Name, replicas)
+		_, err = scale(ctx, sets, s.Name, replicas)
 		if err != nil {
 			return err
 		}
@@ -166,8 +166,8 @@ type scaler interface {
 
 // scale updates the number of replicas on a scaler. The desired number of replicas before scaling
 // was updated is returned.
-func scale(sc scaler, name string, replicas int32) (int32, error) {
-	scale, err := sc.GetScale(context.TODO(), name, metav1.GetOptions{})
+func scale(ctx context.Context, sc scaler, name string, replicas int32) (int32, error) {
+	scale, err := sc.GetScale(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get scale of %q: %v", name, err)
 	}
@@ -175,7 +175,7 @@ func scale(sc scaler, name string, replicas int32) (int32, error) {
 	prevReplicas := scale.Spec.Replicas
 	scale.Spec.Replicas = replicas
 
-	_, err = sc.UpdateScale(context.TODO(), name, scale, metav1.UpdateOptions{})
+	_, err = sc.UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to update scale of %q to %d: %v", name, replicas, err)
 	}

--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -85,6 +85,20 @@ func (c *Client) GetPodByLabels(labels map[string]string) (v1.Pod, error) {
 	return c.podBySelector(selector.String())
 }
 
+// ListPods returns the non-evicted pods matching the selector in the given namespace.
+func (c *Client) ListPods(ctx context.Context, namespace, selector string) ([]v1.Pod, error) {
+	pods, err := c.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods for selector %q: %v", selector, err)
+	}
+
+	pods.Items = slices.DeleteFunc(pods.Items, func(pod v1.Pod) bool {
+		return pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted"
+	})
+
+	return pods.Items, nil
+}
+
 func (c *Client) podBySelector(selector string) (v1.Pod, error) {
 	listOptions := metav1.ListOptions{
 		LabelSelector: selector,

--- a/pkg/stack/chap.go
+++ b/pkg/stack/chap.go
@@ -22,7 +22,7 @@ var ChapDB = Stack{
 		"DATABASE_SECRET":   chapDBSecretProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}},
+		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}},
 	},
 }
 
@@ -61,7 +61,7 @@ var ChapValkey = Stack{
 		"REDIS_SECRET": chapValkeySecretProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "chap-valkey"}},
+		ValkeyComponent{BaseComponent: kube.BaseComponent{Name: "chap-valkey"}},
 	},
 }
 
@@ -98,7 +98,7 @@ var ChapWorker = Stack{
 	},
 	Requires: []Stack{ChapDB, ChapValkey},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "chap-worker"}},
+		ChapWorkerComponent{BaseComponent: kube.BaseComponent{Name: "chap-worker"}},
 	},
 }
 
@@ -132,7 +132,7 @@ var ChapCore = Stack{
 	Requires:   []Stack{ChapDB, ChapValkey},
 	Companions: []Stack{ChapWorker},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "chap-core"}},
+		ChapCoreComponent{BaseComponent: kube.BaseComponent{Name: "chap-core"}},
 	},
 }
 

--- a/pkg/stack/components.go
+++ b/pkg/stack/components.go
@@ -1,7 +1,10 @@
 package stack
 
 import (
+	"context"
+
 	"github.com/dhis2-sre/im-manager/pkg/kube"
+	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
 // Components returns the components of the named stack.
@@ -11,4 +14,94 @@ func (s Service) Components(stackName string) ([]kube.Component, error) {
 		return nil, err
 	}
 	return stack.Components, nil
+}
+
+// Concrete component types are named for the chart/technology they operate on; the Kubernetes
+// workload kind behind each is an implementation detail of its Restart. This is what lets a future
+// dhis2 stack swap BitnamiPostgresComponent for CNPGPostgresComponent in its definition alone,
+// bringing operations specific to that technology (e.g. CNPG's native S3 backup) without any
+// dispatch changes.
+
+// DHIS2CoreComponent operates on the dhis2-core chart's Deployment.
+type DHIS2CoreComponent struct {
+	kube.BaseComponent
+}
+
+func (c DHIS2CoreComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// BitnamiPostgresComponent operates on the Bitnami PostgreSQL chart's StatefulSet.
+type BitnamiPostgresComponent struct {
+	kube.BaseComponent
+}
+
+func (c BitnamiPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// CNPGPostgresComponent operates on a CloudNativePG-managed PostgreSQL cluster. Restart currently
+// applies the generic StatefulSet patch, which finds nothing against CNPG's bare pods (unchanged
+// from before components existed); roadmap step 5 reimplements it via the Cluster custom resource's
+// restart annotation.
+type CNPGPostgresComponent struct {
+	kube.BaseComponent
+}
+
+func (c CNPGPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// MinioComponent operates on the Bitnami MinIO chart's Deployment.
+type MinioComponent struct {
+	kube.BaseComponent
+}
+
+func (c MinioComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// PgAdminComponent operates on the runix pgadmin4 chart's StatefulSet.
+type PgAdminComponent struct {
+	kube.BaseComponent
+}
+
+func (c PgAdminComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// WhoamiComponent operates on the whoami-go chart's Deployment.
+type WhoamiComponent struct {
+	kube.BaseComponent
+}
+
+func (c WhoamiComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// ValkeyComponent operates on the Bitnami Valkey chart's StatefulSet.
+type ValkeyComponent struct {
+	kube.BaseComponent
+}
+
+func (c ValkeyComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// ChapWorkerComponent operates on the chap-worker chart's Deployment.
+type ChapWorkerComponent struct {
+	kube.BaseComponent
+}
+
+func (c ChapWorkerComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// ChapCoreComponent operates on the chap-core chart's Deployment.
+type ChapCoreComponent struct {
+	kube.BaseComponent
+}
+
+func (c ChapCoreComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
 }

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,19 @@ func TestEveryStackHasUniqueNamedComponents(t *testing.T) {
 	}
 
 	assert.Empty(t, IMJobRunner.Components, "im-job-runner deliberately has no components until jobs are redesigned")
+}
+
+// TestDHIS2CoreAdvertisesFilestoreBackup asserts the capability listing: the dhis2-core component
+// supports filestore backup for every storage backend, while other stacks only expose the base
+// operations.
+func TestDHIS2CoreAdvertisesFilestoreBackup(t *testing.T) {
+	core, err := kube.FindComponent(DHIS2Core.Components, "dhis2")
+	require.NoError(t, err)
+	assert.Contains(t, core.SupportedOperations(nil), kube.OperationFilestoreBackup)
+
+	whoami, err := kube.FindComponent(WhoamiGo.Components, "whoami")
+	require.NoError(t, err)
+	assert.Equal(t, []kube.Operation{kube.OperationRestart, kube.OperationRestartReplica}, whoami.SupportedOperations(nil))
 }
 
 // TestComponentNamesMatchHelmfileImType asserts every declared component name is an im-type label

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -10,6 +12,9 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 // allStacks are the deployable stack definitions; every one must declare its components. The
@@ -32,6 +37,56 @@ func TestEveryStackHasUniqueNamedComponents(t *testing.T) {
 	}
 
 	assert.Empty(t, IMJobRunner.Components, "im-job-runner deliberately has no components until jobs are redesigned")
+}
+
+// TestComponentRestartTargetsExpectedWorkload asserts each technology component patches the
+// Kubernetes workload kind its chart actually deploys.
+func TestComponentRestartTargetsExpectedWorkload(t *testing.T) {
+	instance := &model.DeploymentInstance{ID: 1, Name: "myinstance", Group: &model.Group{ID: 7, Namespace: "ns"}}
+
+	tests := []struct {
+		component   kube.Component
+		statefulSet bool
+	}{
+		{DHIS2CoreComponent{kube.BaseComponent{Name: "dhis2"}}, false},
+		{BitnamiPostgresComponent{kube.BaseComponent{Name: "db"}}, true},
+		{CNPGPostgresComponent{kube.BaseComponent{Name: "chap-db"}}, true},
+		{MinioComponent{kube.BaseComponent{Name: "minio"}}, false},
+		{PgAdminComponent{kube.BaseComponent{Name: "pgadmin"}}, true},
+		{WhoamiComponent{kube.BaseComponent{Name: "whoami"}}, false},
+		{ValkeyComponent{kube.BaseComponent{Name: "chap-valkey"}}, true},
+		{ChapWorkerComponent{kube.BaseComponent{Name: "chap-worker"}}, false},
+		{ChapCoreComponent{kube.BaseComponent{Name: "chap-core"}}, false},
+	}
+
+	for _, test := range tests {
+		name := test.component.ComponentName()
+		t.Run(fmt.Sprintf("%T", test.component), func(t *testing.T) {
+			labels := map[string]string{"im-id": "1", "im-type": name}
+			meta := metav1.ObjectMeta{Name: name, Namespace: "ns", Labels: labels}
+
+			var client *kube.Client
+			if test.statefulSet {
+				client = &kube.Client{Clientset: fake.NewSimpleClientset(&appsv1.StatefulSet{ObjectMeta: meta})}
+			} else {
+				client = &kube.Client{Clientset: fake.NewSimpleClientset(&appsv1.Deployment{ObjectMeta: meta})}
+			}
+
+			require.NoError(t, test.component.Restart(context.Background(), client, instance))
+
+			var annotations map[string]string
+			if test.statefulSet {
+				got, err := client.Clientset.AppsV1().StatefulSets("ns").Get(context.TODO(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				annotations = got.Spec.Template.Annotations
+			} else {
+				got, err := client.Clientset.AppsV1().Deployments("ns").Get(context.TODO(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				annotations = got.Spec.Template.Annotations
+			}
+			assert.NotEmpty(t, annotations["kubectl.kubernetes.io/restartedAt"])
+		})
+	}
 }
 
 // TestDHIS2CoreAdvertisesFilestoreBackup asserts the capability listing: the dhis2-core component

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -287,6 +287,11 @@ var DHIS2Core = Stack{
 				"app.kubernetes.io/instance=%s",
 				"app.kubernetes.io/instance=%s-minio",
 			},
+			// All STORAGE_TYPE backends (minio, filesystem, s3) support filestore backup, so no
+			// predicate; the first parameter-gated capability arrives with CNPG-backed stacks.
+			Capabilities: []kube.Capability{
+				{Operation: kube.OperationFilestoreBackup},
+			},
 		}},
 	},
 }

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -156,7 +156,7 @@ var DHIS2DB = Stack{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{
+		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name:        "db",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s-database"},
 		}},
@@ -203,7 +203,7 @@ var MINIO = Stack{
 	},
 	Requires: []Stack{DHIS2DB},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{
+		MinioComponent{BaseComponent: kube.BaseComponent{
 			Name:        "minio",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s-minio"},
 		}},
@@ -281,7 +281,7 @@ var DHIS2Core = Stack{
 		ChapCore,
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{
+		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{
 			Name: "dhis2",
 			PVCPatterns: []string{
 				"app.kubernetes.io/instance=%s",
@@ -405,8 +405,8 @@ var DHIS2 = Stack{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "dhis2"}},
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{
+		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{Name: "dhis2"}},
+		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name: "db",
 			PVCPatterns: []string{
 				"app.kubernetes.io/instance=%s-database",
@@ -439,7 +439,7 @@ var PgAdmin = Stack{
 		DHIS2DB,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "pgadmin"}},
+		PgAdminComponent{BaseComponent: kube.BaseComponent{Name: "pgadmin"}},
 	},
 }
 
@@ -460,7 +460,7 @@ var WhoamiGo = Stack{
 		"CHART_VERSION":     {Priority: 5, DisplayName: "Chart Version", DefaultValue: &whoamiGoDefaults.chartVersion},
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "whoami"}},
+		WhoamiComponent{BaseComponent: kube.BaseComponent{Name: "whoami"}},
 	},
 }
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -64,6 +64,23 @@ definitions:
                 type: integer
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/kube
+    ComponentStatus:
+        properties:
+            name:
+                type: string
+                x-go-name: Name
+            replicas:
+                items:
+                    $ref: '#/definitions/Replica'
+                type: array
+                x-go-name: Replicas
+            supportedOperations:
+                items:
+                    $ref: '#/definitions/Operation'
+                type: array
+                x-go-name: SupportedOperations
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/instance
     CopyDatabaseRequest:
         properties:
             group:
@@ -484,6 +501,10 @@ definitions:
                 x-go-name: UserID
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/model
+    Operation:
+        title: Operation is the name of an action a component supports, as exposed to API clients.
+        type: string
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/kube
     Parameter:
         properties:
             value:
@@ -520,6 +541,30 @@ definitions:
                 x-go-name: RefreshToken
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/user
+    Replica:
+        description: |-
+            Replica is a live pod backing a component. Replicas are discovered from the cluster on demand
+            and never persisted.
+        properties:
+            createdAt:
+                format: date-time
+                type: string
+                x-go-name: CreatedAt
+            name:
+                type: string
+                x-go-name: Name
+            phase:
+                type: string
+                x-go-name: Phase
+            ready:
+                type: boolean
+                x-go-name: Ready
+            restarts:
+                format: int32
+                type: integer
+                x-go-name: Restarts
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/kube
     Request:
         properties:
             key:
@@ -1880,6 +1925,31 @@ paths:
                 "200":
                     $ref: '#/responses/HealthResponse'
             summary: Health status
+    /instances/{id}/components:
+        get:
+            description: List the components of an instance along with their supported operations and live replicas
+            operationId: instanceComponents
+            parameters:
+                - format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "200":
+                    $ref: '#/responses/Components'
+                "401":
+                    $ref: '#/responses/Error'
+                "403":
+                    $ref: '#/responses/Error'
+                "404":
+                    $ref: '#/responses/Error'
+                "415":
+                    $ref: '#/responses/Error'
+            security:
+                - oauth2: []
+            summary: Instance components
     /instances/{id}/details:
         put:
             description: Returns the details of an instance including parameters
@@ -2004,11 +2074,19 @@ paths:
                 - description: |-
                     selector
                     type: string
-                    description: restart a specific deployment labeled with im-type=<selector>
+                    description: restart a specific component labeled with im-type=<selector>
                   in: query
                   name: selector
                   type: string
                   x-go-name: Selector
+                - description: |-
+                    replica
+                    type: string
+                    description: restart a single replica (pod) of the component given by selector
+                  in: query
+                  name: replica
+                  type: string
+                  x-go-name: Replica
             responses:
                 "202":
                     description: ""
@@ -2486,6 +2564,12 @@ responses:
         schema:
             items:
                 $ref: '#/definitions/Cluster'
+            type: array
+    Components:
+        description: ""
+        schema:
+            items:
+                $ref: '#/definitions/ComponentStatus'
             type: array
     CreateExternalDownloadResponse:
         description: ""


### PR DESCRIPTION
Roadmap step 3, targeting version-3.0. Adds GET /instances/:id/components returning each component of an instance with its supported operations and live replicas, so clients can render per-component actions and per-replica restart buttons. The restart endpoint gains a replica query parameter which deletes a single pod after validating it belongs to the component given by selector, letting the controller recreate it; replica without selector is a 400. Components can now declare capabilities beyond the base restart/restartReplica operations, optionally gated on decrypted instance parameters. dhis2-core's core component advertises filestoreBackup without a predicate since all storage backends (minio, filesystem, s3) support it since #1562; the first genuinely parameter-gated capability arrives with CNPG-backed stacks. Concrete component types are named for the chart/technology they operate on (BitnamiPostgresComponent, MinioComponent, DHIS2CoreComponent, ...) and live in pkg/stack next to the stack definitions; the Kubernetes workload kind is an implementation detail of each Restart, and the generic DeploymentComponent/StatefulSetComponent types are gone. chap-db is typed CNPGPostgresComponent, keeping today's statefulset restart behavior until restart is reimplemented via the Cluster CR in the operator step. A future dhis2v2 stack swaps the postgres component type in its definition alone to gain CNPG-specific operations such as native S3 backup. Context is threaded through the kube operation helpers (RestartDeployment, RestartStatefulSet, Pause, Resume, scale), replacing the context.TODO() calls carried over from the verbatim extraction, so request cancellation reaches the Kubernetes API. Covered by unit tests on the component model, a table test asserting each technology type patches the workload kind its chart deploys, and an integration test exercising the listing, the validation error and a real replica restart against k3s.