### PR TITLE
feat: parameter groups with declarative visibility conditions

### DIFF
--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -63,8 +63,9 @@ type BaseComponent struct {
 	Capabilities []Capability
 	// When gates the component's presence on the instance's decrypted parameters; nil means the
 	// component is always present (e.g. a minio component only exists when STORAGE_TYPE is minio,
-	// mirroring the chart's own enable condition).
-	When CapabilityPredicate
+	// mirroring the chart's own enable condition). Declarative so the stacks API can serve the
+	// same condition to clients.
+	When *Condition
 }
 
 func (b BaseComponent) ComponentName() string {
@@ -73,7 +74,7 @@ func (b BaseComponent) ComponentName() string {
 
 // Present reports whether this component exists for an instance with the given decrypted parameters.
 func (b BaseComponent) Present(params model.DeploymentInstanceParameters) bool {
-	return b.When == nil || b.When(params)
+	return b.When.Matches(params)
 }
 
 // PresentComponents returns the components present for an instance with the given decrypted parameters.

--- a/pkg/kube/component_test.go
+++ b/pkg/kube/component_test.go
@@ -89,9 +89,7 @@ func TestSupportedOperations(t *testing.T) {
 
 func TestPresentComponents(t *testing.T) {
 	always := testComponent{BaseComponent{Name: "always"}}
-	whenMinio := testComponent{BaseComponent{Name: "minio", When: func(params model.DeploymentInstanceParameters) bool {
-		return params["STORAGE_TYPE"].Value == "minio"
-	}}}
+	whenMinio := testComponent{BaseComponent{Name: "minio", When: &Condition{Parameter: "STORAGE_TYPE", Equals: "minio"}}}
 	components := []Component{always, whenMinio}
 
 	assert.True(t, always.Present(nil))

--- a/pkg/kube/condition.go
+++ b/pkg/kube/condition.go
@@ -1,0 +1,21 @@
+package kube
+
+import "github.com/dhis2-sre/im-manager/pkg/model"
+
+// Condition is a declarative predicate over an instance's parameters: it holds when the named
+// parameter has the given value. Being data rather than code, the same condition both gates a
+// component's presence on the backend and is served to clients, so forms can react to parameter
+// edits without a round trip and cannot disagree with the backend about when something exists.
+type Condition struct {
+	Parameter string `json:"parameter"`
+	Equals    string `json:"equals"`
+}
+
+// Matches reports whether the condition holds for the given decrypted parameters. A nil condition
+// always holds.
+func (c *Condition) Matches(params model.DeploymentInstanceParameters) bool {
+	if c == nil {
+		return true
+	}
+	return params[c.Parameter].Value == c.Equals
+}

--- a/pkg/kube/condition_test.go
+++ b/pkg/kube/condition_test.go
@@ -1,0 +1,19 @@
+package kube
+
+import (
+	"testing"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditionMatches(t *testing.T) {
+	var nilCondition *Condition
+	assert.True(t, nilCondition.Matches(nil))
+
+	condition := &Condition{Parameter: "STORAGE_TYPE", Equals: "minio"}
+	assert.True(t, condition.Matches(model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "minio"}}))
+	assert.False(t, condition.Matches(model.DeploymentInstanceParameters{"STORAGE_TYPE": {Value: "s3"}}))
+	assert.False(t, condition.Matches(model.DeploymentInstanceParameters{}))
+	assert.False(t, condition.Matches(nil))
+}

--- a/pkg/stack/handler.go
+++ b/pkg/stack/handler.go
@@ -60,6 +60,8 @@ func toResponseStack(stack Stack) StackResponse {
 		s.Requires[i] = StackResponse{Name: require.Name}
 	}
 
+	s.ParameterGroups = stack.ParameterGroups
+
 	for parameterName, parameter := range stack.Parameters {
 		s.Parameters = append(s.Parameters, StackParameterResponse{
 			ParameterName: parameterName,
@@ -68,6 +70,7 @@ func toResponseStack(stack Stack) StackResponse {
 			Consumed:      parameter.Consumed,
 			Priority:      parameter.Priority,
 			Sensitive:     parameter.Sensitive,
+			Group:         parameter.Group,
 		})
 	}
 
@@ -82,13 +85,15 @@ type StackParameterResponse struct {
 	Consumed      bool    `json:"consumed"`
 	Priority      uint    `json:"priority"`
 	Sensitive     bool    `json:"sensitive"`
+	Group         string  `json:"group,omitempty"`
 }
 
 // swagger:model Stack
 type StackResponse struct {
-	Name       string                   `json:"name"`
-	Parameters []StackParameterResponse `json:"parameters,omitempty"`
-	Requires   []StackResponse          `json:"requires,omitempty"`
+	Name            string                   `json:"name"`
+	Parameters      []StackParameterResponse `json:"parameters,omitempty"`
+	ParameterGroups []ParameterGroup         `json:"parameterGroups,omitempty"`
+	Requires        []StackResponse          `json:"requires,omitempty"`
 }
 
 // FindAll stack

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -440,44 +440,52 @@ var DHIS2 = Stack{
 // and the minio companion.
 var DHIS2V2 = Stack{
 	Name: "dhis2-v2",
+	ParameterGroups: []ParameterGroup{
+		{Name: "dhis2", Title: "DHIS 2 Core"},
+		{Name: "db", Title: "PostgreSQL"},
+		{Name: "storage", Title: "Storage"},
+		{Name: "minio", Title: "MinIO", When: whenStorageIsMinio},
+		{Name: "s3", Title: "S3", When: whenStorageIsS3},
+		{Name: "filesystem", Title: "Filesystem", When: whenStorageIsFilesystem},
+	},
 	Parameters: StackParameters{
-		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", DefaultValue: &dhis2CoreDefaults.imageTag},
-		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", DefaultValue: &dhis2CoreDefaults.imageRepository},
-		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
-		"DATABASE_ID":                     {Priority: 4, DisplayName: "Database"},
-		"DATABASE_NAME":                   {Priority: 5, DisplayName: "Database Name", DefaultValue: &dhis2DBDefaults.dbName},
-		"DATABASE_PASSWORD":               {Priority: 6, DisplayName: "Database Password", DefaultValue: &dhis2DBDefaults.dbPassword, Sensitive: true},
-		"DATABASE_SIZE":                   {Priority: 7, DisplayName: "Database Size", DefaultValue: &dhis2DBDefaults.dbSize},
-		"DATABASE_USERNAME":               {Priority: 8, DisplayName: "Database Username", DefaultValue: &dhis2DBDefaults.dbUsername, Sensitive: true},
-		"STORAGE_TYPE":                    {Priority: 10, DisplayName: "Storage type", DefaultValue: &dhis2CoreDefaults.storageType, Validator: storage},
-		"MINIO_STORAGE_SIZE":              {Priority: 11, DisplayName: "MinIO storage size (only in effect if \"Storage\" is set to \"minio\")", DefaultValue: &minIODefaults.storageSize},
-		"FILESYSTEM_VOLUME_SIZE":          {Priority: 12, DisplayName: "Filesystem volume size (only in effect if \"Storage\" is set to \"filesystem\")", DefaultValue: &dhis2CoreDefaults.filesystemVolumeSize, Sensitive: true},
-		"S3_BUCKET":                       {Priority: 13, DisplayName: "S3 bucket", DefaultValue: &dhis2CoreDefaults.s3Bucket},
-		"S3_REGION":                       {Priority: 14, DisplayName: "S3 region", DefaultValue: &dhis2CoreDefaults.s3Region, Sensitive: true},
-		"S3_IDENTITY":                     {Priority: 15, DisplayName: "S3 identity", DefaultValue: &dhis2CoreDefaults.s3Identity, Sensitive: true},
-		"S3_SECRET":                       {Priority: 16, DisplayName: "S3 secret", DefaultValue: &dhis2CoreDefaults.s3Secret, Sensitive: true},
-		"DHIS2_HOME":                      {Priority: 17, DisplayName: "DHIS2 Home Directory", DefaultValue: &dhis2CoreDefaults.dhis2Home},
-		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {Priority: 18, DisplayName: "Flyway Migrate Out Of Order", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
-		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {Priority: 19, DisplayName: "Flyway Repair Before Migration", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		"CORE_RESOURCES_REQUESTS_CPU":     {Priority: 20, DisplayName: "Core Resources Requests CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
-		"CORE_RESOURCES_REQUESTS_MEMORY":  {Priority: 21, DisplayName: "Core Resources Requests Memory", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
-		"DB_RESOURCES_REQUESTS_CPU":       {Priority: 22, DisplayName: "DB Resources Requests CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
-		"DB_RESOURCES_REQUESTS_MEMORY":    {Priority: 23, DisplayName: "DB Resources Requests Memory", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
-		"MIN_READY_SECONDS":               {Priority: 24, DisplayName: "Minimum Ready Seconds", DefaultValue: &dhis2CoreDefaults.minReadySeconds},
-		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {Priority: 25, DisplayName: "Liveness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
-		"READINESS_PROBE_TIMEOUT_SECONDS": {Priority: 26, DisplayName: "Readiness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
-		"STARTUP_PROBE_FAILURE_THRESHOLD": {Priority: 27, DisplayName: "Startup Probe Failure Threshold", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
-		"STARTUP_PROBE_PERIOD_SECONDS":    {Priority: 28, DisplayName: "Startup Probe Period Seconds", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
-		"CHART_VERSION":                   {Priority: 29, DisplayName: "Chart Version", DefaultValue: &dhis2V2Defaults.chartVersion},
-		"JAVA_OPTS":                       {Priority: 30, DisplayName: "JAVA Options", DefaultValue: &dhis2CoreDefaults.javaOpts},
-		"ENABLE_QUERY_LOGGING":            {Priority: 31, DisplayName: "Enable Query Logging", DefaultValue: &dhis2CoreDefaults.enableQueryLogging},
-		"SAME_SITE_COOKIES":               {Priority: 32, DisplayName: "Same site cookies", DefaultValue: &dhis2CoreDefaults.sameSiteCookies, Validator: sameSiteCookies},
-		"CUSTOM_DHIS2_CONFIG":             {Priority: 33, DisplayName: "Custom DHIS2 config (applied to top of dhis.conf)", DefaultValue: &dhis2CoreDefaults.customDhis2Config, Sensitive: true},
-		"GOOGLE_AUTH_PROJECT_ID":          {Priority: 0, DisplayName: "Google auth project id", DefaultValue: &dhis2CoreDefaults.googleAuthProjectId, Sensitive: true},
-		"GOOGLE_AUTH_PRIVATE_KEY":         {Priority: 0, DisplayName: "Google auth private key", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKey, Sensitive: true},
-		"GOOGLE_AUTH_PRIVATE_KEY_ID":      {Priority: 0, DisplayName: "Google auth private key id", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKeyId, Sensitive: true},
-		"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 0, DisplayName: "Google auth client email", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
-		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 0, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
+		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imageTag},
+		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imageRepository},
+		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
+		"DATABASE_ID":                     {Priority: 4, DisplayName: "Database", Group: "db"},
+		"DATABASE_NAME":                   {Priority: 5, DisplayName: "Database Name", Group: "db", DefaultValue: &dhis2DBDefaults.dbName},
+		"DATABASE_PASSWORD":               {Priority: 6, DisplayName: "Database Password", Group: "db", DefaultValue: &dhis2DBDefaults.dbPassword, Sensitive: true},
+		"DATABASE_SIZE":                   {Priority: 7, DisplayName: "Database Size", Group: "db", DefaultValue: &dhis2DBDefaults.dbSize},
+		"DATABASE_USERNAME":               {Priority: 8, DisplayName: "Database Username", Group: "db", DefaultValue: &dhis2DBDefaults.dbUsername, Sensitive: true},
+		"STORAGE_TYPE":                    {Priority: 10, DisplayName: "Storage type", Group: "storage", DefaultValue: &dhis2CoreDefaults.storageType, Validator: storage},
+		"MINIO_STORAGE_SIZE":              {Priority: 11, DisplayName: "Storage size", Group: "minio", DefaultValue: &minIODefaults.storageSize},
+		"FILESYSTEM_VOLUME_SIZE":          {Priority: 12, DisplayName: "Volume size", Group: "filesystem", DefaultValue: &dhis2CoreDefaults.filesystemVolumeSize, Sensitive: true},
+		"S3_BUCKET":                       {Priority: 13, DisplayName: "Bucket", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Bucket},
+		"S3_REGION":                       {Priority: 14, DisplayName: "Region", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Region, Sensitive: true},
+		"S3_IDENTITY":                     {Priority: 15, DisplayName: "Identity", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Identity, Sensitive: true},
+		"S3_SECRET":                       {Priority: 16, DisplayName: "Secret", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Secret, Sensitive: true},
+		"DHIS2_HOME":                      {Priority: 17, DisplayName: "DHIS2 Home Directory", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.dhis2Home},
+		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {Priority: 18, DisplayName: "Flyway Migrate Out Of Order", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {Priority: 19, DisplayName: "Flyway Repair Before Migration", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+		"CORE_RESOURCES_REQUESTS_CPU":     {Priority: 20, DisplayName: "Resources Requests CPU", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+		"CORE_RESOURCES_REQUESTS_MEMORY":  {Priority: 21, DisplayName: "Resources Requests Memory", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+		"DB_RESOURCES_REQUESTS_CPU":       {Priority: 22, DisplayName: "Resources Requests CPU", Group: "db", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+		"DB_RESOURCES_REQUESTS_MEMORY":    {Priority: 23, DisplayName: "Resources Requests Memory", Group: "db", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+		"MIN_READY_SECONDS":               {Priority: 24, DisplayName: "Minimum Ready Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.minReadySeconds},
+		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {Priority: 25, DisplayName: "Liveness Probe Timeout Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+		"READINESS_PROBE_TIMEOUT_SECONDS": {Priority: 26, DisplayName: "Readiness Probe Timeout Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+		"STARTUP_PROBE_FAILURE_THRESHOLD": {Priority: 27, DisplayName: "Startup Probe Failure Threshold", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+		"STARTUP_PROBE_PERIOD_SECONDS":    {Priority: 28, DisplayName: "Startup Probe Period Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+		"CHART_VERSION":                   {Priority: 29, DisplayName: "Chart Version", Group: "dhis2", DefaultValue: &dhis2V2Defaults.chartVersion},
+		"JAVA_OPTS":                       {Priority: 30, DisplayName: "JAVA Options", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.javaOpts},
+		"ENABLE_QUERY_LOGGING":            {Priority: 31, DisplayName: "Enable Query Logging", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.enableQueryLogging},
+		"SAME_SITE_COOKIES":               {Priority: 32, DisplayName: "Same site cookies", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.sameSiteCookies, Validator: sameSiteCookies},
+		"CUSTOM_DHIS2_CONFIG":             {Priority: 33, DisplayName: "Custom DHIS2 config (applied to top of dhis.conf)", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.customDhis2Config, Sensitive: true},
+		"GOOGLE_AUTH_PROJECT_ID":          {Priority: 34, DisplayName: "Google auth project id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthProjectId, Sensitive: true},
+		"GOOGLE_AUTH_PRIVATE_KEY":         {Priority: 35, DisplayName: "Google auth private key", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKey, Sensitive: true},
+		"GOOGLE_AUTH_PRIVATE_KEY_ID":      {Priority: 36, DisplayName: "Google auth private key id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKeyId, Sensitive: true},
+		"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 37, DisplayName: "Google auth client email", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
+		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 38, DisplayName: "Google auth client id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
 	},
 	ParameterProviders: ParameterProviders{
 		"DATABASE_HOSTNAME": dhis2V2PostgresHostnameProvider,
@@ -497,7 +505,7 @@ var DHIS2V2 = Stack{
 		MinioComponent{BaseComponent: kube.BaseComponent{
 			Name:        "minio",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s,app.kubernetes.io/name=minio"},
-			When:        storageTypeIsMinio,
+			When:        whenStorageIsMinio,
 		}},
 	},
 }
@@ -508,11 +516,14 @@ var dhis2V2Defaults = struct {
 	chartVersion: "1.0.0",
 }
 
-// The minio component only exists when the file store lives in the bundled MinIO, mirroring the
-// chart's own minio.enabled condition.
-var storageTypeIsMinio = kube.CapabilityPredicate(func(params model.DeploymentInstanceParameters) bool {
-	return params["STORAGE_TYPE"].Value == minIOStorage
-})
+// The storage conditions mirror the chart's own gating of each file store backend on STORAGE_TYPE.
+// The minio condition doubles as the minio component's presence predicate, so the deploy form's
+// section visibility and the backend's component listing cannot disagree.
+var (
+	whenStorageIsMinio      = &kube.Condition{Parameter: "STORAGE_TYPE", Equals: minIOStorage}
+	whenStorageIsS3         = &kube.Condition{Parameter: "STORAGE_TYPE", Equals: s3Storage}
+	whenStorageIsFilesystem = &kube.Condition{Parameter: "STORAGE_TYPE", Equals: filesystemStorage}
+)
 
 // Provides the PostgreSQL hostname of a dhis2-v2 instance: the CNPG cluster's read-write service,
 // named after the chart fullname (<release>-dhis2).

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -438,54 +438,58 @@ var DHIS2 = Stack{
 // DHIS2V2 deploys the dhis2 umbrella chart: one release bundling DHIS 2 core, PostgreSQL and an
 // optional MinIO file store, replacing the deployment-level composition of dhis2-db, dhis2-core
 // and the minio companion.
-var DHIS2V2 = Stack{
+var DHIS2V2 = withGroupedParameters(Stack{
 	Name: "dhis2-v2",
 	ParameterGroups: []ParameterGroup{
-		{Name: "dhis2", Title: "DHIS 2 Core"},
-		{Name: "db", Title: "PostgreSQL"},
-		{Name: "storage", Title: "Storage"},
-		{Name: "minio", Title: "MinIO", When: whenStorageIsMinio},
-		{Name: "s3", Title: "S3", When: whenStorageIsS3},
-		{Name: "filesystem", Title: "Filesystem", When: whenStorageIsFilesystem},
-	},
-	Parameters: StackParameters{
-		"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imageTag},
-		"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imageRepository},
-		"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
-		"DATABASE_ID":                     {Priority: 4, DisplayName: "Database", Group: "db"},
-		"DATABASE_NAME":                   {Priority: 5, DisplayName: "Database Name", Group: "db", DefaultValue: &dhis2DBDefaults.dbName},
-		"DATABASE_PASSWORD":               {Priority: 6, DisplayName: "Database Password", Group: "db", DefaultValue: &dhis2DBDefaults.dbPassword, Sensitive: true},
-		"DATABASE_SIZE":                   {Priority: 7, DisplayName: "Database Size", Group: "db", DefaultValue: &dhis2DBDefaults.dbSize},
-		"DATABASE_USERNAME":               {Priority: 8, DisplayName: "Database Username", Group: "db", DefaultValue: &dhis2DBDefaults.dbUsername, Sensitive: true},
-		"STORAGE_TYPE":                    {Priority: 10, DisplayName: "Storage type", Group: "storage", DefaultValue: &dhis2CoreDefaults.storageType, Validator: storage},
-		"MINIO_STORAGE_SIZE":              {Priority: 11, DisplayName: "Storage size", Group: "minio", DefaultValue: &minIODefaults.storageSize},
-		"FILESYSTEM_VOLUME_SIZE":          {Priority: 12, DisplayName: "Volume size", Group: "filesystem", DefaultValue: &dhis2CoreDefaults.filesystemVolumeSize, Sensitive: true},
-		"S3_BUCKET":                       {Priority: 13, DisplayName: "Bucket", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Bucket},
-		"S3_REGION":                       {Priority: 14, DisplayName: "Region", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Region, Sensitive: true},
-		"S3_IDENTITY":                     {Priority: 15, DisplayName: "Identity", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Identity, Sensitive: true},
-		"S3_SECRET":                       {Priority: 16, DisplayName: "Secret", Group: "s3", DefaultValue: &dhis2CoreDefaults.s3Secret, Sensitive: true},
-		"DHIS2_HOME":                      {Priority: 17, DisplayName: "DHIS2 Home Directory", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.dhis2Home},
-		"FLYWAY_MIGRATE_OUT_OF_ORDER":     {Priority: 18, DisplayName: "Flyway Migrate Out Of Order", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
-		"FLYWAY_REPAIR_BEFORE_MIGRATION":  {Priority: 19, DisplayName: "Flyway Repair Before Migration", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
-		"CORE_RESOURCES_REQUESTS_CPU":     {Priority: 20, DisplayName: "Resources Requests CPU", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
-		"CORE_RESOURCES_REQUESTS_MEMORY":  {Priority: 21, DisplayName: "Resources Requests Memory", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
-		"DB_RESOURCES_REQUESTS_CPU":       {Priority: 22, DisplayName: "Resources Requests CPU", Group: "db", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
-		"DB_RESOURCES_REQUESTS_MEMORY":    {Priority: 23, DisplayName: "Resources Requests Memory", Group: "db", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
-		"MIN_READY_SECONDS":               {Priority: 24, DisplayName: "Minimum Ready Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.minReadySeconds},
-		"LIVENESS_PROBE_TIMEOUT_SECONDS":  {Priority: 25, DisplayName: "Liveness Probe Timeout Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
-		"READINESS_PROBE_TIMEOUT_SECONDS": {Priority: 26, DisplayName: "Readiness Probe Timeout Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
-		"STARTUP_PROBE_FAILURE_THRESHOLD": {Priority: 27, DisplayName: "Startup Probe Failure Threshold", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
-		"STARTUP_PROBE_PERIOD_SECONDS":    {Priority: 28, DisplayName: "Startup Probe Period Seconds", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
-		"CHART_VERSION":                   {Priority: 29, DisplayName: "Chart Version", Group: "dhis2", DefaultValue: &dhis2V2Defaults.chartVersion},
-		"JAVA_OPTS":                       {Priority: 30, DisplayName: "JAVA Options", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.javaOpts},
-		"ENABLE_QUERY_LOGGING":            {Priority: 31, DisplayName: "Enable Query Logging", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.enableQueryLogging},
-		"SAME_SITE_COOKIES":               {Priority: 32, DisplayName: "Same site cookies", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.sameSiteCookies, Validator: sameSiteCookies},
-		"CUSTOM_DHIS2_CONFIG":             {Priority: 33, DisplayName: "Custom DHIS2 config (applied to top of dhis.conf)", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.customDhis2Config, Sensitive: true},
-		"GOOGLE_AUTH_PROJECT_ID":          {Priority: 34, DisplayName: "Google auth project id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthProjectId, Sensitive: true},
-		"GOOGLE_AUTH_PRIVATE_KEY":         {Priority: 35, DisplayName: "Google auth private key", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKey, Sensitive: true},
-		"GOOGLE_AUTH_PRIVATE_KEY_ID":      {Priority: 36, DisplayName: "Google auth private key id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKeyId, Sensitive: true},
-		"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 37, DisplayName: "Google auth client email", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
-		"GOOGLE_AUTH_CLIENT_ID":           {Priority: 38, DisplayName: "Google auth client id", Group: "dhis2", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
+		{Name: "dhis2", Title: "DHIS 2 Core", Parameters: StackParameters{
+			"IMAGE_TAG":                       {Priority: 1, DisplayName: "Image Tag", DefaultValue: &dhis2CoreDefaults.imageTag},
+			"IMAGE_REPOSITORY":                {Priority: 2, DisplayName: "Image Repository", DefaultValue: &dhis2CoreDefaults.imageRepository},
+			"IMAGE_PULL_POLICY":               {Priority: 3, DisplayName: "Image Pull Policy", DefaultValue: &dhis2CoreDefaults.imagePullPolicy, Validator: imagePullPolicy},
+			"DHIS2_HOME":                      {Priority: 17, DisplayName: "DHIS2 Home Directory", DefaultValue: &dhis2CoreDefaults.dhis2Home},
+			"FLYWAY_MIGRATE_OUT_OF_ORDER":     {Priority: 18, DisplayName: "Flyway Migrate Out Of Order", DefaultValue: &dhis2CoreDefaults.flywayMigrateOutOfOrder},
+			"FLYWAY_REPAIR_BEFORE_MIGRATION":  {Priority: 19, DisplayName: "Flyway Repair Before Migration", DefaultValue: &dhis2CoreDefaults.flywayRepairBeforeMigration},
+			"CORE_RESOURCES_REQUESTS_CPU":     {Priority: 20, DisplayName: "Resources Requests CPU", DefaultValue: &dhis2CoreDefaults.resourcesRequestsCPU},
+			"CORE_RESOURCES_REQUESTS_MEMORY":  {Priority: 21, DisplayName: "Resources Requests Memory", DefaultValue: &dhis2CoreDefaults.resourcesRequestsMemory},
+			"MIN_READY_SECONDS":               {Priority: 24, DisplayName: "Minimum Ready Seconds", DefaultValue: &dhis2CoreDefaults.minReadySeconds},
+			"LIVENESS_PROBE_TIMEOUT_SECONDS":  {Priority: 25, DisplayName: "Liveness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.livenessProbeTimeoutSeconds},
+			"READINESS_PROBE_TIMEOUT_SECONDS": {Priority: 26, DisplayName: "Readiness Probe Timeout Seconds", DefaultValue: &dhis2CoreDefaults.readinessProbeTimeoutSeconds},
+			"STARTUP_PROBE_FAILURE_THRESHOLD": {Priority: 27, DisplayName: "Startup Probe Failure Threshold", DefaultValue: &dhis2CoreDefaults.startupProbeFailureThreshold},
+			"STARTUP_PROBE_PERIOD_SECONDS":    {Priority: 28, DisplayName: "Startup Probe Period Seconds", DefaultValue: &dhis2CoreDefaults.startupProbePeriodSeconds},
+			"CHART_VERSION":                   {Priority: 29, DisplayName: "Chart Version", DefaultValue: &dhis2V2Defaults.chartVersion},
+			"JAVA_OPTS":                       {Priority: 30, DisplayName: "JAVA Options", DefaultValue: &dhis2CoreDefaults.javaOpts},
+			"ENABLE_QUERY_LOGGING":            {Priority: 31, DisplayName: "Enable Query Logging", DefaultValue: &dhis2CoreDefaults.enableQueryLogging},
+			"SAME_SITE_COOKIES":               {Priority: 32, DisplayName: "Same site cookies", DefaultValue: &dhis2CoreDefaults.sameSiteCookies, Validator: sameSiteCookies},
+			"CUSTOM_DHIS2_CONFIG":             {Priority: 33, DisplayName: "Custom DHIS2 config (applied to top of dhis.conf)", DefaultValue: &dhis2CoreDefaults.customDhis2Config, Sensitive: true},
+			"GOOGLE_AUTH_PROJECT_ID":          {Priority: 34, DisplayName: "Google auth project id", DefaultValue: &dhis2CoreDefaults.googleAuthProjectId, Sensitive: true},
+			"GOOGLE_AUTH_PRIVATE_KEY":         {Priority: 35, DisplayName: "Google auth private key", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKey, Sensitive: true},
+			"GOOGLE_AUTH_PRIVATE_KEY_ID":      {Priority: 36, DisplayName: "Google auth private key id", DefaultValue: &dhis2CoreDefaults.googleAuthPrivateKeyId, Sensitive: true},
+			"GOOGLE_AUTH_CLIENT_EMAIL":        {Priority: 37, DisplayName: "Google auth client email", DefaultValue: &dhis2CoreDefaults.googleAuthClientEmail, Sensitive: true},
+			"GOOGLE_AUTH_CLIENT_ID":           {Priority: 38, DisplayName: "Google auth client id", DefaultValue: &dhis2CoreDefaults.googleAuthClientId, Sensitive: true},
+		}},
+		{Name: "db", Title: "PostgreSQL", Parameters: StackParameters{
+			"DATABASE_ID":                  {Priority: 4, DisplayName: "Database"},
+			"DATABASE_NAME":                {Priority: 5, DisplayName: "Database Name", DefaultValue: &dhis2DBDefaults.dbName},
+			"DATABASE_PASSWORD":            {Priority: 6, DisplayName: "Database Password", DefaultValue: &dhis2DBDefaults.dbPassword, Sensitive: true},
+			"DATABASE_SIZE":                {Priority: 7, DisplayName: "Database Size", DefaultValue: &dhis2DBDefaults.dbSize},
+			"DATABASE_USERNAME":            {Priority: 8, DisplayName: "Database Username", DefaultValue: &dhis2DBDefaults.dbUsername, Sensitive: true},
+			"DB_RESOURCES_REQUESTS_CPU":    {Priority: 22, DisplayName: "Resources Requests CPU", DefaultValue: &dhis2DBDefaults.resourcesRequestsCPU},
+			"DB_RESOURCES_REQUESTS_MEMORY": {Priority: 23, DisplayName: "Resources Requests Memory", DefaultValue: &dhis2DBDefaults.resourcesRequestsMemory},
+		}},
+		{Name: "storage", Title: "Storage", Parameters: StackParameters{
+			"STORAGE_TYPE": {Priority: 10, DisplayName: "Storage type", DefaultValue: &dhis2CoreDefaults.storageType, Validator: storage},
+		}},
+		{Name: "minio", Title: "MinIO", When: whenStorageIsMinio, Parameters: StackParameters{
+			"MINIO_STORAGE_SIZE": {Priority: 11, DisplayName: "Storage size", DefaultValue: &minIODefaults.storageSize},
+		}},
+		{Name: "s3", Title: "S3", When: whenStorageIsS3, Parameters: StackParameters{
+			"S3_BUCKET":   {Priority: 13, DisplayName: "Bucket", DefaultValue: &dhis2CoreDefaults.s3Bucket},
+			"S3_REGION":   {Priority: 14, DisplayName: "Region", DefaultValue: &dhis2CoreDefaults.s3Region, Sensitive: true},
+			"S3_IDENTITY": {Priority: 15, DisplayName: "Identity", DefaultValue: &dhis2CoreDefaults.s3Identity, Sensitive: true},
+			"S3_SECRET":   {Priority: 16, DisplayName: "Secret", DefaultValue: &dhis2CoreDefaults.s3Secret, Sensitive: true},
+		}},
+		{Name: "filesystem", Title: "Filesystem", When: whenStorageIsFilesystem, Parameters: StackParameters{
+			"FILESYSTEM_VOLUME_SIZE": {Priority: 12, DisplayName: "Volume size", DefaultValue: &dhis2CoreDefaults.filesystemVolumeSize, Sensitive: true},
+		}},
 	},
 	ParameterProviders: ParameterProviders{
 		"DATABASE_HOSTNAME": dhis2V2PostgresHostnameProvider,
@@ -508,6 +512,26 @@ var DHIS2V2 = Stack{
 			When:        whenStorageIsMinio,
 		}},
 	},
+})
+
+// withGroupedParameters flattens the parameters declared inside a stack's groups into the stack's
+// parameter map, stamping each parameter's Group with the declaring group's name, so membership
+// follows from where a parameter is declared instead of a string reference. Panics on a duplicate
+// parameter name since that is a definition error caught by any test run.
+func withGroupedParameters(s Stack) Stack {
+	if s.Parameters == nil {
+		s.Parameters = StackParameters{}
+	}
+	for _, group := range s.ParameterGroups {
+		for name, parameter := range group.Parameters {
+			if _, ok := s.Parameters[name]; ok {
+				panic(fmt.Sprintf("stack %q: parameter %q declared more than once", s.Name, name))
+			}
+			parameter.Group = group.Name
+			s.Parameters[name] = parameter
+		}
+	}
+	return s
 }
 
 var dhis2V2Defaults = struct {

--- a/pkg/stack/stack_definitions_test.go
+++ b/pkg/stack/stack_definitions_test.go
@@ -198,3 +198,34 @@ func getSystemParameters() []string {
 	sort.Strings(parameters)
 	return parameters
 }
+
+// assert group declarations are consistent: unique group names with titles, every parameter's
+// group referencing a declared group, and every group condition referencing a stack parameter.
+func TestParameterGroupsAreConsistent(t *testing.T) {
+	for _, s := range All {
+		groups := make(map[string]bool, len(s.ParameterGroups))
+		for _, group := range s.ParameterGroups {
+			assert.NotEmptyf(t, group.Name, "stack %q declares a group without a name", s.Name)
+			assert.NotEmptyf(t, group.Title, "stack %q group %q has no title", s.Name, group.Name)
+			assert.Falsef(t, groups[group.Name], "stack %q declares group %q twice", s.Name, group.Name)
+			groups[group.Name] = true
+
+			if group.When != nil {
+				_, ok := s.Parameters[group.When.Parameter]
+				assert.Truef(t, ok, "stack %q group %q condition references unknown parameter %q", s.Name, group.Name, group.When.Parameter)
+			}
+		}
+
+		for name, parameter := range s.Parameters {
+			if parameter.Group != "" {
+				assert.Truef(t, groups[parameter.Group], "stack %q parameter %q references undeclared group %q", s.Name, name, parameter.Group)
+			}
+		}
+
+		if len(s.ParameterGroups) > 0 {
+			for name, parameter := range s.Parameters {
+				assert.NotEmptyf(t, parameter.Group, "stack %q parameter %q has no group but the stack declares groups", s.Name, name)
+			}
+		}
+	}
+}

--- a/pkg/stack/types.go
+++ b/pkg/stack/types.go
@@ -7,10 +7,14 @@ import (
 
 // swagger:model StackDetail
 type Stack struct {
-	Name             string          `json:"name"`
-	Parameters       StackParameters `json:"parameters"`
-	HostnamePattern  string          `json:"hostnamePattern"`
-	HostnameVariable string          `json:"hostnameVariable"`
+	Name       string          `json:"name"`
+	Parameters StackParameters `json:"parameters"`
+	// ParameterGroups are the sections a client renders the parameters in, in order. A group's
+	// condition decides its visibility as the user edits the enabling parameter; component
+	// presence predicates reference the same conditions so form and backend cannot disagree.
+	ParameterGroups  []ParameterGroup `json:"parameterGroups,omitempty"`
+	HostnamePattern  string           `json:"hostnamePattern"`
+	HostnameVariable string           `json:"hostnameVariable"`
 	// ParameterProviders provide parameters to other stacks.
 	ParameterProviders ParameterProviders `json:"-"`
 	// Requires these stacks to deploy an instance of this stack.
@@ -20,6 +24,17 @@ type Stack struct {
 	// Components are the addressable parts a deployed instance of this stack consists of. Their
 	// names equal the im-type label values the stack's helmfile applies.
 	Components []kube.Component `json:"-"`
+}
+
+// ParameterGroup is a named section of a stack's parameters, naturally the component the
+// parameters belong to, with a human-readable title.
+// swagger:model StackParameterGroup
+type ParameterGroup struct {
+	Name  string `json:"name"`
+	Title string `json:"title"`
+	// When gates the group's visibility on the value of another parameter; nil means the group is
+	// always shown.
+	When *kube.Condition `json:"when,omitempty"`
 }
 
 // swagger:model StackDetailParameters
@@ -35,8 +50,11 @@ type StackParameter struct {
 	// Validator ensures that the actual stack parameters are valid according to its rules.
 	Validator func(value string) error `json:"-"`
 	// Priority determines the order in which the parameter is shown.
-	Priority         uint                 `json:"priority"`
-	Sensitive        bool                 `json:"sensitive"`
+	Priority  uint `json:"priority"`
+	Sensitive bool `json:"sensitive"`
+	// Group names the ParameterGroup this parameter belongs to; empty means ungrouped, which
+	// clients render in a single flat section.
+	Group            string               `json:"group,omitempty"`
 	RequireCompanion RequireCompanionFunc `json:"-"`
 }
 

--- a/pkg/stack/types.go
+++ b/pkg/stack/types.go
@@ -35,6 +35,10 @@ type ParameterGroup struct {
 	// When gates the group's visibility on the value of another parameter; nil means the group is
 	// always shown.
 	When *kube.Condition `json:"when,omitempty"`
+	// Parameters declared inside the group. withGroupedParameters flattens them into the stack's
+	// parameter map, stamping each parameter's Group, so membership follows from where a parameter
+	// is declared. Not serialized: the API serves the flat list where each parameter names its group.
+	Parameters StackParameters `json:"-"`
 }
 
 // swagger:model StackDetailParameters
@@ -53,7 +57,8 @@ type StackParameter struct {
 	Priority  uint `json:"priority"`
 	Sensitive bool `json:"sensitive"`
 	// Group names the ParameterGroup this parameter belongs to; empty means ungrouped, which
-	// clients render in a single flat section.
+	// clients render in a single flat section. Populated by withGroupedParameters from the
+	// declaring group, never set by hand.
 	Group            string               `json:"group,omitempty"`
 	RequireCompanion RequireCompanionFunc `json:"-"`
 }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -81,6 +81,21 @@ definitions:
                 x-go-name: SupportedOperations
         type: object
         x-go-package: github.com/dhis2-sre/im-manager/pkg/instance
+    Condition:
+        description: |-
+            Condition is a declarative predicate over an instance's parameters: it holds when the named
+            parameter has the given value. Being data rather than code, the same condition both gates a
+            component's presence on the backend and is served to clients, so forms can react to parameter
+            edits without a round trip and cannot disagree with the backend about when something exists.
+        properties:
+            equals:
+                type: string
+                x-go-name: Equals
+            parameter:
+                type: string
+                x-go-name: Parameter
+        type: object
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/kube
     CopyDatabaseRequest:
         properties:
             group:
@@ -644,6 +659,11 @@ definitions:
             name:
                 type: string
                 x-go-name: Name
+            parameterGroups:
+                items:
+                    $ref: '#/definitions/StackParameterGroup'
+                type: array
+                x-go-name: ParameterGroups
             parameters:
                 items:
                     $ref: '#/definitions/StackParameter'
@@ -668,6 +688,9 @@ definitions:
             displayName:
                 type: string
                 x-go-name: DisplayName
+            group:
+                type: string
+                x-go-name: Group
             parameterName:
                 type: string
                 x-go-name: ParameterName
@@ -680,6 +703,22 @@ definitions:
                 x-go-name: Sensitive
         type: object
         x-go-name: StackParameterResponse
+        x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
+    StackParameterGroup:
+        description: |-
+            ParameterGroup is a named section of a stack's parameters, naturally the component the
+            parameters belong to, with a human-readable title.
+        properties:
+            name:
+                type: string
+                x-go-name: Name
+            title:
+                type: string
+                x-go-name: Title
+            when:
+                $ref: '#/definitions/Condition'
+        type: object
+        x-go-name: ParameterGroup
         x-go-package: github.com/dhis2-sre/im-manager/pkg/stack
     UpdateClusterRequest:
         properties:


### PR DESCRIPTION
Stacks can declare parameter groups, each with a name, a human-readable title and an optional visibility condition on another parameter, and every parameter names its group. The stacks API serves both so the deploy form can render one section per group and react to parameter edits without a round trip.

Conditions are declarative data (kube.Condition) instead of Go closures, and the component presence predicate uses the same type: dhis2-v2 gates both the MinIO parameter section and the MinioComponent on the identical STORAGE_TYPE condition, so form and backend cannot disagree.

dhis2-v2 declares six groups: DHIS 2 Core, PostgreSQL, Storage, and conditional MinIO, S3 and Filesystem sections. The only in effect if caveats are dropped from display names, and the Google auth parameters get real priorities instead of all sharing zero. A definitions test enforces unique titled groups, no dangling references and full group coverage once a stack declares groups.