### PR TITLE
feat: resolve consumed parameters from any providing instance in the deployment

### DIFF
--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -284,23 +284,57 @@ func (s Service) validateNoCycles(instances []*model.DeploymentInstance) (graph.
 			}
 		}
 
-		for _, requiredStack := range stack.Requires {
-			requiredStackName := requiredStack.Name
-			err := g.AddEdge(src.StackName, requiredStackName)
+		for name, stackParameter := range stack.Parameters {
+			if !stackParameter.Consumed {
+				continue
+			}
+			provider, _, err := s.findParameterProvider(instances, src, name)
+			if err != nil {
+				return nil, err
+			}
+			err = g.AddEdge(src.StackName, provider.StackName)
 			if err != nil {
 				if errors.Is(err, graph.ErrEdgeAlreadyExists) {
-					return nil, fmt.Errorf("instance %q requires %q more than once", src.Name, requiredStackName)
+					continue
 				} else if errors.Is(err, graph.ErrEdgeCreatesCycle) {
-					return nil, fmt.Errorf("link from instance %q to stack %q creates a cycle", src.Name, requiredStackName)
-				} else if errors.Is(err, graph.ErrVertexNotFound) {
-					return nil, fmt.Errorf("%q is required by %q", requiredStackName, src.StackName)
+					return nil, fmt.Errorf("link from instance %q to stack %q creates a cycle", src.Name, provider.StackName)
 				}
-				return nil, fmt.Errorf("failed linking instance %q with instance %q: %v", src.Name, requiredStackName, err)
+				return nil, fmt.Errorf("failed linking instance %q with instance %q: %v", src.Name, provider.Name, err)
 			}
 		}
 	}
 
 	return g, nil
