### PR TITLE
fix: allow pod deletion and hook job watching for the service account

### DIFF
--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -11,6 +11,8 @@ rules:
       - pods
     verbs:
       - list
+      # Per-replica restart deletes a pod and lets the owning controller or operator recreate it.
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -67,6 +69,21 @@ rules:
       - create
       - delete
       - patch
+# Helm waits for chart hook jobs (e.g. the dhis2 chart's database seed) by watching them, and the
+# before-hook-creation delete policy recreates them on upgrades. Without watch, helm sits blind
+# until its timeout and marks the release failed even though the hook succeeded.
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 # CloudNativePG clusters deployed by the dhis2-v2 stack. Custom resources are not covered by the
 # namespace-scoped admin grants that handle native resources in group namespaces.
   - apiGroups:


### PR DESCRIPTION
Two RBAC gaps found smoke testing dhis2-v2 on the version-3-0 environment, both verified with kubectl auth can-i against the live service account. Per-replica restart is a supervised pod delete the controller recovers from, but the cluster role only allowed listing pods, so PUT /instances/:id/restart?selector=db&replica=... returned 500 with pods is forbidden. Helm waits for chart hook jobs (the dhis2 chart's database seed) by watching them; without watch on batch jobs helm sat blind until its five minute timeout and marked the release failed even though the seed job completed in 53 seconds, which would also break every subsequent upgrade of the release. Jobs get the full verb set since the before-hook-creation delete policy also needs delete on upgrades.