### PR TITLE
feat: cache kube clients per cluster

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -188,7 +188,8 @@ func run() (err error) {
 		return err
 	}
 
-	instanceService, err := newInstanceService(logger, db, stackService, groupService, s3Client)
+	kubeClients := kube.NewClients()
+	instanceService, err := newInstanceService(logger, db, stackService, groupService, s3Client, kubeClients)
 	if err != nil {
 		return err
 	}
@@ -207,7 +208,7 @@ func run() (err error) {
 
 	notificationHandler := newNotificationHandler(logger, db)
 
-	databaseService, publisher, err := newDatabaseService(ctx, logger, db, groupService, streamEnv, streamName)
+	databaseService, publisher, err := newDatabaseService(ctx, logger, db, groupService, streamEnv, streamName, kubeClients)
 	if err != nil {
 		return err
 	}
@@ -524,7 +525,7 @@ func newStackService() (stack.Service, error) {
 	return stack.NewService(stacks), nil
 }
 
-func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Service, groupService *group.Service, s3Client *storage.S3Client) (*instance.Service, error) {
+func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Service, groupService *group.Service, s3Client *storage.S3Client, kubeClients *kube.Clients) (*instance.Service, error) {
 	instanceParameterEncryptionKey, err := requireEnv("INSTANCE_PARAMETER_ENCRYPTION_KEY")
 	if err != nil {
 		return nil, err
@@ -547,7 +548,7 @@ func newInstanceService(logger *slog.Logger, db *gorm.DB, stackService stack.Ser
 		return nil, err
 	}
 
-	return instance.NewService(logger, instanceRepository, groupService, stackService, helmfileService, s3Client, s3Bucket), nil
+	return instance.NewService(logger, instanceRepository, groupService, stackService, helmfileService, s3Client, s3Bucket, kubeClients), nil
 }
 
 type rabbitMQConfig struct {
@@ -603,7 +604,7 @@ func newInstanceHandler(stackService stack.Service, groupService *group.Service,
 	return instance.NewHandler(stackService, groupService, instanceService, deploymentService, defaultTTL), nil
 }
 
-func newDatabaseService(ctx context.Context, logger *slog.Logger, db *gorm.DB, groupService *group.Service, env *stream.Environment, streamName string) (*database.Service, *notification.Publisher, error) {
+func newDatabaseService(ctx context.Context, logger *slog.Logger, db *gorm.DB, groupService *group.Service, env *stream.Environment, streamName string, kubeClients *kube.Clients) (*database.Service, *notification.Publisher, error) {
 	s3Bucket, err := requireEnv("S3_BUCKET")
 	if err != nil {
 		return nil, nil, err
@@ -618,7 +619,7 @@ func newDatabaseService(ctx context.Context, logger *slog.Logger, db *gorm.DB, g
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create database notification publisher: %w", err)
 	}
-	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, kube.NewClient, publisher)
+	databaseService := database.NewService(logger, s3Bucket, s3Client, groupService, databaseRepository, kubeClients.For, publisher)
 
 	return databaseService, publisher, nil
 }

--- a/pkg/instance/deployment_destroy_test.go
+++ b/pkg/instance/deployment_destroy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/dhis2-sre/im-manager/pkg/inttest"
+	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"github.com/stretchr/testify/require"
@@ -66,7 +67,7 @@ func TestDeleteDeploymentPreservesInstanceRecordWhenDestroyFails(t *testing.T) {
 	require.NoError(t, instanceRepo.SaveDeployment(context.Background(), deployment))
 
 	stackService := stack.NewService(stack.Stacks{"whoami-go": stack.WhoamiGo})
-	service := NewService(logger, instanceRepo, stubGroupService{group: &group}, stackService, failingDestroyHelmfile{failStack: "whoami-go"}, nil, "")
+	service := NewService(logger, instanceRepo, stubGroupService{group: &group}, stackService, failingDestroyHelmfile{failStack: "whoami-go"}, nil, "", kube.NewClients())
 
 	err = service.DeleteDeployment(context.Background(), deployment)
 	require.Error(t, err)

--- a/pkg/instance/filestore.go
+++ b/pkg/instance/filestore.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -314,7 +313,7 @@ func newExternalS3Client(core *model.DeploymentInstance) (*minio.Client, error) 
 func (s Service) filestoreStreamerFor(core *model.DeploymentInstance, cluster model.Cluster) (filestoreStreamer, error) {
 	switch storageType(core) {
 	case "filesystem":
-		ks, err := kube.NewClient(cluster)
+		ks, err := s.kubeClients.For(cluster)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +337,7 @@ func (s Service) filestoreStreamerFor(core *model.DeploymentInstance, cluster mo
 		}
 		return s3APISource{source: NewMinioBackupSource(s.logger, client, core.Parameters["S3_BUCKET"].Value)}, nil
 	default: // minio
-		ks, err := kube.NewClient(cluster)
+		ks, err := s.kubeClients.For(cluster)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -118,7 +118,7 @@ func TestInstanceHandler(t *testing.T) {
 	// blew through the previous 100 seconds.
 	tokenService, err := token.NewService(logger, tokenRepository, privateKey, 3600, 60, "secret", 3600, 3600)
 	require.NoError(t, err, "failed to create token service")
-	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, nil, "")
+	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, nil, "", kube.NewClients())
 
 	s3Dir := t.TempDir()
 	s3Bucket := "database-bucket"
@@ -324,7 +324,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.NoError(t, db.Create(target).Error)
 
 		// The shared instanceService is wired with a nil S3 client; build one with the real client.
-		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket)
+		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients())
 		// minio can briefly refuse connections right after its pod reports ready (the server
 		// restarts during first-run setup), so retry until it is serving. FilestoreBackup returns
 		// before recording anything when the mirror fails, so retries are side-effect free.
@@ -371,7 +371,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.NoError(t, db.Create(target).Error)
 
 		// The shared instanceService is wired with a nil S3 client; build one with the real client.
-		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket)
+		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients())
 		require.NoError(t, fsService.FilestoreBackup(context.Background(), &coreInstance, target.Name, target))
 
 		content := s3.GetObject(t, s3Bucket, "group-name/fsstore-backup-target-fs.tar.gz")

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 )
 
