### PR TITLE
feat: component presence predicates and the dhis2-v2 stack

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -516,20 +516,7 @@ func getPrivateKey(ctx context.Context, logger *slog.Logger) (*rsa.PrivateKey, e
 }
 
 func newStackService() (stack.Service, error) {
-	stacks, err := stack.New(
-		stack.DHIS2DB,
-		stack.MINIO,
-		stack.DHIS2Core,
-		stack.DHIS2,
-		stack.DHIS2V2,
-		stack.PgAdmin,
-		stack.WhoamiGo,
-		stack.IMJobRunner,
-		stack.ChapDB,
-		stack.ChapValkey,
-		stack.ChapWorker,
-		stack.ChapCore,
-	)
+	stacks, err := stack.New(stack.All...)
 	if err != nil {
 		return stack.Service{}, fmt.Errorf("error in stack config: %v", err)
 	}

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -521,6 +521,7 @@ func newStackService() (stack.Service, error) {
 		stack.MINIO,
 		stack.DHIS2Core,
 		stack.DHIS2,
+		stack.DHIS2V2,
 		stack.PgAdmin,
 		stack.WhoamiGo,
 		stack.IMJobRunner,

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -562,6 +562,8 @@ func (s Service) DestroyInstance(ctx context.Context, instance *model.Deployment
 		return err
 	}
 
+	// Deliberately not filtered by presence: PVC deletion skips selectors matching nothing, and a
+	// storage type changed between deploys must not leave the previous component's volumes behind.
 	var selectors []string
 	for _, component := range components {
 		selectors = append(selectors, component.PVCSelectors(instance)...)
@@ -629,10 +631,17 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 		return err
 	}
 
-	components, err := s.stackService.Components(instance.StackName)
+	stack, err := s.stackService.Find(instance.StackName)
 	if err != nil {
 		return err
 	}
+
+	instance, err = s.instanceRepository.DecryptDeploymentInstance(instance, stack)
+	if err != nil {
+		return err
+	}
+
+	components := kube.PresentComponents(stack.Components, instance.Parameters)
 	if len(components) == 0 {
 		return errdef.NewBadRequest("stack %q has no components to restart", instance.StackName)
 	}
@@ -687,7 +696,7 @@ func (s Service) Components(ctx context.Context, instance *model.DeploymentInsta
 		return nil, err
 	}
 
-	components := stack.Components
+	components := kube.PresentComponents(stack.Components, instance.Parameters)
 	statuses := make([]ComponentStatus, len(components))
 	for i, component := range components {
 		replicas, err := component.Replicas(ctx, client, instance)

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -47,6 +47,7 @@ type Replica struct {
 // chart/technology it operates on and implementing Restart against its own Kubernetes resource.
 type Component interface {
 	ComponentName() string
+	Present(params model.DeploymentInstanceParameters) bool
 	Restart(ctx context.Context, client *Client, instance *model.DeploymentInstance) error
 	RestartReplica(ctx context.Context, client *Client, instance *model.DeploymentInstance, podName string) error
 	Replicas(ctx context.Context, client *Client, instance *model.DeploymentInstance) ([]Replica, error)
@@ -60,10 +61,30 @@ type BaseComponent struct {
 	Name         string
 	PVCPatterns  []string
 	Capabilities []Capability
+	// When gates the component's presence on the instance's decrypted parameters; nil means the
+	// component is always present (e.g. a minio component only exists when STORAGE_TYPE is minio,
+	// mirroring the chart's own enable condition).
+	When CapabilityPredicate
 }
 
 func (b BaseComponent) ComponentName() string {
 	return b.Name
+}
+
+// Present reports whether this component exists for an instance with the given decrypted parameters.
+func (b BaseComponent) Present(params model.DeploymentInstanceParameters) bool {
+	return b.When == nil || b.When(params)
+}
+
+// PresentComponents returns the components present for an instance with the given decrypted parameters.
+func PresentComponents(components []Component, params model.DeploymentInstanceParameters) []Component {
+	present := make([]Component, 0, len(components))
+	for _, component := range components {
+		if component.Present(params) {
+			present = append(present, component)
+		}
+	}
+	return present
 }
 
 // SupportedOperations returns the base operations every component supports plus the capabilities

--- a/pkg/kube/component_test.go
+++ b/pkg/kube/component_test.go
@@ -87,6 +87,24 @@ func TestSupportedOperations(t *testing.T) {
 		component.SupportedOperations(minioParams))
 }
 
+func TestPresentComponents(t *testing.T) {
+	always := testComponent{BaseComponent{Name: "always"}}
+	whenMinio := testComponent{BaseComponent{Name: "minio", When: func(params model.DeploymentInstanceParameters) bool {
+		return params["STORAGE_TYPE"].Value == "minio"
+	}}}
+	components := []Component{always, whenMinio}
+
+	assert.True(t, always.Present(nil))
+
+	minioParams := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "minio"}}
+	assert.Len(t, PresentComponents(components, minioParams), 2)
+
+	s3Params := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "s3"}}
+	present := PresentComponents(components, s3Params)
+	require.Len(t, present, 1)
+	assert.Equal(t, "always", present[0].ComponentName())
+}
+
 func TestReplicas(t *testing.T) {
 	instance := componentTestInstance()
 	pod := componentTestPod("core-1", "dhis2")

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -20,10 +20,16 @@ import (
 // allStacks are the deployable stack definitions; every one must declare its components. The
 // job-runner is exempt: it is an old jobs experiment that only labels pods, and jobs get their
 // own design in a separate task.
-var allStacks = []Stack{
-	DHIS2DB, MINIO, DHIS2Core, DHIS2, DHIS2V2, PgAdmin, WhoamiGo,
-	ChapDB, ChapValkey, ChapWorker, ChapCore,
-}
+var allStacks = func() []Stack {
+	var stacks []Stack
+	for _, s := range All {
+		if s.Name == IMJobRunner.Name {
+			continue
+		}
+		stacks = append(stacks, s)
+	}
+	return stacks
+}()
 
 func TestEveryStackHasUniqueNamedComponents(t *testing.T) {
 	for _, s := range allStacks {

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -21,7 +21,7 @@ import (
 // job-runner is exempt: it is an old jobs experiment that only labels pods, and jobs get their
 // own design in a separate task.
 var allStacks = []Stack{
-	DHIS2DB, MINIO, DHIS2Core, DHIS2, PgAdmin, WhoamiGo,
+	DHIS2DB, MINIO, DHIS2Core, DHIS2, DHIS2V2, PgAdmin, WhoamiGo,
 	ChapDB, ChapValkey, ChapWorker, ChapCore,
 }
 
@@ -89,6 +89,27 @@ func TestComponentRestartTargetsExpectedWorkload(t *testing.T) {
 	}
 }
 
+// TestDHIS2V2MinioComponentPresence asserts the minio component only exists when the file store
+// lives in the bundled MinIO, mirroring the chart's minio.enabled condition.
+func TestDHIS2V2MinioComponentPresence(t *testing.T) {
+	names := func(params model.DeploymentInstanceParameters) []string {
+		var names []string
+		for _, c := range kube.PresentComponents(DHIS2V2.Components, params) {
+			names = append(names, c.ComponentName())
+		}
+		return names
+	}
+
+	minioParams := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "minio"}}
+	assert.Equal(t, []string{"dhis2", "db", "minio"}, names(minioParams))
+
+	filesystemParams := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "filesystem"}}
+	assert.Equal(t, []string{"dhis2", "db"}, names(filesystemParams))
+
+	s3Params := model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "s3"}}
+	assert.Equal(t, []string{"dhis2", "db"}, names(s3Params))
+}
+
 // TestDHIS2CoreAdvertisesFilestoreBackup asserts the capability listing: the dhis2-core component
 // supports filestore backup for every storage backend, while other stacks only expose the base
 // operations.
