### PR TITLE
fix: exclude the dhis2 chart seed marker table from database dumps

### DIFF
--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -710,8 +710,10 @@ func newPgDumpConfig(instance *model.DeploymentInstance, stack *stack.Stack) (*p
 	}
 
 	// Restores target a freshly created, empty database, so replace the
-	// default arguments without the --clean option.
-	dump.Options = []string{"--no-owner", "--no-acl", "--blob"}
+	// default arguments without the --clean option. The dhis2 chart's seed marker table is chart
+	// bookkeeping owned by the superuser: excluding it keeps it out of the catalog artifact and
+	// keeps pg_dump from failing to lock it when running as the app user.
+	dump.Options = []string{"--no-owner", "--no-acl", "--blob", "--exclude-table=dhis2_chart_seed_complete"}
 
 	// TODO: This is very DHIS2 specific... More stack meta data?
 	dump.IgnoreTableData = []string{"analytics*", "_*"}


### PR DESCRIPTION
Live validation of dhis2-v2 save failed: the chart seed job creates dhis2_chart_seed_complete as the superuser after the seed script runs, so the ownership loop never covers it and pg_dump as the app user cannot lock it, failing the whole dump.

The marker is chart bookkeeping and has no place in a catalog artifact, so the dump excludes the table entirely. This fixes save for every existing dhis2-v2 deployment without a chart release. Making the chart own the marker properly is worth doing separately.