### PR TITLE
feat: cnpg component restart through the cluster resource

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -20,9 +20,10 @@ import (
 )
 
 // Client talks to a single cluster's Kubernetes API. Construct it with NewClient so RestConfig is
-// populated; the fields are exported so tests can inject a fake Clientset.
+// populated; the fields are exported so tests can inject a fake Clientset and a fake Dynamic client.
 type Client struct {
 	Clientset  kubernetes.Interface
+	Dynamic    dynamic.Interface
 	RestConfig *rest.Config
 }
 
@@ -37,7 +38,12 @@ func NewClient(config model.Cluster) (*Client, error) {
 		return nil, fmt.Errorf("error creating kube client: %v", err)
 	}
 
-	return &Client{Clientset: client, RestConfig: restConfig}, nil
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error creating dynamic kube client: %v", err)
+	}
+
+	return &Client{Clientset: client, Dynamic: dynamicClient, RestConfig: restConfig}, nil
 }
 
 func newMetricsClient(cluster model.Cluster) (*metricsv1beta1.Clientset, error) {

--- a/pkg/kube/operations.go
+++ b/pkg/kube/operations.go
@@ -9,6 +9,7 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -93,6 +94,20 @@ func (c *Client) Resume(ctx context.Context, instance *model.DeploymentInstance)
 		return fmt.Errorf("failed to resume instance %d: %v", instance.ID, err)
 	}
 
+	return nil
+}
+
+var cnpgClusterResource = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "clusters"}
+
+// RestartCNPGCluster triggers a rolling restart of a CloudNativePG cluster by stamping the
+// standard restartedAt annotation on the Cluster resource, the same mechanism as the cnpg kubectl
+// plugin's restart command. Patching the operator-managed pods directly would fight the operator.
+func (c *Client) RestartCNPGCluster(ctx context.Context, namespace, name string) error {
+	data := fmt.Sprintf(`{"metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": "%s"}}}`, time.Now().Format(time.RFC3339))
+	_, err := c.Dynamic.Resource(cnpgClusterResource).Namespace(namespace).Patch(ctx, name, types.MergePatchType, []byte(data), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("error restarting %q: %v", name, err)
+	}
 	return nil
 }
 

--- a/pkg/stack/chap.go
+++ b/pkg/stack/chap.go
@@ -22,7 +22,7 @@ var ChapDB = Stack{
 		"DATABASE_SECRET":   chapDBSecretProvider,
 	},
 	Components: []kube.Component{
-		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}},
+		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "chap-db"}, ClusterPattern: "%s-chap-db-postgres"},
 	},
 }
 

--- a/pkg/stack/components.go
+++ b/pkg/stack/components.go
@@ -2,6 +2,7 @@ package stack
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
@@ -40,16 +41,19 @@ func (c BitnamiPostgresComponent) Restart(ctx context.Context, client *kube.Clie
 	return client.RestartStatefulSet(ctx, instance, c.Name)
 }
 
