### PR TITLE
feat: database save as an advertised component capability

### DIFF
--- a/pkg/database/handler.go
+++ b/pkg/database/handler.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"golang.org/x/exp/slices"
 
 	"github.com/dhis2-sre/im-manager/internal/handler"
+	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-manager/pkg/stack"
 
@@ -43,6 +45,7 @@ type Handler struct {
 type instanceService interface {
 	FindDecryptedDeploymentInstanceById(ctx context.Context, id uint) (*model.DeploymentInstance, error)
 	FindDeploymentById(ctx context.Context, id uint) (*model.Deployment, error)
+	FindDecryptedDeploymentById(ctx context.Context, id uint) (*model.Deployment, error)
 }
 
 type stackService interface {
@@ -50,8 +53,8 @@ type stackService interface {
 }
 
 type deploymentService interface {
-	SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error)
-	Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance) error
+	SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, filestoreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error)
+	Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, filestoreInstance *model.DeploymentInstance) error
 }
 
 // Upload database
@@ -200,19 +203,20 @@ func (h Handler) SaveAs(c *gin.Context) {
 		return
 	}
 
-	deployment, err := h.instanceService.FindDeploymentById(ctx, instance.DeploymentID)
+	if err := supportsDatabaseSave(stack, instance); err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	deployment, err := h.instanceService.FindDecryptedDeploymentById(ctx, instance.DeploymentID)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
 
-	coreInstance, err := getInstanceByStack("dhis2-core", deployment.Instances)
-	if err != nil && !errdef.IsNotFound(err) {
-		_ = c.Error(err)
-		return
-	}
+	filestoreInstance := h.findInstanceWithOperation(deployment.Instances, kube.OperationFilestoreBackup)
 
-	savedDatabase, err := h.deploymentService.SaveAs(ctx, user.ID, instance, stack, coreInstance, request.Name, request.Format)
+	savedDatabase, err := h.deploymentService.SaveAs(ctx, user.ID, instance, stack, filestoreInstance, request.Name, request.Format)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -221,13 +225,34 @@ func (h Handler) SaveAs(c *gin.Context) {
 	c.JSON(http.StatusCreated, savedDatabase)
 }
 
