### PR TITLE
feat: deployment components endpoint

### DIFF
--- a/pkg/instance/docs.go
+++ b/pkg/instance/docs.go
@@ -37,7 +37,7 @@ type _ struct {
 	Selector string `json:"selector"`
 }
 
-// swagger:parameters deleteInstance findById findByIdDecrypted saveInstance pauseInstance resumeInstance resetInstance findDeploymentById deployDeployment deleteDeployment status instanceWithDetails filestoreBackup instanceComponents
+// swagger:parameters deleteInstance findById findByIdDecrypted saveInstance pauseInstance resumeInstance resetInstance findDeploymentById deployDeployment deleteDeployment status instanceWithDetails filestoreBackup instanceComponents deploymentComponents
 type _ struct {
 	// in: path
 	// required: true
@@ -70,6 +70,12 @@ type StatusBody struct {
 type ComponentsBody struct {
 	// in: body
 	Body []ComponentStatus
+}
+
+// swagger:response DeploymentComponents
+type DeploymentComponentsBody struct {
+	// in: body
+	Body []InstanceComponents
 }
 
 // swagger:parameters instanceNameToId

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -652,6 +652,56 @@ func (h Handler) Restart(c *gin.Context) {
 	c.Status(http.StatusAccepted)
 }
 
+// DeploymentComponents deployment components
+func (h Handler) DeploymentComponents(c *gin.Context) {
+	// swagger:route GET /deployments/{id}/components deploymentComponents
+	//
+	// Deployment components
+	//
+	// List the components of every instance in a deployment along with their supported operations and live replicas
+	//
+	// Security:
+	//	oauth2:
+	//
+	// responses:
+	//	200: DeploymentComponents
+	//	401: Error
+	//	403: Error
+	//	404: Error
+	//	415: Error
+	id, ok := handler.GetPathParameter(c, "id")
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+	user, err := handler.GetUserFromContext(ctx)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	deployment, err := h.instanceService.FindDeploymentById(ctx, id)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	canRead := handler.CanReadDeployment(user, deployment)
+	if !canRead {
+		_ = c.Error(errdef.NewUnauthorized("read access denied"))
+		return
+	}
+
+	components, err := h.instanceService.DeploymentComponents(ctx, deployment)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, components)
+}
+
 // Components instance components
 func (h Handler) Components(c *gin.Context) {
 	// swagger:route GET /instances/{id}/components instanceComponents

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -219,6 +219,17 @@ func TestInstanceHandler(t *testing.T) {
 		assert.Equal(t, "Running", replica.Phase)
 		assert.True(t, replica.Ready)
 
+		path = fmt.Sprintf("/deployments/%d/components", deployment.ID)
+		var deploymentComponents []instance.InstanceComponents
+		client.GetJSON(t, path, &deploymentComponents, inttest.WithAuthToken(tokens.AccessToken))
+
+		require.Len(t, deploymentComponents, 1)
+		assert.Equal(t, deploymentInstance.ID, deploymentComponents[0].InstanceID)
+		assert.Equal(t, "whoami-go", deploymentComponents[0].StackName)
+		require.Len(t, deploymentComponents[0].Components, 1)
+		assert.Equal(t, "whoami", deploymentComponents[0].Components[0].Name)
+		require.Len(t, deploymentComponents[0].Components[0].Replicas, 1)
+
 		path = fmt.Sprintf("/instances/%d/restart?replica=%s", deploymentInstance.ID, replica.Name)
 		response := client.Do(t, http.MethodPut, path, nil, http.StatusBadRequest, inttest.WithAuthToken(tokens.AccessToken))
 		assert.Contains(t, string(response), "replica requires a component selector")

--- a/pkg/instance/router.go
+++ b/pkg/instance/router.go
@@ -22,6 +22,7 @@ func Routes(r *gin.Engine, authenticator gin.HandlerFunc, handler Handler) {
 	tokenAuthenticationRouter.POST("/deployments", handler.SaveDeployment)
 	tokenAuthenticationRouter.GET("/deployments", handler.FindDeployments)
 	tokenAuthenticationRouter.GET("/deployments/:id", handler.FindDeploymentById)
+	tokenAuthenticationRouter.GET("/deployments/:id/components", handler.DeploymentComponents)
 	tokenAuthenticationRouter.DELETE("/deployments/:id", handler.DeleteDeployment)
 	tokenAuthenticationRouter.POST("/deployments/:id/instance", handler.SaveInstance)
 	tokenAuthenticationRouter.PATCH("/deployments/:id/instance/:instanceId", handler.UpdateInstance)

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -712,6 +712,40 @@ func (s Service) Components(ctx context.Context, instance *model.DeploymentInsta
 	return statuses, nil
 }
 
+type InstanceComponents struct {
+	InstanceID   uint              `json:"instanceId"`
+	InstanceName string            `json:"instanceName"`
+	StackName    string            `json:"stackName"`
+	Components   []ComponentStatus `json:"components"`
+}
+
+// DeploymentComponents lists every instance's components with live replicas for a whole
+// deployment. Each instance costs cluster round trips, so instances are queried concurrently; the
+// cluster watch cache planned in the roadmap later swaps the implementation under this shape.
+func (s Service) DeploymentComponents(ctx context.Context, deployment *model.Deployment) ([]InstanceComponents, error) {
+	result := make([]InstanceComponents, len(deployment.Instances))
+	group, groupCtx := errgroup.WithContext(ctx)
+	for i, instance := range deployment.Instances {
+		group.Go(func() error {
+			components, err := s.Components(groupCtx, instance)
+			if err != nil {
+				return fmt.Errorf("listing components of instance %q: %w", instance.Name, err)
+			}
+			result[i] = InstanceComponents{
+				InstanceID:   instance.ID,
+				InstanceName: instance.Name,
+				StackName:    instance.StackName,
+				Components:   components,
+			}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func (s Service) Logs(instance *model.DeploymentInstance, group *model.Group, typeSelector string) (io.ReadCloser, error) {
 	ks, err := kube.NewClient(group.Cluster)
 	if err != nil {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -428,6 +428,25 @@ definitions:
                 x-go-name: Status
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/health
+    InstanceComponents:
+        properties:
+            components:
+                items:
+                    $ref: '#/definitions/ComponentStatus'
+                type: array
+                x-go-name: Components
+            instanceId:
+                format: uint64
+                type: integer
+                x-go-name: InstanceID
+            instanceName:
+                type: string
+                x-go-name: InstanceName
+            stackName:
+                type: string
+                x-go-name: StackName
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/instance
     InstanceStatus:
         type: string
         x-go-package: github.com/dhis2-sre/im-manager/pkg/instance
@@ -1423,6 +1442,31 @@ paths:
             security:
                 - oauth2: []
             summary: Update a Deployment
+    /deployments/{id}/components:
+        get:
+            description: List the components of every instance in a deployment along with their supported operations and live replicas
+            operationId: deploymentComponents
+            parameters:
+                - format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "200":
+                    $ref: '#/responses/DeploymentComponents'
+                "401":
+                    $ref: '#/responses/Error'
+                "403":
+                    $ref: '#/responses/Error'
+                "404":
+                    $ref: '#/responses/Error'
+                "415":
+                    $ref: '#/responses/Error'
+            security:
+                - oauth2: []
+            summary: Deployment components
     /deployments/{id}/deploy:
         post:
             description: Deploy a deployment...
@@ -2579,6 +2623,12 @@ responses:
         description: ""
         schema:
             $ref: '#/definitions/Database'
+    DeploymentComponents:
+        description: ""
+        schema:
+            items:
+                $ref: '#/definitions/InstanceComponents'
+            type: array
     DeploymentInstance:
         description: ""
         schema:


### PR DESCRIPTION
GET /deployments/:id/components returns per-instance component statuses for a whole deployment: instance id, name, stack and each component's supported operations and live replicas.

Instances are queried concurrently since each costs cluster round trips. The implementation is deliberately naive and slow; its shape is the contract the cluster watch cache from the roadmap's status step later serves instantly, so the web client binds to it once (companion PR dhis2-sre/im-web-client#848).

Read-gated like the other deployment endpoints and covered in the components integration subtest.