-// CNPGPostgresComponent operates on a CloudNativePG-managed PostgreSQL cluster. Restart currently
-// applies the generic StatefulSet patch, which finds nothing against CNPG's bare pods (unchanged
-// from before components existed); roadmap step 5 reimplements it via the Cluster custom resource's
-// restart annotation.
+// CNPGPostgresComponent operates on a CloudNativePG-managed PostgreSQL cluster. Restart goes
+// through the Cluster custom resource so the operator performs the rollout; patching the bare pods
+// it manages would fight it.
 type CNPGPostgresComponent struct {
 	kube.BaseComponent
+	// ClusterPattern names the Cluster resource, formatted with the instance's "<name>-<groupID>"
+	// unique name, e.g. "%s-dhis2-postgresql".
+	ClusterPattern string
 }
 
 func (c CNPGPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
-	return client.RestartStatefulSet(ctx, instance, c.Name)
+	clusterName := fmt.Sprintf(c.ClusterPattern, fmt.Sprintf("%s-%d", instance.Name, instance.Group.ID))
+	return client.RestartCNPGCluster(ctx, instance.Group.Namespace, clusterName)
 }
 
 // MinioComponent operates on the Bitnami MinIO chart's Deployment.

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -56,7 +60,8 @@ func TestComponentRestartTargetsExpectedWorkload(t *testing.T) {
 	}{
 		{DHIS2CoreComponent{kube.BaseComponent{Name: "dhis2"}}, false},
 		{BitnamiPostgresComponent{kube.BaseComponent{Name: "db"}}, true},
-		{CNPGPostgresComponent{kube.BaseComponent{Name: "chap-db"}}, true},
+		// CNPGPostgresComponent is absent: its restart patches the Cluster custom resource, covered
+		// by TestCNPGComponentRestartPatchesCluster.
 		{MinioComponent{kube.BaseComponent{Name: "minio"}}, false},
 		{PgAdminComponent{kube.BaseComponent{Name: "pgadmin"}}, true},
 		{WhoamiComponent{kube.BaseComponent{Name: "whoami"}}, false},
@@ -93,6 +98,28 @@ func TestComponentRestartTargetsExpectedWorkload(t *testing.T) {
 			assert.NotEmpty(t, annotations["kubectl.kubernetes.io/restartedAt"])
 		})
 	}
+}
+
+// TestCNPGComponentRestartPatchesCluster asserts the CNPG component restarts through the Cluster
+// custom resource, named by the cluster pattern, rather than touching the operator's pods.
+func TestCNPGComponentRestartPatchesCluster(t *testing.T) {
+	instance := &model.DeploymentInstance{ID: 1, Name: "myinstance", Group: &model.Group{ID: 7, Namespace: "ns"}}
+	gvr := schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "clusters"}
+	cluster := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "postgresql.cnpg.io/v1",
+		"kind":       "Cluster",
+		"metadata":   map[string]any{"name": "myinstance-7-dhis2-postgresql", "namespace": "ns"},
+	}}
+	scheme := runtime.NewScheme()
+	client := &kube.Client{Dynamic: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{gvr: "ClusterList"}, cluster)}
+
+	component := CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "db"}, ClusterPattern: "%s-dhis2-postgresql"}
+	require.NoError(t, component.Restart(context.Background(), client, instance))
+
+	got, err := client.Dynamic.Resource(gvr).Namespace("ns").Get(context.Background(), "myinstance-7-dhis2-postgresql", metav1.GetOptions{})
+	require.NoError(t, err)
+	annotations := got.GetAnnotations()
+	assert.NotEmpty(t, annotations["kubectl.kubernetes.io/restartedAt"])
 }
 
 // TestDHIS2V2MinioComponentPresence asserts the minio component only exists when the file store

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -493,7 +493,7 @@ var DHIS2V2 = Stack{
 		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name:        "db",
 			PVCPatterns: []string{"cnpg.io/cluster=%s-dhis2-postgresql"},
-		}},
+		}, ClusterPattern: "%s-dhis2-postgresql"},
 		MinioComponent{BaseComponent: kube.BaseComponent{
 			Name:        "minio",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s,app.kubernetes.io/name=minio"},


### PR DESCRIPTION
First slice of roadmap step 5. The CNPG postgres component's restart stamps the standard kubectl.kubernetes.io/restartedAt annotation on the CloudNativePG Cluster resource through a new dynamic client on kube.Client, the same mechanism as the cnpg kubectl plugin's restart command, so the operator performs a supervised rollout. Previously the component carried the generic statefulset patch, which found nothing against CNPG's bare operator-managed pods; that gap was confirmed during the dhis2-v2 live validation. The Cluster name comes from a ClusterPattern on the component, set for dhis2-v2 (%s-dhis2-postgresql) and chap-db (%s-chap-db-postgres), which makes chap-db's restart operation real for the first time too. RBAC already covers the patch verb on clusters.postgresql.cnpg.io from #1629. Covered by a unit test patching a Cluster through the fake dynamic client; live verification on the version-3-0 environment follows the next env redeploy.