-func NewService(logger *slog.Logger, instanceRepository *repository, groupService groupService, stackService stack.Service, helmfileService helmfile, s3Client *storage.S3Client, s3Bucket string) *Service {
+func NewService(logger *slog.Logger, instanceRepository *repository, groupService groupService, stackService stack.Service, helmfileService helmfile, s3Client *storage.S3Client, s3Bucket string, kubeClients *kube.Clients) *Service {
 	return &Service{
 		logger:             logger,
 		instanceRepository: instanceRepository,
@@ -37,6 +37,7 @@ func NewService(logger *slog.Logger, instanceRepository *repository, groupServic
 		helmfileService:    helmfileService,
 		s3Client:           s3Client,
 		s3Bucket:           s3Bucket,
+		kubeClients:        kubeClients,
 	}
 }
 
@@ -58,6 +59,7 @@ type Service struct {
 	helmfileService    helmfile
 	s3Client           *storage.S3Client
 	s3Bucket           string
+	kubeClients        *kube.Clients
 }
 
 // restoreFilestoreToS3 restores the given filestore backup into the instance's external
@@ -584,7 +586,7 @@ func (s Service) DestroyInstance(ctx context.Context, instance *model.Deployment
 		return err
 	}
 
-	client, err := kube.NewClient(group.Cluster)
+	client, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return err
 	}
@@ -626,7 +628,7 @@ func (s Service) Pause(ctx context.Context, instance *model.DeploymentInstance) 
 		return err
 	}
 
-	ks, err := kube.NewClient(group.Cluster)
+	ks, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return err
 	}
@@ -640,7 +642,7 @@ func (s Service) Resume(ctx context.Context, instance *model.DeploymentInstance)
 		return err
 	}
 
-	ks, err := kube.NewClient(group.Cluster)
+	ks, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return err
 	}
@@ -658,7 +660,7 @@ func (s Service) Restart(ctx context.Context, instance *model.DeploymentInstance
 		return err
 	}
 
-	client, err := kube.NewClient(group.Cluster)
+	client, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return err
 	}
@@ -713,7 +715,7 @@ func (s Service) Components(ctx context.Context, instance *model.DeploymentInsta
 		return nil, err
 	}
 
