### PR TITLE
refactor: name components by chart technology

### DIFF
--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -597,7 +597,7 @@ func (s Service) Pause(ctx context.Context, instance *model.DeploymentInstance) 
 		return err
 	}
 
-	return ks.Pause(instance)
+	return ks.Pause(ctx, instance)
 }
 
 func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance) error {
@@ -611,7 +611,7 @@ func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance)
 		return err
 	}
 
-	return ks.Resume(instance)
+	return ks.Resume(ctx, instance)
 }
 
 func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance, componentName, podName string) error {

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -43,8 +43,8 @@ type Replica struct {
 }
 
 // Component is a single addressable part of a deployed stack (e.g. dhis2 core, its database).
-// Components are static stack metadata; pkg/stack owns the registry mapping each stack to its
-// components. Each concrete type knows how to restart its own underlying Kubernetes resource.
+// Components are static stack metadata; pkg/stack defines the concrete types, each named for the
+// chart/technology it operates on and implementing Restart against its own Kubernetes resource.
 type Component interface {
 	ComponentName() string
 	Restart(ctx context.Context, client *Client, instance *model.DeploymentInstance) error
@@ -150,24 +150,6 @@ func (b BaseComponent) PVCSelectors(instance *model.DeploymentInstance) []string
 		selectors[i] = fmt.Sprintf(pattern, uniqueName)
 	}
 	return selectors
-}
-
-// DeploymentComponent restarts a workload backed by a Deployment.
-type DeploymentComponent struct {
-	BaseComponent
-}
-
-func (c DeploymentComponent) Restart(_ context.Context, client *Client, instance *model.DeploymentInstance) error {
-	return client.RestartDeployment(instance, c.Name)
-}
-
-// StatefulSetComponent restarts a workload backed by a StatefulSet.
-type StatefulSetComponent struct {
-	BaseComponent
-}
-
-func (c StatefulSetComponent) Restart(_ context.Context, client *Client, instance *model.DeploymentInstance) error {
-	return client.RestartStatefulSet(instance, c.Name)
 }
 
 // FindComponent returns the component with the given name, or a not-found error.

--- a/pkg/kube/component_test.go
+++ b/pkg/kube/component_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -27,30 +26,13 @@ func componentLabels(componentName string) map[string]string {
 	return map[string]string{"im-id": "1", "im-type": componentName}
 }
 
