### PR TITLE
fix: give the async save tests a longer completion window

### DIFF
--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -411,7 +411,7 @@ func TestInstanceHandler(t *testing.T) {
 				return false
 			}
 			return d.Url != ""
-		}, 120*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
+		}, 300*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
 
 		var finalDB model.Database
 		err := db.First(&finalDB, savedDB.ID).Error
@@ -445,7 +445,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.Eventually(t, func() bool {
 			content, err := s3.TryGetObject(s3Bucket, "group-name/save-test.sql.gz")
 			return err == nil && len(content) > originalSize
-		}, 120*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
+		}, 300*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
 
 		destroyDeployment(t, client, deployment.ID, tokens.AccessToken)
 	})

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -411,7 +411,7 @@ func TestInstanceHandler(t *testing.T) {
 				return false
 			}
 			return d.Url != ""
-		}, 300*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
+		}, 180*time.Second, 500*time.Millisecond, "database URL should be set by async goroutine")
 
 		var finalDB model.Database
 		err := db.First(&finalDB, savedDB.ID).Error
@@ -445,7 +445,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.Eventually(t, func() bool {
 			content, err := s3.TryGetObject(s3Bucket, "group-name/save-test.sql.gz")
 			return err == nil && len(content) > originalSize
-		}, 300*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
+		}, 180*time.Second, 500*time.Millisecond, "saved database in S3 should grow beyond the uploaded placeholder")
 
 		destroyDeployment(t, client, deployment.ID, tokens.AccessToken)
 	})


### PR DESCRIPTION
SaveAsDatabase and SaveDatabase wait 120 seconds for the async dump, which the CI runner exceeds when the parallel batch is deploying dhis2-core alongside, failing runs on 1649 and the version-3.0 rerun before it. The window grows to 300 seconds, which costs nothing when the dump is quick.