-	client, err := kube.NewClient(group.Cluster)
+	client, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -779,7 +781,7 @@ func (s Service) DeploymentComponents(ctx context.Context, deployment *model.Dep
 }
 
 func (s Service) Logs(instance *model.DeploymentInstance, group *model.Group, typeSelector string) (io.ReadCloser, error) {
-	ks, err := kube.NewClient(group.Cluster)
+	ks, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -946,7 +948,7 @@ const (
 )
 
 func (s Service) GetStatus(instance *model.DeploymentInstance) (InstanceStatus, error) {
-	ks, err := kube.NewClient(instance.Group.Cluster)
+	ks, err := s.kubeClients.For(instance.Group.Cluster)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/dhis2-sre/im-manager/pkg/kube"
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/dhis2-sre/im-manager/pkg/stack"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		instance := &model.DeploymentInstance{
 			StackName: "stack",
 			Parameters: map[string]model.DeploymentInstanceParameter{
@@ -50,7 +51,7 @@ func TestResolveParameters(t *testing.T) {
 			"name-a": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -88,7 +89,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-a": stackA,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -150,7 +151,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-b": stackB,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -189,7 +190,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-b": stackB,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -251,7 +252,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("ResolvedFromAnyProvidingStack", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{"HOST": {ParameterName: "HOST", Value: "db.svc"}}},
@@ -268,7 +269,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("MissingProvider", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		instances := []*model.DeploymentInstance{
 			{StackName: "consumer", Parameters: map[string]model.DeploymentInstanceParameter{}},
 		}
@@ -280,7 +281,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("AmbiguousProviders", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider, "other-provider": otherProvider})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "")
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
 		instances := []*model.DeploymentInstance{
 			{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
 			{StackName: "other-provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
@@ -295,7 +296,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 	t.Run("PgAdminComposesWithDhis2V2", func(t *testing.T) {
 		stacks, err := stack.New(stack.All...)
 		require.NoError(t, err)
-		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "")
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients())
 		group := &model.Group{Name: "group", Namespace: "namespace"}
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
@@ -318,7 +319,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 	t.Run("PgAdminComposesWithDhis2DB", func(t *testing.T) {
 		stacks, err := stack.New(stack.All...)
 		require.NoError(t, err)
-		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "")
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients())
 		group := &model.Group{Name: "group", Namespace: "namespace"}
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{

--- a/pkg/kube/clients.go
+++ b/pkg/kube/clients.go
@@ -1,0 +1,51 @@
+package kube
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+)
+
+// Clients caches one Client per cluster so the SOPS kubeconfig decrypt, REST config and client
+// construction happen once per cluster instead of once per request. Entries are keyed by cluster
+// id and UpdatedAt, so saving a cluster (e.g. rotating its kubeconfig) naturally invalidates the
+// cached client without any explicit hook.
+type Clients struct {
+	mu        sync.Mutex
+	byCluster map[string]*Client
+	build     func(model.Cluster) (*Client, error)
+}
+
+func NewClients() *Clients {
+	return &Clients{byCluster: map[string]*Client{}, build: NewClient}
+}
+
+// For returns the cached client for the cluster, building it on first use.
+func (c *Clients) For(cluster model.Cluster) (*Client, error) {
+	key := fmt.Sprintf("%d-%d", cluster.ID, cluster.UpdatedAt.UnixNano())
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if client, ok := c.byCluster[key]; ok {
+		return client, nil
+	}
+
+	client, err := c.build(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	// Drop any stale entry for the same cluster under an older UpdatedAt.
+	for existing := range c.byCluster {
+		var id uint
+		var updated int64
+		if _, err := fmt.Sscanf(existing, "%d-%d", &id, &updated); err == nil && id == cluster.ID && existing != key {
+			delete(c.byCluster, existing)
+		}
+	}
+
+	c.byCluster[key] = client
+	return client, nil
+}

--- a/pkg/kube/clients_test.go
+++ b/pkg/kube/clients_test.go
@@ -1,0 +1,42 @@
+package kube
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientsCachePerCluster(t *testing.T) {
+	builds := 0
+	clients := NewClients()
+	clients.build = func(cluster model.Cluster) (*Client, error) {
+		builds++
+		return &Client{}, nil
+	}
+
+	updated := time.Now()
+	clusterA := model.Cluster{ID: 1, UpdatedAt: updated}
+	clusterB := model.Cluster{ID: 2, UpdatedAt: updated}
+
+	first, err := clients.For(clusterA)
+	require.NoError(t, err)
+	second, err := clients.For(clusterA)
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+	assert.Equal(t, 1, builds)
+
+	_, err = clients.For(clusterB)
+	require.NoError(t, err)
+	assert.Equal(t, 2, builds)
+
+	// Saving the cluster bumps UpdatedAt, invalidating the cached client.
+	clusterA.UpdatedAt = updated.Add(time.Minute)
+	third, err := clients.For(clusterA)
+	require.NoError(t, err)
+	assert.NotSame(t, first, third)
+	assert.Equal(t, 3, builds)
+	assert.Len(t, clients.byCluster, 2, "the stale entry for the updated cluster is dropped")
+}


### PR DESCRIPTION
Every status, components, restart, logs and dump request built a fresh kube client, including a full SOPS decrypt of the cluster kubeconfig, which is an AWS KMS round trip when SOPS_KMS_ARN is set. kube.Clients now caches one client per cluster, keyed by cluster id and UpdatedAt so saving a cluster (e.g. a kubeconfig rotation) invalidates the cached client with no explicit hook.

One shared cache is created in main and used by the instance service, the filestore streamers and the database pod executor. The helmfile ingress and cert issuer discovery and the group resources metrics client still build ad hoc clients, both are per-deploy or rare paths and can follow later.

First slice of the cluster-as-source-of-truth design.