### PR TITLE
fix: grant the service account access to cloudnativepg clusters

### DIFF
--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -67,3 +67,17 @@ rules:
       - create
       - delete
       - patch
+# CloudNativePG clusters deployed by the dhis2-v2 stack. Custom resources are not covered by the
+# namespace-scoped admin grants that handle native resources in group namespaces.
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete


### PR DESCRIPTION
Deploying the dhis2-v2 stack on the version-3-0 feature environment failed with clusters.postgresql.cnpg.io is forbidden for the instance manager's service account. The namespace-scoped admin grants that let helm manage native resources in group namespaces do not cover custom resources, so the CNPG Cluster templated by the dhis2 chart needs explicit rules on the cluster role. Verified against the live environment where the CNPG CRDs are present and only RBAC blocked the install; the Doris CRDs will need the same treatment when a stack first enables the bundled dorisCluster.