### PR TITLE
feat: locate the postgres pod through the stack's component for pg_dump

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -618,9 +618,7 @@ func newDatabaseService(ctx context.Context, logger *slog.Logger, db *gorm.DB, g
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create database notification publisher: %w", err)
 	}
-	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, func(c model.Cluster) (database.PodExecutor, error) {
-		return kube.NewClient(c)
-	}, publisher)
+	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, kube.NewClient, publisher)
 
 	return databaseService, publisher, nil
 }

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"github.com/dhis2-sre/im-manager/pkg/kube"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-manager/pkg/stack"
@@ -54,7 +55,7 @@ type PodExecutor interface {
 	Exec(ctx context.Context, namespace, podName, container string, command []string, stdout, stderr io.Writer) error
 }
 
-type podExecutorFunc func(cluster model.Cluster) (PodExecutor, error)
+type podExecutorFunc func(cluster model.Cluster) (*kube.Client, error)
 
 type Service struct {
 	logger       *slog.Logger
@@ -589,17 +590,19 @@ func (s Service) Dump(ctx context.Context, userId uint, database *model.Database
 	dump.Host = "localhost"
 	command := buildPgDumpCommand(dump, format)
 
-	podExecutor, err := s.podExecutor(group.Cluster)
+	client, err := s.podExecutor(group.Cluster)
 	if err != nil {
 		return fail(err)
 	}
 
-	hostname, err := stack.ParameterProviders["DATABASE_HOSTNAME"].Provide(*instance)
+	access, err := kube.FindPostgresAccess(stack.Components)
+	if err != nil {
+		return fail(errdef.NewBadRequest("stack %q does not support database save", stack.Name))
+	}
+	podName, container, err := access.PostgresPod(ctx, client, instance)
 	if err != nil {
 		return fail(err)
 	}
-	// TODO: get pod by label selector instead
-	podName := strings.Split(hostname, ".")[0] + "-0"
 	namespace := instance.Group.Namespace
 
 	pr, pw := io.Pipe()
@@ -617,10 +620,10 @@ func (s Service) Dump(ctx context.Context, userId uint, database *model.Database
 		uploadDone <- uploadResult{size, err}
 	}()
 
-	s.logger.InfoContext(ctx, "starting pg_dump", "pod", podName, "namespace", namespace, "command", strings.Join(redactPgPassword(command), " "))
+	s.logger.InfoContext(ctx, "starting pg_dump", "pod", podName, "container", container, "namespace", namespace, "command", strings.Join(redactPgPassword(command), " "))
 	publish("started", "", 0)
 
-	if err := execPgDump(ctx, podExecutor, namespace, podName, command, pw, format, database.Name); err != nil {
+	if err := execPgDump(ctx, client, namespace, podName, container, command, pw, format, database.Name); err != nil {
 		s.logger.ErrorContext(ctx, "failed to exec pg_dump", "error", err)
 		<-uploadDone
 		publish("error", err.Error(), 0)
@@ -648,7 +651,7 @@ func (s Service) Dump(ctx context.Context, userId uint, database *model.Database
 	return saved, nil
 }
 
-func execPgDump(ctx context.Context, executor PodExecutor, namespace, podName string, command []string, pw *io.PipeWriter, format string, databaseName string) error {
+func execPgDump(ctx context.Context, executor PodExecutor, namespace, podName, container string, command []string, pw *io.PipeWriter, format string, databaseName string) error {
 	var execWriter io.WriteCloser = pw
 	var gzWriter *gzip.Writer
 	if format == "plain" {
@@ -658,7 +661,7 @@ func execPgDump(ctx context.Context, executor PodExecutor, namespace, podName st
 	}
 
 	var stderrBuf strings.Builder
-	execErr := executor.Exec(ctx, namespace, podName, "postgresql", command, execWriter, &stderrBuf)
+	execErr := executor.Exec(ctx, namespace, podName, container, command, execWriter, &stderrBuf)
 
 	if gzWriter != nil {
 		gzWriter.Close()

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -128,9 +128,7 @@ func TestInstanceHandler(t *testing.T) {
 	uploader := manager.NewUploader(s3.Client)
 	s3Client := storage.NewS3Client(logger, s3.Client, uploader)
 	databaseRepository := database.NewRepository(db)
-	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, func(c model.Cluster) (database.PodExecutor, error) {
-		return kube.NewClient(c)
-	}, noopPublisher{})
+	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, kube.NewClient, noopPublisher{})
 	deploymentService := deployment.NewService(logger, instanceService, databaseService, tokenService, noopPublisher{})
 
 	// this is only to allow testing using multiple users without bringing in all our auth stack

--- a/pkg/kube/postgres.go
+++ b/pkg/kube/postgres.go
@@ -1,0 +1,27 @@
+package kube
+
+import (
+	"context"
+
+	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"github.com/dhis2-sre/im-manager/pkg/model"
+)
+
+// PostgresAccess is implemented by components that can locate their primary PostgreSQL pod for
+// exec-based operations such as pg_dump. The pod and container differ per technology: Bitnami runs
+// a StatefulSet with a "postgresql" container while CloudNativePG labels its current primary with
+// cnpg.io/instanceRole and uses a "postgres" container.
+type PostgresAccess interface {
+	PostgresPod(ctx context.Context, client *Client, instance *model.DeploymentInstance) (pod string, container string, err error)
+}
+
+// FindPostgresAccess returns the postgres component among the given components, or a not-found
+// error for stacks without one.
+func FindPostgresAccess(components []Component) (PostgresAccess, error) {
+	for _, component := range components {
+		if access, ok := component.(PostgresAccess); ok {
+			return access, nil
+		}
+	}
+	return nil, errdef.NewNotFound("no postgres component found")
+}

--- a/pkg/stack/components.go
+++ b/pkg/stack/components.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
@@ -41,6 +42,20 @@ func (c BitnamiPostgresComponent) Restart(ctx context.Context, client *kube.Clie
 	return client.RestartStatefulSet(ctx, instance, c.Name)
 }
 
+const bitnamiPostgresContainer = "postgresql"
+
+// PostgresPod returns the component's single pod, located by the im labels its chart applies.
+func (c BitnamiPostgresComponent) PostgresPod(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) (string, string, error) {
+	replicas, err := c.Replicas(ctx, client, instance)
+	if err != nil {
+		return "", "", err
+	}
+	if len(replicas) == 0 {
+		return "", "", errdef.NewNotFound("no postgres pod found for component %q", c.Name)
+	}
+	return replicas[0].Name, bitnamiPostgresContainer, nil
+}
+
 // CNPGPostgresComponent operates on a CloudNativePG-managed PostgreSQL cluster. Restart goes
 // through the Cluster custom resource so the operator performs the rollout; patching the bare pods
 // it manages would fight it.
@@ -54,6 +69,22 @@ type CNPGPostgresComponent struct {
 func (c CNPGPostgresComponent) Restart(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) error {
 	clusterName := fmt.Sprintf(c.ClusterPattern, fmt.Sprintf("%s-%d", instance.Name, instance.Group.ID))
 	return client.RestartCNPGCluster(ctx, instance.Group.Namespace, clusterName)
+}
+
+const cnpgPostgresContainer = "postgres"
+
+// PostgresPod returns the CNPG cluster's current primary, located by the operator's role label.
+func (c CNPGPostgresComponent) PostgresPod(ctx context.Context, client *kube.Client, instance *model.DeploymentInstance) (string, string, error) {
+	clusterName := fmt.Sprintf(c.ClusterPattern, fmt.Sprintf("%s-%d", instance.Name, instance.Group.ID))
+	selector := fmt.Sprintf("cnpg.io/cluster=%s,cnpg.io/instanceRole=primary", clusterName)
+	pods, err := client.ListPods(ctx, instance.Group.Namespace, selector)
+	if err != nil {
+		return "", "", err
+	}
+	if len(pods) != 1 {
+		return "", "", errdef.NewNotFound("expected one primary pod for cluster %q, found %d", clusterName, len(pods))
+	}
+	return pods[0].Name, cnpgPostgresContainer, nil
 }
 
 // MinioComponent operates on the Bitnami MinIO chart's Deployment.

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,4 +218,73 @@ func helmfileImTypes(t *testing.T, stackDir string) []string {
 		imTypes = append(imTypes, match[1])
 	}
 	return imTypes
+}
+
+func TestPostgresPod(t *testing.T) {
+	instance := &model.DeploymentInstance{ID: 1, Name: "myinstance", Group: &model.Group{ID: 7, Namespace: "ns"}}
+
+	t.Run("BitnamiViaImLabels", func(t *testing.T) {
+		component := BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{Name: "db"}}
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance-database-0",
+			Namespace: "ns",
+			Labels:    map[string]string{"im-id": "1", "im-type": "db"},
+		}}
+		client := &kube.Client{Clientset: fake.NewSimpleClientset(pod)}
+
+		name, container, err := component.PostgresPod(context.Background(), client, instance)
+
+		require.NoError(t, err)
+		assert.Equal(t, "myinstance-database-0", name)
+		assert.Equal(t, "postgresql", container)
+	})
+
+	t.Run("BitnamiNoPod", func(t *testing.T) {
+		component := BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{Name: "db"}}
+		client := &kube.Client{Clientset: fake.NewSimpleClientset()}
+
+		_, _, err := component.PostgresPod(context.Background(), client, instance)
+
+		require.ErrorContains(t, err, "no postgres pod found")
+	})
+
+	t.Run("CNPGViaPrimaryRoleLabel", func(t *testing.T) {
+		component := CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "db"}, ClusterPattern: "%s-dhis2-postgresql"}
+		primary := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance-7-dhis2-postgresql-1",
+			Namespace: "ns",
+			Labels:    map[string]string{"cnpg.io/cluster": "myinstance-7-dhis2-postgresql", "cnpg.io/instanceRole": "primary"},
+		}}
+		replica := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name:      "myinstance-7-dhis2-postgresql-2",
+			Namespace: "ns",
+			Labels:    map[string]string{"cnpg.io/cluster": "myinstance-7-dhis2-postgresql", "cnpg.io/instanceRole": "replica"},
+		}}
+		client := &kube.Client{Clientset: fake.NewSimpleClientset(primary, replica)}
+
+		name, container, err := component.PostgresPod(context.Background(), client, instance)
+
+		require.NoError(t, err)
+		assert.Equal(t, "myinstance-7-dhis2-postgresql-1", name)
+		assert.Equal(t, "postgres", container)
+	})
+
+	t.Run("CNPGNoPrimary", func(t *testing.T) {
+		component := CNPGPostgresComponent{BaseComponent: kube.BaseComponent{Name: "db"}, ClusterPattern: "%s-dhis2-postgresql"}
+		client := &kube.Client{Clientset: fake.NewSimpleClientset()}
+
+		_, _, err := component.PostgresPod(context.Background(), client, instance)
+
+		require.ErrorContains(t, err, "expected one primary pod")
+	})
+}
+
+func TestFindPostgresAccess(t *testing.T) {
+	for _, s := range []Stack{DHIS2DB, DHIS2, DHIS2V2, ChapDB} {
+		_, err := kube.FindPostgresAccess(s.Components)
+		assert.NoErrorf(t, err, "stack %q should have a postgres component", s.Name)
+	}
+
+	_, err := kube.FindPostgresAccess(WhoamiGo.Components)
+	require.ErrorContains(t, err, "no postgres component found")
 }


### PR DESCRIPTION
Dump asked for the pod by string surgery on the DATABASE_HOSTNAME and exec'd into a hardcoded postgresql container, both Bitnami conventions, so saving a dhis2-v2 instance failed against its CNPG cluster.

Postgres components now implement PostgresAccess: Bitnami locates its pod through the im labels and keeps the postgresql container, CNPG selects the current primary through the operator's cnpg.io/instanceRole label and uses the postgres container. The database service asks the stack's component instead of assuming a technology, and stacks without a postgres component get a clear save-not-supported error.

First slice of the component save design.