-func getInstanceByStack(stack string, instances []*model.DeploymentInstance) (*model.DeploymentInstance, error) {
-	for _, instance := range instances {
-		if instance.StackName == stack {
-			return instance, nil
+// supportsDatabaseSave rejects save requests against stacks whose components advertise no
+// databaseSave capability, e.g. whoami or a redis-only stack.
+func supportsDatabaseSave(stack *stack.Stack, instance *model.DeploymentInstance) error {
+	for _, component := range kube.PresentComponents(stack.Components, instance.Parameters) {
+		if slices.Contains(component.SupportedOperations(instance.Parameters), kube.OperationDatabaseSave) {
+			return nil
 		}
 	}
-	return nil, errdef.NewNotFound("failed to find instance of type %s", stack)
+	return errdef.NewBadRequest("stack %q does not support database save", stack.Name)
+}
+
+// findInstanceWithOperation returns the deployment instance whose present components advertise the
+// given operation, or nil when none does. This replaces hardcoded stack names: the filestore backup
+// runs against whichever instance advertises it, the dhis2-core sibling in the classic composition
+// or the dhis2-v2 instance itself.
+func (h Handler) findInstanceWithOperation(instances []*model.DeploymentInstance, operation kube.Operation) *model.DeploymentInstance {
+	for _, candidate := range instances {
+		candidateStack, err := h.stackService.Find(candidate.StackName)
+		if err != nil {
+			continue
+		}
+		for _, component := range kube.PresentComponents(candidateStack.Components, candidate.Parameters) {
+			if slices.Contains(component.SupportedOperations(candidate.Parameters), operation) {
+				return candidate
+			}
+		}
+	}
+	return nil
 }
 
 // Save database
@@ -267,6 +292,11 @@ func (h Handler) Save(c *gin.Context) {
 		return
 	}
 
+	if err := supportsDatabaseSave(stack, instance); err != nil {
+		_ = c.Error(err)
+		return
+	}
+
 	parameter := "DATABASE_ID"
 	databaseId, exists := instance.Parameters[parameter]
 	if !exists {
@@ -291,19 +321,15 @@ func (h Handler) Save(c *gin.Context) {
 		return
 	}
 
-	deployment, err := h.instanceService.FindDeploymentById(ctx, instance.DeploymentID)
+	deployment, err := h.instanceService.FindDecryptedDeploymentById(ctx, instance.DeploymentID)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
 
-	coreInstance, err := getInstanceByStack("dhis2-core", deployment.Instances)
-	if err != nil && !errdef.IsNotFound(err) {
-		_ = c.Error(err)
-		return
-	}
+	filestoreInstance := h.findInstanceWithOperation(deployment.Instances, kube.OperationFilestoreBackup)
 
-	if err := h.deploymentService.Save(ctx, user.ID, database, instance, stack, coreInstance); err != nil {
+	if err := h.deploymentService.Save(ctx, user.ID, database, instance, stack, filestoreInstance); err != nil {
 		_ = c.Error(err)
 		return
 	}

--- a/pkg/deployment/service.go
+++ b/pkg/deployment/service.go
@@ -157,8 +157,9 @@ func findInstanceById(instances []*model.DeploymentInstance, id uint) (*model.De
 }
 
 // SaveAs dumps the instance's database into a new record. The record is returned right away
-// while the dump and the filestore backup of the dhis2-core sibling run in the background.
-func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error) {
+// while the dump and the filestore backup run in the background against whichever instance
+// advertises the filestoreBackup capability.
+func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.DeploymentInstance, stack *stack.Stack, filestoreInstance *model.DeploymentInstance, name string, format string) (*model.Database, error) {
 	created, err := s.databaseService.CreateDatabase(ctx, userId, instance.GroupName, name)
 	if err != nil {
 		return nil, err
@@ -172,7 +173,7 @@ func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.Deploy
 		if err != nil {
 			return
 		}
-		s.saveFilestore(ctx, userId, coreInstance, dumped)
+		s.saveFilestore(ctx, userId, filestoreInstance, dumped)
 	}()
 
 	return created, nil
@@ -180,7 +181,7 @@ func (s Service) SaveAs(ctx context.Context, userId uint, instance *model.Deploy
 
 // Save overwrites the instance's source database with a fresh dump. The lock check runs before
 // returning; the dump, finalization and filestore backup run in the background.
-func (s Service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, coreInstance *model.DeploymentInstance) error {
+func (s Service) Save(ctx context.Context, userId uint, database *model.Database, instance *model.DeploymentInstance, stack *stack.Stack, filestoreInstance *model.DeploymentInstance) error {
 	locked, wasLocked, err := s.databaseService.EnsureLocked(ctx, database, instance.ID, userId)
 	if err != nil {
 		return err
@@ -195,19 +196,19 @@ func (s Service) Save(ctx context.Context, userId uint, database *model.Database
 			s.logger.ErrorContext(ctx, "save database failed", "databaseName", locked.Name, "error", err)
 			return
 		}
-		s.saveFilestore(ctx, locked.UserID, coreInstance, saved)
+		s.saveFilestore(ctx, locked.UserID, filestoreInstance, saved)
 	}()
 
 	return nil
 }
 
-func (s Service) saveFilestore(ctx context.Context, userId uint, coreInstance *model.DeploymentInstance, database *model.Database) {
-	if coreInstance == nil {
+func (s Service) saveFilestore(ctx context.Context, userId uint, filestoreInstance *model.DeploymentInstance, database *model.Database) {
+	if filestoreInstance == nil {
 		return
 	}
 
 	s.publisher.Publish(ctx, userId, database.GroupName, kindFilestoreBackup, newFilestoreEvent(database, "started", ""))
-	if err := s.instanceService.FilestoreBackup(ctx, coreInstance, database.Name, database); err != nil {
+	if err := s.instanceService.FilestoreBackup(ctx, filestoreInstance, database.Name, database); err != nil {
 		s.logger.ErrorContext(ctx, "filestore backup failed", "groupName", database.GroupName, "databaseName", database.Name, "error", err)
 		s.publisher.Publish(ctx, userId, database.GroupName, kindFilestoreBackup, newFilestoreEvent(database, "error", err.Error()))
 		return

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -20,6 +20,7 @@ const (
 	OperationRestart         Operation = "restart"
 	OperationRestartReplica  Operation = "restartReplica"
 	OperationFilestoreBackup Operation = "filestoreBackup"
+	OperationDatabaseSave    Operation = "databaseSave"
 )
 
 // CapabilityPredicate decides whether a capability applies given the instance's decrypted parameters.

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -298,8 +298,9 @@ func TestDatabaseSaveCapability(t *testing.T) {
 		assert.Containsf(t, component.SupportedOperations(params), kube.OperationDatabaseSave, "stack %q should advertise databaseSave", s.Name)
 	}
 
-	// chap-db deliberately does not advertise databaseSave: its database is not part of the
-	// DATABASE_ID catalog flow.
+	// chap-db does not advertise databaseSave yet: saving CHAP is planned, but needs its
+	// parameter names mapped in the dump config and a seed/restore path first. Enabling it then
+	// is just adding the capability to its component.
 	chapAccess, err := kube.FindPostgresAccess(ChapDB.Components)
 	require.NoError(t, err)
 	assert.NotContains(t, chapAccess.(kube.Component).SupportedOperations(params), kube.OperationDatabaseSave)

--- a/pkg/stack/components_test.go
+++ b/pkg/stack/components_test.go
@@ -288,3 +288,19 @@ func TestFindPostgresAccess(t *testing.T) {
 	_, err := kube.FindPostgresAccess(WhoamiGo.Components)
 	require.ErrorContains(t, err, "no postgres component found")
 }
+
+func TestDatabaseSaveCapability(t *testing.T) {
+	params := model.DeploymentInstanceParameters{}
+	for _, s := range []Stack{DHIS2DB, DHIS2, DHIS2V2} {
+		access, err := kube.FindPostgresAccess(s.Components)
+		require.NoErrorf(t, err, "stack %q", s.Name)
+		component := access.(kube.Component)
+		assert.Containsf(t, component.SupportedOperations(params), kube.OperationDatabaseSave, "stack %q should advertise databaseSave", s.Name)
+	}
+
+	// chap-db deliberately does not advertise databaseSave: its database is not part of the
+	// DATABASE_ID catalog flow.
+	chapAccess, err := kube.FindPostgresAccess(ChapDB.Components)
+	require.NoError(t, err)
+	assert.NotContains(t, chapAccess.(kube.Component).SupportedOperations(params), kube.OperationDatabaseSave)
+}

--- a/pkg/stack/dhis2.go
+++ b/pkg/stack/dhis2.go
@@ -46,6 +46,9 @@ var DHIS2 = Stack{
 		DHIS2CoreComponent{BaseComponent: kube.BaseComponent{Name: "dhis2"}},
 		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name: "db",
+			Capabilities: []kube.Capability{
+				{Operation: kube.OperationDatabaseSave},
+			},
 			PVCPatterns: []string{
 				"app.kubernetes.io/instance=%s-database",
 				// The redis release carries no im labels yet, so it has no component; its PVC

--- a/pkg/stack/dhis2_db.go
+++ b/pkg/stack/dhis2_db.go
@@ -30,6 +30,9 @@ var DHIS2DB = Stack{
 		BitnamiPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name:        "db",
 			PVCPatterns: []string{"app.kubernetes.io/instance=%s-database"},
+			Capabilities: []kube.Capability{
+				{Operation: kube.OperationDatabaseSave},
+			},
 		}},
 	},
 }

--- a/pkg/stack/dhis2_v2.go
+++ b/pkg/stack/dhis2_v2.go
@@ -75,6 +75,9 @@ var DHIS2V2 = withGroupedParameters(Stack{
 		CNPGPostgresComponent{BaseComponent: kube.BaseComponent{
 			Name:        "db",
 			PVCPatterns: []string{"cnpg.io/cluster=%s-dhis2-postgresql"},
+			Capabilities: []kube.Capability{
+				{Operation: kube.OperationDatabaseSave},
+			},
 		}, ClusterPattern: "%s-dhis2-postgresql"},
 		MinioComponent{BaseComponent: kube.BaseComponent{
 			Name:        "minio",


### PR DESCRIPTION
The postgres components of dhis2-db, dhis2 and dhis2-v2 advertise a databaseSave capability, so the components API tells clients which part of a deployment a save touches. chap-db deliberately does not advertise it since its database is outside the DATABASE_ID catalog flow.

The save handlers no longer hardcode dhis2-core to find the filestore instance: the filestore backup runs against whichever instance advertises the filestoreBackup capability, which also fixes dhis2-v2 saves silently skipping the filestore backup. Saving an instance whose stack has no databaseSave component is rejected up front.

The pg_dump mechanics are unchanged. Stacked on #1647, merge that first.