@@ -122,6 +143,13 @@ func TestComponentPVCSelectorParity(t *testing.T) {
 		"dhis2-core": {"app.kubernetes.io/instance=%s", "app.kubernetes.io/instance=%s-minio"},
 		"dhis2-db":   {"app.kubernetes.io/instance=%s-database"},
 		"minio":      {"app.kubernetes.io/instance=%s-minio"},
+		// dhis2-v2 postdates the hardcoded map; the release's own PVCs share its instance label so
+		// selectors are qualified by chart name, and the CNPG cluster labels its volumes itself.
+		"dhis2-v2": {
+			"app.kubernetes.io/instance=%s,app.kubernetes.io/name=dhis2",
+			"cnpg.io/cluster=%s-dhis2-postgresql",
+			"app.kubernetes.io/instance=%s,app.kubernetes.io/name=minio",
+		},
 	}
 
 	instance := &model.DeploymentInstance{Name: "mydb", Group: &model.Group{ID: 7}}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -418,6 +418,91 @@ var DHIS2 = Stack{
 	},
 }
 
+// DHIS2V2 deploys the dhis2 umbrella chart: one release bundling DHIS 2 core, PostgreSQL and an
+// optional MinIO file store, replacing the deployment-level composition of dhis2-db, dhis2-core
+// and the minio companion.
+var DHIS2V2 = Stack{
+	Name: "dhis2-v2",
+	Parameters: StackParameters{
+		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", DefaultValue: &dhis2CoreDefaults.imageTag},
+		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", DefaultValue: &dhis2CoreDefaults.imageRepository},
+		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
+		"DATABASE_ID":                     {Priority: 4, DisplayName: "Database"},
+		"DATABASE_NAME":                   {Priority: 5, DisplayName: "Database Name", DefaultValue: &dhis2DBDefaults.dbName},
+		"DATABASE_PASSWORD":               {Priority: 6, DisplayName: "Database Password", DefaultValue: &dhis2DBDefaults.dbPassword, Sensitive: true},
+		"DATABASE_SIZE":                   {Priority: 7, DisplayName: "Database Size", DefaultValue: &dhis2DBDefaults.dbSize},
+		"DATABASE_USERNAME":               {Priority: 8, DisplayName: "Database Username", DefaultValue: &dhis2DBDefaults.dbUsername, Sensitive: true},
+		"STORAGE_TYPE":                    {Priority: 10, DisplayName: "Storage type", DefaultValue: &dhis2CoreDefaults.storageType, Validator: storage},
+		"MINIO_STORAGE_SIZE":              {Priority: 11, DisplayName: "MinIO storage size (only in effect if \"Storage\" is set to \"minio\")", DefaultValue: &minIODefaults.storageSize},
+		"FILESYSTEM_VOLUME_SIZE":          {Priority: 12, DisplayName: "Filesystem volume size (only in effect if \"Storage\" is set to \"filesystem\")", DefaultValue: &dhis2CoreDefaults.filesystemVolumeSize, Sensitive: true},
+		"S3_BUCKET":                       {Priority: 13, DisplayName: "S3 bucket", DefaultValue: &dhis2CoreDefaults.s3Bucket},
+		"S3_REGION":                       {Priority: 14, DisplayName: "S3 region", DefaultValue: &dhis2CoreDefaults.s3Region, Sensitive: true},
+		"S3_IDENTITY":                     {Priority: 15, DisplayName: "S3 identity", DefaultValue: &dhis2CoreDefaults.s3Identity, Sensitive: true},
+		"S3_SECRET":                       {Priority: 16, DisplayName: "S3 secret", DefaultValue: &dhis2CoreDefaults.s3Secret, Sensitive: true},
+		"DHIS2_HOME":                      {Priority: 17, DisplayName: "DHIS2 Home Directory", DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {Priority: 18, DisplayName: "Flyway Migrate Out Of Order", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {Priority: 19, DisplayName: "Flyway Repair Before Migration", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		"CORE_RESOURCES_REQUESTS_CPU":     {Priority: 20, DisplayName: "Core Resources Requests CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		"CORE_RESOURCES_REQUESTS_MEMORY":  {Priority: 21, DisplayName: "Core Resources Requests Memory", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		"DB_RESOURCES_REQUESTS_CPU":       {Priority: 22, DisplayName: "DB Resources Requests CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		"DB_RESOURCES_REQUESTS_MEMORY":    {Priority: 23, DisplayName: "DB Resources Requests Memory", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+		"MIN_READY_SECONDS":               {Priority: 24, DisplayName: "Minimum Ready Seconds", DefaultValue: &dhis2CoreDefaults.minReadySeconds},
+		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {Priority: 25, DisplayName: "Liveness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		"READINESS_PROBE_TIMEOUT_SECONDS": {Priority: 26, DisplayName: "Readiness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		"STARTUP_PROBE_FAILURE_THRESHOLD": {Priority: 27, DisplayName: "Startup Probe Failure Threshold", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		"STARTUP_PROBE_PERIOD_SECONDS":    {Priority: 28, DisplayName: "Startup Probe Period Seconds", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+		"CHART_VERSION":                   {Priority: 29, DisplayName: "Chart Version", DefaultValue: &dhis2V2Defaults.chartVersion},
+		"JAVA_OPTS":                       {Priority: 30, DisplayName: "JAVA Options", DefaultValue: &dhis2CoreDefaults.javaOpts},
+		"ENABLE_QUERY_LOGGING":            {Priority: 31, DisplayName: "Enable Query Logging", DefaultValue: &dhis2CoreDefaults.enableQueryLogging},
+		"SAME_SITE_COOKIES":               {Priority: 32, DisplayName: "Same site cookies", DefaultValue: &dhis2CoreDefaults.sameSiteCookies, Validator: sameSiteCookies},
+		"CUSTOM_DHIS2_CONFIG":             {Priority: 33, DisplayName: "Custom DHIS2 config (applied to top of dhis.conf)", DefaultValue: &dhis2CoreDefaults.customDhis2Config, Sensitive: true},
+		"GOOGLE_AUTH_PROJECT_ID":          {Priority: 0, DisplayName: "Google auth project id", DefaultValue: &dhis2CoreDefaults.googleAuthProjectId, Sensitive: true},
+		"GOOGLE_AUTH_PRIVATE_KEY":         {Priority: 0, DisplayName: "Google auth private key", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKey, Sensitive: true},
+		"GOOGLE_AUTH_PRIVATE_KEY_ID":      {Priority: 0, DisplayName: "Google auth private key id", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKeyId, Sensitive: true},
+		"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 0, DisplayName: "Google auth client email", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
+		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 0, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
+	},
+	ParameterProviders: ParameterProviders{
+		"DATABASE_HOSTNAME": dhis2V2PostgresHostnameProvider,
+	},
+	Components: []kube.Component{
+		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{
+			Name:        "dhis2",
+			PVCPatterns: []string{"app.kubernetes.io/instance=%s,app.kubernetes.io/name=dhis2"},
+			Capabilities: []kube.Capability{
+				{Operation: kube.OperationFilestoreBackup},
+			},
+		}},
+		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{
+			Name:        "db",
+			PVCPatterns: []string{"cnpg.io/cluster=%s-dhis2-postgresql"},
+		}},
+		MinioComponent{BaseComponent: kube.BaseComponent{
+			Name:        "minio",
+			PVCPatterns: []string{"app.kubernetes.io/instance=%s,app.kubernetes.io/name=minio"},
+			When:        storageTypeIsMinio,
+		}},
+	},
+}
+
+var dhis2V2Defaults = struct {
+	chartVersion string
+}{
+	chartVersion: "0.1.0",
+}
+
+// The minio component only exists when the file store lives in the bundled MinIO, mirroring the
+// chart's own minio.enabled condition.
+var storageTypeIsMinio = kube.CapabilityPredicate(func(params model.DeploymentInstanceParameters) bool {
+	return params["STORAGE_TYPE"].Value == minIOStorage
+})
+
+// Provides the PostgreSQL hostname of a dhis2-v2 instance: the CNPG cluster's read-write service,
+// named after the chart fullname (<release>-dhis2).
+var dhis2V2PostgresHostnameProvider = ParameterProviderFunc(func(instance model.DeploymentInstance) (string, error) {
+	return fmt.Sprintf("%s-%d-dhis2-postgresql-rw.%s.svc", instance.Name, instance.Group.ID, instance.Group.Namespace), nil
+})
+
 var dhis2Defaults = struct {
 	installRedis string
 }{

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -22,6 +22,23 @@ import (
 // Stacks represents all deployable stacks.
 type Stacks map[string]Stack
 
+// All lists every stack the service serves. main.go registers exactly this list and the tests
+// derive their expectations from it, so a new stack is added here and nowhere else.
+var All = []Stack{
+	DHIS2DB,
+	MINIO,
+	DHIS2Core,
+	DHIS2,
+	DHIS2V2,
+	PgAdmin,
+	WhoamiGo,
+	IMJobRunner,
+	ChapDB,
+	ChapValkey,
+	ChapWorker,
+	ChapCore,
+}
+
 // New creates stacks ensuring consumed parameters are provided by required stacks.
 func New(stacks ...Stack) (Stacks, error) {
 	_, err := ValidateNoCycles(stacks)

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -505,7 +505,7 @@ var DHIS2V2 = Stack{
 var dhis2V2Defaults = struct {
 	chartVersion string
 }{
-	chartVersion: "0.1.0",
+	chartVersion: "1.0.0",
 }
 
 // The minio component only exists when the file store lives in the bundled MinIO, mirroring the

--- a/pkg/stack/stack_definitions_test.go
+++ b/pkg/stack/stack_definitions_test.go
@@ -41,6 +41,7 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 		"dhis2-db":      DHIS2DB.Parameters,
 		"dhis2-core":    DHIS2Core.Parameters,
 		"dhis2":         DHIS2.Parameters,
+		"dhis2-v2":      DHIS2V2.Parameters,
 		"minio":         MINIO.Parameters,
 		"pgadmin":       PgAdmin.Parameters,
 		"whoami-go":     WhoamiGo.Parameters,

--- a/pkg/stack/stack_definitions_test.go
+++ b/pkg/stack/stack_definitions_test.go
@@ -37,19 +37,9 @@ func TestStackDefinitionsAreInSyncWithHelmfile(t *testing.T) {
 	// helmfileParameters will not contain Go Validator or Provider functions. We therefore need to
 	// create a map of stack name to parameters with parameters only containing. DefaultValue and
 	// Consumed as we cannot ignore fields in the assertions we use.
-	stacks := map[string]StackParameters{
-		"dhis2-db":      DHIS2DB.Parameters,
-		"dhis2-core":    DHIS2Core.Parameters,
-		"dhis2":         DHIS2.Parameters,
-		"dhis2-v2":      DHIS2V2.Parameters,
-		"minio":         MINIO.Parameters,
-		"pgadmin":       PgAdmin.Parameters,
-		"whoami-go":     WhoamiGo.Parameters,
-		"im-job-runner": IMJobRunner.Parameters,
-		"chap-db":       ChapDB.Parameters,
-		"chap-valkey":   ChapValkey.Parameters,
-		"chap-worker":   ChapWorker.Parameters,
-		"chap-core":     ChapCore.Parameters,
+	stacks := make(map[string]StackParameters, len(All))
+	for _, s := range All {
+		stacks[s.Name] = s.Parameters
 	}
 	stackDefinitions := make(map[string]StackParameters)
 	for stackName, stackParameters := range stacks {

--- a/stacks/dhis2-v2/helmfile.yaml.gotmpl
+++ b/stacks/dhis2-v2/helmfile.yaml.gotmpl
@@ -1,0 +1,180 @@
+# stackParameters: GOOGLE_AUTH_PROJECT_ID,GOOGLE_AUTH_PRIVATE_KEY_ID,GOOGLE_AUTH_PRIVATE_KEY,GOOGLE_AUTH_CLIENT_EMAIL,GOOGLE_AUTH_CLIENT_ID
+{{ $_ := requiredEnv "DATABASE_ID" }}
+helmDefaults:
+  createNamespace: false
+  deleteWait: true
+
+releases:
+  - name: "{{ requiredEnv "INSTANCE_NAME" }}"
+    namespace: "{{ requiredEnv "INSTANCE_NAMESPACE" }}"
+    chart: dhis2/dhis2
+    version: "{{ requiredEnv "CHART_VERSION" }}"
+    values:
+      - image:
+          repository: dhis2/{{ requiredEnv "IMAGE_REPOSITORY" }}
+          tag: "{{ requiredEnv "IMAGE_TAG" }}"
+          pullPolicy: {{ requiredEnv "IMAGE_PULL_POLICY" }}
+      - ingress:
+          enabled: true
+          hostname: {{ requiredEnv "INSTANCE_HOSTNAME" }}
+          path: /{{ requiredEnv "INSTANCE_PATH_NAME" }}
+          certIssuer: "{{ env "CERT_ISSUER" }}"
+          className: "{{ env "INGRESS_CLASS" }}"
+          annotations:
+            nginx.ingress.kubernetes.io/proxy-body-size: 128m
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+      - dhis2Home: "{{ requiredEnv "DHIS2_HOME" }}"
+      - catalinaOpts: "-Dcontext.path=/{{ requiredEnv "INSTANCE_PATH_NAME" }} -Dcontext.sameSiteCookies={{ requiredEnv "SAME_SITE_COOKIES" }}"
+      - contextPath: /{{ requiredEnv "INSTANCE_PATH_NAME" }}
+      - javaOpts: "{{ requiredEnv "JAVA_OPTS" }}"
+      - minReadySeconds: {{ requiredEnv "MIN_READY_SECONDS" }}
+      - startupProbe:
+          failureThreshold: {{ requiredEnv "STARTUP_PROBE_FAILURE_THRESHOLD" }}
+          periodSeconds: {{ requiredEnv "STARTUP_PROBE_PERIOD_SECONDS" }}
+          path: /{{ requiredEnv "INSTANCE_PATH_NAME" }}
+      - livenessProbe:
+          timeoutSeconds: {{ requiredEnv "LIVENESS_PROBE_TIMEOUT_SECONDS" }}
+          path: /{{ requiredEnv "INSTANCE_PATH_NAME" }}
+      - readinessProbe:
+          timeoutSeconds: {{ requiredEnv "READINESS_PROBE_TIMEOUT_SECONDS" }}
+          path: /{{ requiredEnv "INSTANCE_PATH_NAME" }}
+      - commonLabels:
+          im: "true"
+          im-default: "true"
+          im-deployment-id: "{{ requiredEnv "DEPLOYMENT_ID" }}"
+          im-instance-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+          im-type: "dhis2"
+          im-creation-timestamp: "{{ requiredEnv "INSTANCE_CREATION_TIMESTAMP" }}"
+          im-ttl: "{{ requiredEnv "INSTANCE_TTL" }}"
+
+      - storage:
+          type: {{ requiredEnv "STORAGE_TYPE" }}
+
+      {{- if eq (requiredEnv "STORAGE_TYPE") "filesystem" }}
+      - storage:
+          volumeSize: {{ requiredEnv "FILESYSTEM_VOLUME_SIZE" }}
+      # Restore the filestore into dhis-home before core starts, ahead of the chart's
+      # dhis2-home-permissions init container so it fixes ownership of the extracted files.
+      - initContainers:
+          - name: "{{ requiredEnv "INSTANCE_NAME" }}-init-fs"
+            image: alpine:3.18
+            imagePullPolicy: {{ requiredEnv "IMAGE_PULL_POLICY" }}
+            env:
+              - name: DHIS2_HOME
+                value: "{{ requiredEnv "DHIS2_HOME" }}"
+              - name: FILESTORE_DOWNLOAD_URL
+                value: {{ env "FILESTORE_DOWNLOAD_URL" | default "" }}
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                {{- readFile "./seed-filesystem.sh" | nindent 16 }}
+            volumeMounts:
+              - name: dhis-home
+                mountPath: "{{ requiredEnv "DHIS2_HOME" }}"
+      {{- end }}
+
+      {{- if eq (requiredEnv "STORAGE_TYPE") "s3" }}
+      - S3:
+          provider: aws-s3
+          container: "{{ requiredEnv "S3_BUCKET" }}"
+          endpoint: ""
+          location: "{{ requiredEnv "S3_REGION" }}"
+          identity: "{{ requiredEnv "S3_IDENTITY" }}"
+          secret: "{{ requiredEnv "S3_SECRET" }}"
+      {{- end }}
+
+      {{- if ne (requiredEnv "CUSTOM_DHIS2_CONFIG") "" }}
+      - customConfigSnippet:
+          {{- requiredEnv "CUSTOM_DHIS2_CONFIG" | nindent 10 }}
+      {{- end }}
+
+      - sessionCookieSameSite: {{ requiredEnv "SAME_SITE_COOKIES" }}
+
+      - flyway:
+          migrateOutOfOrder: {{ requiredEnv "FLYWAY_MIGRATE_OUT_OF_ORDER" }}
+          repairBeforeMigration: {{ requiredEnv "FLYWAY_REPAIR_BEFORE_MIGRATION" }}
+
+      - enableQueryLogging: {{ requiredEnv "ENABLE_QUERY_LOGGING" }}
+
+      - googleAuth:
+          projectId: "{{ requiredEnv "GOOGLE_AUTH_PROJECT_ID" }}"
+          privateKeyId: "{{ requiredEnv "GOOGLE_AUTH_PRIVATE_KEY_ID" }}"
+          privateKey: '{{ requiredEnv "GOOGLE_AUTH_PRIVATE_KEY" }}'
+          clientEmail: "{{ requiredEnv "GOOGLE_AUTH_CLIENT_EMAIL" }}"
+          clientId: "{{ requiredEnv "GOOGLE_AUTH_CLIENT_ID" }}"
+
+      - resources:
+          requests:
+            cpu: {{ requiredEnv "CORE_RESOURCES_REQUESTS_CPU" }}
+            memory: {{ requiredEnv "CORE_RESOURCES_REQUESTS_MEMORY" }}
+
+      # Database credentials are set once; the PostgreSQL subchart and core's connection settings
+      # both read them from here.
+      - global:
+          postgresql:
+            auth:
+              username: {{ requiredEnv "DATABASE_USERNAME" }}
+              password: {{ requiredEnv "DATABASE_PASSWORD" }}
+              database: {{ requiredEnv "DATABASE_NAME" }}
+
+      - postgresql:
+          commonLabels:
+            im: "true"
+            im-deployment-id: "{{ requiredEnv "DEPLOYMENT_ID" }}"
+            im-instance-id: "{{ requiredEnv "INSTANCE_ID" }}"
+            im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+            im-type: "db"
+            im-creation-timestamp: "{{ requiredEnv "INSTANCE_CREATION_TIMESTAMP" }}"
+            im-ttl: "{{ requiredEnv "INSTANCE_TTL" }}"
+          storageSize: {{ requiredEnv "DATABASE_SIZE" }}
+          resources:
+            requests:
+              cpu: {{ requiredEnv "DB_RESOURCES_REQUESTS_CPU" }}
+              memory: {{ requiredEnv "DB_RESOURCES_REQUESTS_MEMORY" }}
+          seed:
+            enabled: true
+            extraEnv:
+              - name: DATABASE_DOWNLOAD_URL
+                value: {{ env "DATABASE_DOWNLOAD_URL" | default "" }}
+              - name: DATABASE_USERNAME
+                value: {{ requiredEnv "DATABASE_USERNAME" }}
+            script: |
+              {{- readFile "./seed.sh" | indent 14 }}
+
+      {{- if eq (requiredEnv "STORAGE_TYPE") "minio" }}
+      - minio:
+          enabled: true
+          commonLabels:
+            im: "true"
+            im-deployment-id: "{{ requiredEnv "DEPLOYMENT_ID" }}"
+            im-instance-id: "{{ requiredEnv "INSTANCE_ID" }}"
+            im-id: "{{ requiredEnv "INSTANCE_ID" }}"
+            im-type: "minio"
+            im-creation-timestamp: "{{ requiredEnv "INSTANCE_CREATION_TIMESTAMP" }}"
+            im-ttl: "{{ requiredEnv "INSTANCE_TTL" }}"
+          persistence:
+            size: {{ requiredEnv "MINIO_STORAGE_SIZE" }}
+            annotations:
+              helm.sh/resource-policy: keep
+          sidecars:
+            - name: "{{ requiredEnv "INSTANCE_NAME" }}-minio-seed"
+              # Should match the version used by the main container
+              image: bitnamilegacy/minio:2024.8.29-debian-12-r2
+              pullPolicy: {{ requiredEnv "IMAGE_PULL_POLICY" }}
+              env:
+                - name: FILESTORE_DOWNLOAD_URL
+                  value: {{ env "FILESTORE_DOWNLOAD_URL" | default "" }}
+              command:
+                - "/bin/bash"
+                - "-c"
+                - |
+                  {{- readFile "./seed-minio.sh" | nindent 18 }}
+      {{- end }}
+
+repositories:
+  - name: dhis2
+    url: https://dhis2-sre.github.io/dhis2-core-chart
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami

--- a/stacks/dhis2-v2/seed-filesystem.sh
+++ b/stacks/dhis2-v2/seed-filesystem.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -o pipefail
+
+# The marker lives outside files/ so it is not swept into the next backup.
+marker="$DHIS2_HOME/.im-filestore-seeded"
+
+if [ -f "$marker" ]; then
+  echo "Filestore already seeded, skipping..."
+  exit 0
+fi
+
+if [ -z "${FILESTORE_DOWNLOAD_URL:-}" ]; then
+  echo "No filestore to seed"
+  exit 0
+fi
+
+apk add --no-cache curl tar gzip
+
+echo "Filestore download URL: $FILESTORE_DOWNLOAD_URL"
+echo "Seeding filesystem..."
+
+tmp_file=$(mktemp)
+trap 'rm -f "$tmp_file"' EXIT
+
+if ! curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail --show-error -L "$FILESTORE_DOWNLOAD_URL" > "$tmp_file"; then
+  echo "Failed to download filestore from $FILESTORE_DOWNLOAD_URL"
+  exit 1
+fi
+
+mkdir -p "$DHIS2_HOME/files"
+if ! gunzip -c "$tmp_file" | tar xf - -C "$DHIS2_HOME/files"; then
+  echo "Failed to extract filestore archive"
+  exit 1
+fi
+
+# Write the marker only after a successful extract so a failed attempt retries.
+echo "Seeded from $FILESTORE_DOWNLOAD_URL" > "$marker"
+
+echo "Done seeding filesystem!"

--- a/stacks/dhis2-v2/seed-minio.sh
+++ b/stacks/dhis2-v2/seed-minio.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+# Use 127.0.0.1 to ensure we hit the main MinIO container in the same pod.
+MINIO_URL="http://127.0.0.1:9000"
+
+timeout=60
+elapsed=0
+success_count=0
+required_successes=5
+
+while [ "$success_count" -lt "$required_successes" ]; do
+  if curl --silent --fail "$MINIO_URL/minio/health/ready"; then
+    success_count=$((success_count + 1))
+    echo "MinIO health check $success_count/$required_successes passed"
+  else
+    success_count=0
+    echo "MinIO health check failed, resetting counter"
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+  if [ "$elapsed" -ge "$timeout" ]; then
+    echo "Timeout reached: MinIO is not ready after $timeout seconds."
+    exit 1
+  fi
+done
+
+echo "MinIO is stable and ready!"
+mc alias set local "$MINIO_URL" dhisdhis dhisdhis
+
+seed_file=local/dhis2/seeded.txt
+if mc stat $seed_file >/dev/null 2>&1; then
+  echo "Already seeded, skipping..."
+else
+  if [[ -z "${FILESTORE_DOWNLOAD_URL:-}" ]]; then
+    echo "No filestore to seed"
+  else
+    echo "Filestore download URL: $FILESTORE_DOWNLOAD_URL"
+    echo "Seeding..."
+
+    tmp_file=$(mktemp)
+    if ! curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail --show-error -L "$FILESTORE_DOWNLOAD_URL" > "$tmp_file"; then
+      echo "Failed to download filestore from $FILESTORE_DOWNLOAD_URL"
+      exit 1
+    fi
+
+    tmp_dir=$(mktemp -d /tmp/minio.XXXXXX)
+    trap 'rm -f "$tmp_file"; rm -rf "$tmp_dir"' EXIT
+    gunzip -c "$tmp_file" | tar xf - -C "$tmp_dir"
+    chmod -R u+rwx,go+rx "$tmp_dir"
+
+    mc mirror "$tmp_dir"/ local/dhis2/
+
+    echo "Seeded from $FILESTORE_DOWNLOAD_URL" | mc pipe $seed_file
+
+    if ! mc stat $seed_file >/dev/null 2>&1; then
+      echo "Seeding verification failed: $seed_file not found after upload"
+      exit 1
+    fi
+    echo "Seeding verified: $seed_file exists"
+
+    rm -f "$tmp_file"
+    rm -rf "$tmp_dir"
+
+    echo "Done seeding!"
+  fi
+fi
+
+# Wait forever, if the sidecar container terminates Kubernetes will restart it
+tail -f /dev/null

--- a/stacks/dhis2-v2/seed.sh
+++ b/stacks/dhis2-v2/seed.sh
@@ -1,0 +1,46 @@
+# Runs inside the dhis2 chart's seed job, which prepares superuser PGHOST/PGUSER/PGPASSWORD/
+# PGDATABASE, waits for the database and guards with a marker table; DHIS 2 waits for the marker.
+
+function exec_psql() {
+  psql --no-align --tuples-only --command="$1"
+}
+
+if [[ -z "${DATABASE_DOWNLOAD_URL:-}" ]]; then
+  echo "Seeding aborted. No database download URL found!"
+  exit 0
+fi
+
+echo "DATABASE_DOWNLOAD_URL: $DATABASE_DOWNLOAD_URL"
+
+exec_psql "create extension if not exists postgis"
+exec_psql "create extension if not exists pg_trgm"
+exec_psql "create extension if not exists btree_gin"
+
+tmp_file=$(mktemp)
+curl --connect-timeout 10 --retry 5 --retry-delay 1 --fail -L "$DATABASE_DOWNLOAD_URL" >"$tmp_file" || {
+  echo "curl failed with exit code $?"
+  exit 1
+}
+
+# Try pg_restore... Or gzipped sql
+# pg_restore often returns a non zero return code due to benign errors resulting in executing of gunzip despite the restore being successful
+# gunzip will fail because the input isn't gzipped causing the whole seed script to fail... Which is why there's a "|| true" at the end
+(pg_restore --verbose -d "$PGDATABASE" -j 4 "$tmp_file") ||
+  (gunzip -v -c "$tmp_file" | psql) || true
+rm "$tmp_file"
+
+## Change ownership to $DATABASE_USERNAME
+change_owner() {
+  local query=$1
+  local obj_type=$2
+
+  entities=$(exec_psql "$query")
+  for entity in $entities; do
+    echo "Changing owner of $obj_type $entity to $DATABASE_USERNAME"
+    exec_psql "ALTER $obj_type \"$entity\" OWNER TO $DATABASE_USERNAME"
+  done
+}
+
+change_owner "SELECT tablename FROM pg_tables WHERE schemaname = 'public'" "TABLE"
+change_owner "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = 'public'" "SEQUENCE"
+change_owner "SELECT table_name FROM information_schema.views WHERE table_schema = 'public'" "VIEW"


### PR DESCRIPTION
Roadmap step 9's IM half, targeting version-3.0.

Components can declare a presence predicate evaluated against decrypted instance parameters: Restart now decrypts internally like Components and both filter by presence, so an absent component is a 404 and restart-all skips it. DestroyInstance deliberately stays unfiltered since PVC deletion skips empty selectors and a changed storage type must not orphan the previous component's volumes.

The first consumer is the new dhis2-v2 stack: one release of the dhis2 chart (dhis2-sre/dhis2-core-chart#86) bundling core, a CloudNativePG PostgreSQL cluster and an optional MinIO, replacing the dhis2-db + dhis2-core + minio companion composition. STORAGE_TYPE maps to the chart's storage.type and minio.enabled, database credentials are set once via global.postgresql.auth, hostnames resolve to the chart's services (the CNPG read-write service for the database), and each component carries its own im-type label (dhis2, db, minio).

Seeding uses the chart's marker-guarded post-install job with the seed script adapted to its superuser PG* environment, replacing the Bitnami initdb mechanism.

The db component is a CNPGPostgresComponent with its volume selected via the cnpg.io/cluster label; its CR-based restart lands with roadmap step 5, until then restart targets nothing, unchanged from chap-db today. The minio component only exists when STORAGE_TYPE is minio, so the components endpoint never lists a phantom minio. DATABASE_VERSION is dropped since the PostgreSQL version rides the chart's PostGIS image.

Deploying requires the published dhis2 chart, now released as dhis2 1.0.0 (dhis2-sre/dhis2-core-chart#86 merged with charts/core removed and the dhis2 chart promoted to the only chart); the CHART_VERSION default points at 1.0.0. Integration coverage for a live dhis2-v2 deploy needs the CNPG operator in the test k3s and follows separately.
