### PR TITLE
fix: pull bitnami infrastructure charts via oci instead of the chart index

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -37,8 +37,7 @@ deploy:
       - name: im-rabbitmq-{{ .ENVIRONMENT }}
         namespace: instance-manager-{{ .CLASSIFICATION }}
         createNamespace: true
-        remoteChart: rabbitmq
-        repo: https://charts.bitnami.com/bitnami
+        remoteChart: oci://registry-1.docker.io/bitnamicharts/rabbitmq
         version: 14.4.2
         upgradeOnChange: true
         useHelmSecrets: true
@@ -65,8 +64,7 @@ deploy:
       - name: im-manager-postgresql-{{ .ENVIRONMENT }}
         namespace: instance-manager-{{ .CLASSIFICATION }}
         createNamespace: true
-        remoteChart: postgresql
-        repo: https://charts.bitnami.com/bitnami
+        remoteChart: oci://registry-1.docker.io/bitnamicharts/postgresql
         version: 13.2.30
         upgradeOnChange: true
         useHelmSecrets: true


### PR DESCRIPTION
The rabbitmq and postgresql infrastructure charts came from charts.bitnami.com, whose huge index download keeps timing out. This has failed the last several version-3-0 environment deploys, which is why the environment still lacks the deployment components endpoint, and the same timeouts have been eating CI and local test runs all week.

The OCI references pull the chart directly without the index and have been reliable in the chart repository's CI. The bitnamilegacy image overrides are untouched.