-func TestDeploymentComponentRestartPatchesDeployment(t *testing.T) {
-	instance := componentTestInstance()
-	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "core", Namespace: "ns", Labels: componentLabels("dhis2")}}
-	c := &Client{Clientset: fake.NewSimpleClientset(dep)}
-
-	component := DeploymentComponent{BaseComponent{Name: "dhis2"}}
-	require.NoError(t, component.Restart(context.Background(), c, instance))
-
-	got, err := c.Clientset.AppsV1().Deployments("ns").Get(context.TODO(), "core", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotEmpty(t, got.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"])
+// testComponent is a minimal concrete Component; the real technology-named types live in pkg/stack.
+type testComponent struct {
+	BaseComponent
 }
 
-func TestStatefulSetComponentRestartPatchesStatefulSet(t *testing.T) {
-	instance := componentTestInstance()
-	set := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns", Labels: componentLabels("db")}}
-	c := &Client{Clientset: fake.NewSimpleClientset(set)}
-
-	component := StatefulSetComponent{BaseComponent{Name: "db"}}
-	require.NoError(t, component.Restart(context.Background(), c, instance))
-
-	got, err := c.Clientset.AppsV1().StatefulSets("ns").Get(context.TODO(), "db", metav1.GetOptions{})
-	require.NoError(t, err)
-	assert.NotEmpty(t, got.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"])
+func (c testComponent) Restart(context.Context, *Client, *model.DeploymentInstance) error {
+	return nil
 }
 
 func TestPVCSelectors(t *testing.T) {
@@ -160,8 +142,8 @@ func TestRestartReplicaMissingPod(t *testing.T) {
 
 func TestFindComponent(t *testing.T) {
 	components := []Component{
-		DeploymentComponent{BaseComponent{Name: "dhis2"}},
-		StatefulSetComponent{BaseComponent{Name: "db"}},
+		testComponent{BaseComponent{Name: "dhis2"}},
+		testComponent{BaseComponent{Name: "db"}},
 	}
 
 	found, err := FindComponent(components, "db")

--- a/pkg/kube/operations.go
+++ b/pkg/kube/operations.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componentName string) error {
+func (c *Client) RestartStatefulSet(ctx context.Context, instance *model.DeploymentInstance, componentName string) error {
 	selector, err := labelSelector(instance.ID, componentName)
 	if err != nil {
 		return err
@@ -22,7 +22,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 	}
 
 	statefulSets := c.Clientset.AppsV1().StatefulSets(instance.Group.Namespace)
-	statefulSetsList, err := statefulSets.List(context.TODO(), listOptions)
+	statefulSetsList, err := statefulSets.List(ctx, listOptions)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 
 	statefulSet := statefulSetsItems[0]
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = statefulSets.Patch(context.TODO(), statefulSet.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	_, err = statefulSets.Patch(ctx, statefulSet.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("error restarting %q: %v", statefulSet.Name, err)
 	}
@@ -45,7 +45,7 @@ func (c *Client) RestartStatefulSet(instance *model.DeploymentInstance, componen
 	return nil
 }
 
-func (c *Client) RestartDeployment(instance *model.DeploymentInstance, componentName string) error {
+func (c *Client) RestartDeployment(ctx context.Context, instance *model.DeploymentInstance, componentName string) error {
 	selector, err := labelSelector(instance.ID, componentName)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 	}
 
 	deployments := c.Clientset.AppsV1().Deployments(instance.Group.Namespace)
-	deploymentList, err := deployments.List(context.TODO(), listOptions)
+	deploymentList, err := deployments.List(ctx, listOptions)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 
 	deployment := deploymentItems[0]
 	data := fmt.Sprintf(`{"spec": {"template": {"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}}}`, time.Now().Format(time.RFC3339))
-	_, err = deployments.Patch(context.TODO(), deployment.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
+	_, err = deployments.Patch(ctx, deployment.Name, types.StrategicMergePatchType, []byte(data), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("error restarting %q: %v", deployment.Name, err)
 	}
@@ -78,8 +78,8 @@ func (c *Client) RestartDeployment(instance *model.DeploymentInstance, component
 	return nil
 }
 
-func (c *Client) Pause(instance *model.DeploymentInstance) error {
-	err := c.scale(instance, 0)
+func (c *Client) Pause(ctx context.Context, instance *model.DeploymentInstance) error {
+	err := c.scale(ctx, instance, 0)
 	if err != nil {
 		return fmt.Errorf("failed to pause instance %d: %v", instance.ID, err)
 	}
@@ -87,8 +87,8 @@ func (c *Client) Pause(instance *model.DeploymentInstance) error {
 	return nil
 }
 
-func (c *Client) Resume(instance *model.DeploymentInstance) error {
-	err := c.scale(instance, 1)
+func (c *Client) Resume(ctx context.Context, instance *model.DeploymentInstance) error {
+	err := c.scale(ctx, instance, 1)
 	if err != nil {
 		return fmt.Errorf("failed to resume instance %d: %v", instance.ID, err)
 	}
@@ -124,31 +124,31 @@ func (c *Client) DeletePVCs(ctx context.Context, namespace string, selectors []s
 	return nil
 }
 
-func (c *Client) scale(instance *model.DeploymentInstance, replicas int32) error {
+func (c *Client) scale(ctx context.Context, instance *model.DeploymentInstance, replicas int32) error {
 	labelSelector := fmt.Sprintf("im-id=%d", instance.ID)
 	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
 
 	deployments := c.Clientset.AppsV1().Deployments(instance.Group.Namespace)
-	deploymentList, err := deployments.List(context.TODO(), listOptions)
+	deploymentList, err := deployments.List(ctx, listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding deployments using selector %q: %v", labelSelector, err)
 	}
 
 	for _, d := range deploymentList.Items {
-		_, err = scale(deployments, d.Name, replicas)
+		_, err = scale(ctx, deployments, d.Name, replicas)
 		if err != nil {
 			return err
 		}
 	}
 
 	sets := c.Clientset.AppsV1().StatefulSets(instance.Group.Namespace)
-	setsList, err := sets.List(context.TODO(), listOptions)
+	setsList, err := sets.List(ctx, listOptions)
 	if err != nil {
 		return fmt.Errorf("error finding StatefulSets using selector %q: %v", labelSelector, err)
 	}
 
 	for _, s := range setsList.Items {
-		_, err = scale(sets, s.Name, replicas)
+		_, err = scale(ctx, sets, s.Name, replicas)
 		if err != nil {
 			return err
 		}
@@ -166,8 +166,8 @@ type scaler interface {
 
 // scale updates the number of replicas on a scaler. The desired number of replicas before scaling
 // was updated is returned.
-func scale(sc scaler, name string, replicas int32) (int32, error) {
-	scale, err := sc.GetScale(context.TODO(), name, metav1.GetOptions{})
+func scale(ctx context.Context, sc scaler, name string, replicas int32) (int32, error) {
+	scale, err := sc.GetScale(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to get scale of %q: %v", name, err)
 	}
@@ -175,7 +175,7 @@ func scale(sc scaler, name string, replicas int32) (int32, error) {
 	prevReplicas := scale.Spec.Replicas
 	scale.Spec.Replicas = replicas
 
-	_, err = sc.UpdateScale(context.TODO(), name, scale, metav1.UpdateOptions{})
+	_, err = sc.UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to update scale of %q to %d: %v", name, replicas, err)
 	}

--- a/pkg/stack/chap.go
+++ b/pkg/stack/chap.go
@@ -22,7 +22,7 @@ var ChapDB = Stack{
 		"DATABASE_SECRET":   chapDBSecretProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}},
+		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}},
 	},
 }
 
@@ -61,7 +61,7 @@ var ChapValkey = Stack{
 		"REDIS_SECRET": chapValkeySecretProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "chap-valkey"}},
+		ValkeyComponent{BaseComponent: kube.BaseComponent{Name: "chap-valkey"}},
 	},
 }
 
@@ -98,7 +98,7 @@ var ChapWorker = Stack{
 	},
 	Requires: []Stack{ChapDB, ChapValkey},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "chap-worker"}},
+		ChapWorkerComponent{BaseComponent: kube.BaseComponent{Name: "chap-worker"}},
 	},
 }
 
@@ -132,7 +132,7 @@ var ChapCore = Stack{
 	Requires:   []Stack{ChapDB, ChapValkey},
 	Companions: []Stack{ChapWorker},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "chap-core"}},
+		ChapCoreComponent{BaseComponent: kube.BaseComponent{Name: "chap-core"}},
 	},
 }
 

--- a/pkg/stack/components.go
+++ b/pkg/stack/components.go
@@ -1,7 +1,10 @@
 package stack
 
 import (
+	"context"
+
 	"github.com/dhis2-sre/im-manager/pkg/kube"
+	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
 // Components returns the components of the named stack.
@@ -11,4 +14,94 @@ func (s Service) Components(stackName string) ([]kube.Component, error) {
 		return nil, err
 	}
 	return stack.Components, nil
+}
+
+// Concrete component types are named for the chart/technology they operate on; the Kubernetes
+// workload kind behind each is an implementation detail of its Restart. This is what lets a future
+// dhis2 stack swap BitnamiPostgresComponent for CNPGPostgresComponent in its definition alone,
+// bringing operations specific to that technology (e.g. CNPG's native S3 backup) without any
+// dispatch changes.
+
+// DHIS2CoreComponent operates on the dhis2-core chart's Deployment.
+type DHIS2CoreComponent struct {
+	kube.BaseComponent
+}
+
+func (c DHIS2CoreComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// BitnamiPostgresComponent operates on the Bitnami PostgreSQL chart's StatefulSet.
+type BitnamiPostgresComponent struct {
+	kube.BaseComponent
+}
+
+func (c BitnamiPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// CNPGPostgresComponent operates on a CloudNativePG-managed PostgreSQL cluster. Restart currently
+// applies the generic StatefulSet patch, which finds nothing against CNPG's bare pods (unchanged
+// from before components existed); roadmap step 5 reimplements it via the Cluster custom resource's
+// restart annotation.
+type CNPGPostgresComponent struct {
+	kube.BaseComponent
+}
+
+func (c CNPGPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// MinioComponent operates on the Bitnami MinIO chart's Deployment.
+type MinioComponent struct {
+	kube.BaseComponent
+}
+
+func (c MinioComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// PgAdminComponent operates on the runix pgadmin4 chart's StatefulSet.
+type PgAdminComponent struct {
+	kube.BaseComponent
+}
+
+func (c PgAdminComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// WhoamiComponent operates on the whoami-go chart's Deployment.
+type WhoamiComponent struct {
+	kube.BaseComponent
+}
+
+func (c WhoamiComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// ValkeyComponent operates on the Bitnami Valkey chart's StatefulSet.
+type ValkeyComponent struct {
+	kube.BaseComponent
+}
+
+func (c ValkeyComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartStatefulSet(ctx, instance, c.Name)
+}
+
+// ChapWorkerComponent operates on the chap-worker chart's Deployment.
+type ChapWorkerComponent struct {
+	kube.BaseComponent
+}
+
+func (c ChapWorkerComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
+}
+
+// ChapCoreComponent operates on the chap-core chart's Deployment.
+type ChapCoreComponent struct {
+	kube.BaseComponent
+}
+
+func (c ChapCoreComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
+	return client.RestartDeployment(ctx, instance, c.Name)
 }

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -10,6 +12,9 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 // allStacks are the deployable stack definitions; every one must declare its components. The
@@ -32,6 +37,56 @@ func TestEveryStackHasUniqueNamedComponents(t *testing.T) {
 	}
 
 	assert.Empty(t, IMJobRunner.Components, "im-job-runner deliberately has no components until jobs are redesigned")
+}
+
+// TestComponentRestartTargetsExpectedWorkload asserts each technology component patches the
+// Kubernetes workload kind its chart actually deploys.
+func TestComponentRestartTargetsExpectedWorkload(t *testing.T) {
+	instance := &model.DeploymentInstance{ID: 1, Name: "myinstance", Group: &model.Group{ID: 7, Namespace: "ns"}}
+
+	tests := []struct {
+		component   kube.Component
+		statefulSet bool
+	}{
+		{DHIS2CoreComponent{kube.BaseComponent{Name: "dhis2"}}, false},
+		{BitnamiPostgresComponent{kube.BaseComponent{Name: "db"}}, true},
+		{CNPGPostgresComponent{kube.BaseComponent{Name: "chap-db"}}, true},
+		{MinioComponent{kube.BaseComponent{Name: "minio"}}, false},
+		{PgAdminComponent{kube.BaseComponent{Name: "pgadmin"}}, true},
+		{WhoamiComponent{kube.BaseComponent{Name: "whoami"}}, false},
+		{ValkeyComponent{kube.BaseComponent{Name: "chap-valkey"}}, true},
+		{ChapWorkerComponent{kube.BaseComponent{Name: "chap-worker"}}, false},
+		{ChapCoreComponent{kube.BaseComponent{Name: "chap-core"}}, false},
+	}
+
+	for _, test := range tests {
+		name := test.component.ComponentName()
+		t.Run(fmt.Sprintf("%T", test.component), func(t *testing.T) {
+			labels := map[string]string{"im-id": "1", "im-type": name}
+			meta := metav1.ObjectMeta{Name: name, Namespace: "ns", Labels: labels}
+
+			var client *kube.Client
+			if test.statefulSet {
+				client = &kube.Client{Clientset: fake.NewSimpleClientset(&appsv1.StatefulSet{ObjectMeta: meta})}
+			} else {
+				client = &kube.Client{Clientset: fake.NewSimpleClientset(&appsv1.Deployment{ObjectMeta: meta})}
+			}
+
+			require.NoError(t, test.component.Restart(context.Background(), client, instance))
+
+			var annotations map[string]string
+			if test.statefulSet {
+				got, err := client.Clientset.AppsV1().StatefulSets("ns").Get(context.TODO(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				annotations = got.Spec.Template.Annotations
+			} else {
+				got, err := client.Clientset.AppsV1().Deployments("ns").Get(context.TODO(), name, metav1.GetOptions{})
+				require.NoError(t, err)
+				annotations = got.Spec.Template.Annotations
+			}
+			assert.NotEmpty(t, annotations["kubectl.kubernetes.io/restartedAt"])
+		})
+	}
 }
 
 // TestDHIS2CoreAdvertisesFilestoreBackup asserts the capability listing: the dhis2-core component

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -156,7 +156,7 @@ var DHIS2DB = Stack{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{
+		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name:        "db",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s-database"},
 		}},
@@ -203,7 +203,7 @@ var MINIO = Stack{
 	},
 	Requires: []Stack{DHIS2DB},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{
+		MinioComponent{BaseComponent: kube.BaseComponent{
 			Name:        "minio",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s-minio"},
 		}},
@@ -281,7 +281,7 @@ var DHIS2Core = Stack{
 		ChapCore,
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{
+		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{
 			Name: "dhis2",
 			PVCPatterns: []string{
 				"app.kubernetes.io/instance=%s",
@@ -405,8 +405,8 @@ var DHIS2 = Stack{
 		"DATABASE_HOSTNAME": postgresHostnameProvider,
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "dhis2"}},
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{
+		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{Name: "dhis2"}},
+		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name: "db",
 			PVCPatterns: []string{
 				"app.kubernetes.io/instance=%s-database",
@@ -439,7 +439,7 @@ var PgAdmin = Stack{
 		DHIS2DB,
 	},
 	Components: []kube.Component{
-		kube.StatefulSetComponent{BaseComponent: kube.BaseComponent{Name: "pgadmin"}},
+		PgAdminComponent{BaseComponent: kube.BaseComponent{Name: "pgadmin"}},
 	},
 }
 
@@ -460,7 +460,7 @@ var WhoamiGo = Stack{
 		"CHART_VERSION":     {Priority: 5, DisplayName: "Chart Version", DefaultValue: &whoamiGoDefaults.chartVersion},
 	},
 	Components: []kube.Component{
-		kube.DeploymentComponent{BaseComponent: kube.BaseComponent{Name: "whoami"}},
+		WhoamiComponent{BaseComponent: kube.BaseComponent{Name: "whoami"}},
 	},
 }
 


### PR DESCRIPTION
Stacked on #1620, retargets to version-3.0 when it merges. Re-cuts the concrete component types by chart/technology per design discussion: a component is a BitnamiPostgresComponent or MinioComponent, not a StatefulSetComponent; the workload kind is an implementation detail inside each two-line Restart delegating to the shared helpers. DeploymentComponent/StatefulSetComponent are deleted. chap-db becomes CNPGPostgresComponent, keeping its current statefulset restart no-op behavior against CNPG bare pods until roadmap step 5 implements restart via the Cluster CR. A future dhis2v2 stack swaps the postgres component type in its definition alone to gain CNPG-specific operations. Also threads context through the kube operation helpers (RestartDeployment, RestartStatefulSet, Pause, Resume, scale), removing the context.TODO() calls carried over from the verbatim extraction, so request cancellation propagates to the Kubernetes API. No behavior change otherwise; restart delegation is covered by a new table test over every technology type.