+}
+
+// findParameterProvider returns the instance providing the named parameter: the one whose stack
+// declares it as a non-consumed parameter or serves it through a parameter provider. A requirement
+// is therefore satisfied by whichever stack actually provides the parameter, so e.g. pgadmin
+// composes with dhis2-db and dhis2-v2 alike.
+func (s Service) findParameterProvider(instances []*model.DeploymentInstance, consumer *model.DeploymentInstance, parameterName string) (*model.DeploymentInstance, *stack.Stack, error) {
+	var providerInstance *model.DeploymentInstance
+	var providerStack *stack.Stack
+	for _, candidate := range instances {
+		if candidate.StackName == consumer.StackName {
+			continue
+		}
+		candidateStack, err := s.stackService.Find(candidate.StackName)
+		if err != nil {
+			return nil, nil, err
+		}
+		candidateParameter, hasParameter := candidateStack.Parameters[parameterName]
+		_, hasProvider := candidateStack.ParameterProviders[parameterName]
+		if (hasParameter && !candidateParameter.Consumed) || hasProvider {
+			if providerInstance != nil {
+				return nil, nil, errdef.NewBadRequest("parameter %q consumed by %q is provided by both %q and %q", parameterName, consumer.StackName, providerInstance.StackName, candidate.StackName)
+			}
+			providerInstance, providerStack = candidate, candidateStack
+		}
+	}
+	if providerInstance == nil {
+		return nil, nil, errdef.NewBadRequest("no instance provides parameter %q consumed by %q", parameterName, consumer.StackName)
+	}
+	return providerInstance, providerStack, nil
 }
 
 func (s Service) resolveParameters(deployment *model.Deployment) error {
@@ -323,7 +357,7 @@ func (s Service) resolveParameters(deployment *model.Deployment) error {
 			return err
 		}
 
-		err = resolveConsumedParameters(deployment, instance, stack)
+		err = s.resolveConsumedParameters(deployment, instance, stack)
 		if err != nil {
 			return err
 		}
@@ -346,36 +380,34 @@ func validateParameters(instanceParameters model.DeploymentInstanceParameters, s
 	return errors.Join(errs...)
 }
 
-func resolveConsumedParameters(deployment *model.Deployment, instance *model.DeploymentInstance, stack *stack.Stack) error {
+func (s Service) resolveConsumedParameters(deployment *model.Deployment, instance *model.DeploymentInstance, stack *stack.Stack) error {
 	for name, parameter := range instance.Parameters {
 		stackParameter := stack.Parameters[name]
 		if !stackParameter.Consumed {
 			continue
 		}
 
-		for _, requiredStack := range stack.Requires {
-			// consume from instance parameters
-			sourceInstance := findInstanceByStackName(requiredStack.Name, deployment)
-			if sourceInstance == nil {
-				return errdef.NewNotFound("failed to find required instance %q of instance %q", requiredStack.Name, instance.Name)
-			}
-
-			if sourceInstanceParameter, ok := sourceInstance.Parameters[name]; ok {
-				parameter.Value = sourceInstanceParameter.Value
-			}
-
-			// consume from provider
-			if provider, ok := requiredStack.ParameterProviders[name]; ok {
-				sourceInstance.Group = instance.Group
-				value, err := provider.Provide(*sourceInstance)
-				if err != nil {
-					return fmt.Errorf("failed to provide value for instance %q parameter %q: %v", instance.Name, name, err)
-				}
-				parameter.Value = value
-			}
-
-			instance.Parameters[name] = parameter
+		sourceInstance, sourceStack, err := s.findParameterProvider(deployment.Instances, instance, name)
+		if err != nil {
+			return err
 		}
+
+		// consume from instance parameters
+		if sourceInstanceParameter, ok := sourceInstance.Parameters[name]; ok {
+			parameter.Value = sourceInstanceParameter.Value
+		}
+
+		// consume from provider
+		if provider, ok := sourceStack.ParameterProviders[name]; ok {
+			sourceInstance.Group = instance.Group
+			value, err := provider.Provide(*sourceInstance)
+			if err != nil {
+				return fmt.Errorf("failed to provide value for instance %q parameter %q: %v", instance.Name, name, err)
+			}
+			parameter.Value = value
+		}
+
+		instance.Parameters[name] = parameter
 	}
 	return nil
 }

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -132,7 +132,7 @@ func TestResolveParameters(t *testing.T) {
 		assert.ElementsMatch(t, want, deployment.Instances)
 	})
 
-	t.Run("RequiredInstanceNotInDeployment", func(t *testing.T) {
+	t.Run("ParameterProviderNotInDeployment", func(t *testing.T) {
 		stackA := stack.Stack{
 			Name: "stack-a",
 		}
@@ -163,7 +163,7 @@ func TestResolveParameters(t *testing.T) {
 
 		err := service.resolveParameters(deployment)
 
-		require.ErrorContains(t, err, `failed to find required instance "stack-a" of instance "name-b"`)
+		require.ErrorContains(t, err, `no instance provides parameter "parameter" consumed by "stack-b"`)
 	})
 
 	t.Run("ResolveParameterUsingProvider", func(t *testing.T) {
@@ -226,5 +226,113 @@ func TestResolveParameters(t *testing.T) {
 			},
 		}
 		assert.ElementsMatch(t, want, deployment.Instances)
+	})
+}
+
+func TestProviderBasedRequirements(t *testing.T) {
+	consumer := stack.Stack{
+		Name: "consumer",
+		Parameters: map[string]stack.StackParameter{
+			"HOST": {Consumed: true},
+		},
+	}
+	provider := stack.Stack{
+		Name: "provider",
+		Parameters: map[string]stack.StackParameter{
+			"HOST": {},
+		},
+	}
+	otherProvider := stack.Stack{
+		Name: "other-provider",
+		Parameters: map[string]stack.StackParameter{
+			"HOST": {},
+		},
+	}
+
+	t.Run("ResolvedFromAnyProvidingStack", func(t *testing.T) {
+		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider})
+		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		deployment := &model.Deployment{
+			Instances: []*model.DeploymentInstance{
+				{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{"HOST": {ParameterName: "HOST", Value: "db.svc"}}},
+				{StackName: "consumer", Parameters: map[string]model.DeploymentInstanceParameter{}},
+			},
+		}
+
+		_, err := service.validateNoCycles(deployment.Instances)
+		require.NoError(t, err)
+		err = service.resolveParameters(deployment)
+		require.NoError(t, err)
+		assert.Equal(t, "db.svc", deployment.Instances[1].Parameters["HOST"].Value)
+	})
+
+	t.Run("MissingProvider", func(t *testing.T) {
+		stackService := stack.NewService(stack.Stacks{"consumer": consumer})
+		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		instances := []*model.DeploymentInstance{
+			{StackName: "consumer", Parameters: map[string]model.DeploymentInstanceParameter{}},
+		}
+
+		_, err := service.validateNoCycles(instances)
+
+		require.ErrorContains(t, err, `no instance provides parameter "HOST" consumed by "consumer"`)
+	})
+
+	t.Run("AmbiguousProviders", func(t *testing.T) {
+		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider, "other-provider": otherProvider})
+		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		instances := []*model.DeploymentInstance{
+			{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
+			{StackName: "other-provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
+			{StackName: "consumer", Parameters: map[string]model.DeploymentInstanceParameter{}},
+		}
+
+		_, err := service.validateNoCycles(instances)
+
+		require.ErrorContains(t, err, `provided by both`)
+	})
+
+	t.Run("PgAdminComposesWithDhis2V2", func(t *testing.T) {
+		stacks, err := stack.New(stack.All...)
+		require.NoError(t, err)
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "")
+		group := &model.Group{Name: "group", Namespace: "namespace"}
+		deployment := &model.Deployment{
+			Instances: []*model.DeploymentInstance{
+				{Name: "core", StackName: "dhis2-v2", GroupName: "group", Group: group, Parameters: map[string]model.DeploymentInstanceParameter{}},
+				{Name: "admin", StackName: "pgadmin", GroupName: "group", Group: group, Parameters: map[string]model.DeploymentInstanceParameter{}},
+			},
+		}
+
+		_, err = service.validateNoCycles(deployment.Instances)
+		require.NoError(t, err)
+		err = service.resolveParameters(deployment)
+		require.NoError(t, err)
+
+		pgadmin := deployment.Instances[1]
+		assert.Contains(t, pgadmin.Parameters["DATABASE_HOSTNAME"].Value, "-dhis2-postgresql-rw.namespace.svc")
+		assert.NotEmpty(t, pgadmin.Parameters["DATABASE_NAME"].Value)
+		assert.NotEmpty(t, pgadmin.Parameters["DATABASE_USERNAME"].Value)
+	})
+
+	t.Run("PgAdminComposesWithDhis2DB", func(t *testing.T) {
+		stacks, err := stack.New(stack.All...)
+		require.NoError(t, err)
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "")
+		group := &model.Group{Name: "group", Namespace: "namespace"}
+		deployment := &model.Deployment{
+			Instances: []*model.DeploymentInstance{
+				{Name: "db", StackName: "dhis2-db", GroupName: "group", Group: group, Parameters: map[string]model.DeploymentInstanceParameter{}},
+				{Name: "admin", StackName: "pgadmin", GroupName: "group", Group: group, Parameters: map[string]model.DeploymentInstanceParameter{}},
+			},
+		}
+
+		_, err = service.validateNoCycles(deployment.Instances)
+		require.NoError(t, err)
+		err = service.resolveParameters(deployment)
+		require.NoError(t, err)
+
+		pgadmin := deployment.Instances[1]
+		assert.NotEmpty(t, pgadmin.Parameters["DATABASE_HOSTNAME"].Value)
 	})
 }


### PR DESCRIPTION
A consumed parameter is now resolved from whichever instance in the deployment provides it, either as a non-consumed stack parameter or through a parameter provider, instead of strictly walking the consuming stack declared Requires. Deployment ordering derives its edges the same way. Zero providers and ambiguous providers are clear errors.

This lets pgadmin compose with dhis2-db and dhis2-v2 alike, and any future postgres-providing stack, without declaring each pairing. All existing compositions resolve to exactly one provider per consumed parameter, so their behavior is unchanged. The static per-stack Requires validation stays as a definition-time check of the canonical composition.