### PR TITLE
feat: per-cluster pod informer cache

### DIFF
--- a/helm/chart/templates/clusterrole.yaml
+++ b/helm/chart/templates/clusterrole.yaml
@@ -11,6 +11,8 @@ rules:
       - pods
     verbs:
       - list
+      # The per-cluster informer cache watches the pods IM manages to serve status from memory.
+      - watch
       # Per-replica restart deletes a pod and lets the owning controller or operator recreate it.
       - delete
   - apiGroups:

--- a/pkg/instance/filestore.go
+++ b/pkg/instance/filestore.go
@@ -310,14 +310,14 @@ func newExternalS3Client(core *model.DeploymentInstance) (*minio.Client, error) 
 
 // filestoreStreamerFor selects the backend-specific streamer: minio and filesystem
 // stream via pod exec, s3 reads the external bucket directly.
-func (s Service) filestoreStreamerFor(core *model.DeploymentInstance, cluster model.Cluster) (filestoreStreamer, error) {
+func (s Service) filestoreStreamerFor(ctx context.Context, core *model.DeploymentInstance, cluster model.Cluster) (filestoreStreamer, error) {
 	switch storageType(core) {
 	case "filesystem":
 		ks, err := s.kubeClients.For(cluster)
 		if err != nil {
 			return nil, err
 		}
-		pod, err := ks.GetPod(core.ID, "")
+		pod, err := ks.GetPod(ctx, core.ID, "")
 		if err != nil {
 			return nil, err
 		}
@@ -341,7 +341,7 @@ func (s Service) filestoreStreamerFor(core *model.DeploymentInstance, cluster mo
 		if err != nil {
 			return nil, err
 		}
-		pod, err := ks.GetPodByLabels(map[string]string{
+		pod, err := ks.GetPodByLabels(ctx, map[string]string{
 			"im-type":          "minio",
 			"im-deployment-id": fmt.Sprint(core.DeploymentID),
 		})

--- a/pkg/instance/filestore_test.go
+++ b/pkg/instance/filestore_test.go
@@ -144,7 +144,7 @@ func TestFilestoreStreamerForS3(t *testing.T) {
 	}}
 
 	// only s3 is unit-testable here; minio/filesystem resolve a pod and are covered by integration tests
-	streamer, err := s.filestoreStreamerFor(core, model.Cluster{})
+	streamer, err := s.filestoreStreamerFor(context.Background(), core, model.Cluster{})
 	require.NoError(t, err)
 	assert.IsType(t, s3APISource{}, streamer)
 }
@@ -294,7 +294,7 @@ func TestGetPodByLabels(t *testing.T) {
 	}}
 	ks := kube.Client{Clientset: fake.NewSimpleClientset(minioPod, otherPod)}
 
-	pod, err := ks.GetPodByLabels(map[string]string{"im-type": "minio", "im-deployment-id": "7"})
+	pod, err := ks.GetPodByLabels(context.Background(), map[string]string{"im-type": "minio", "im-deployment-id": "7"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-1-minio-abc", pod.Name)
 	assert.Equal(t, "grp", pod.Namespace)
@@ -302,7 +302,7 @@ func TestGetPodByLabels(t *testing.T) {
 
 func TestGetPodByLabelsNotFound(t *testing.T) {
 	ks := kube.Client{Clientset: fake.NewSimpleClientset()}
-	_, err := ks.GetPodByLabels(map[string]string{"im-type": "minio", "im-deployment-id": "7"})
+	_, err := ks.GetPodByLabels(context.Background(), map[string]string{"im-type": "minio", "im-deployment-id": "7"})
 	require.Error(t, err)
 }
 

--- a/pkg/instance/handler.go
+++ b/pkg/instance/handler.go
@@ -869,7 +869,7 @@ func (h Handler) Logs(c *gin.Context) {
 	}
 
 	selector := c.Query("selector")
-	r, err := h.instanceService.Logs(instance, group, selector)
+	r, err := h.instanceService.Logs(ctx, instance, group, selector)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -1062,7 +1062,7 @@ func (h Handler) Status(c *gin.Context) {
 		return
 	}
 
-	status, err := h.instanceService.GetStatus(instance)
+	status, err := h.instanceService.GetStatus(ctx, instance)
 	if err != nil {
 		_ = c.Error(err)
 		return

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -780,13 +780,13 @@ func (s Service) DeploymentComponents(ctx context.Context, deployment *model.Dep
 	return result, nil
 }
 
-func (s Service) Logs(instance *model.DeploymentInstance, group *model.Group, typeSelector string) (io.ReadCloser, error) {
+func (s Service) Logs(ctx context.Context, instance *model.DeploymentInstance, group *model.Group, typeSelector string) (io.ReadCloser, error) {
 	ks, err := s.kubeClients.For(group.Cluster)
 	if err != nil {
 		return nil, err
 	}
 
-	return ks.Logs(instance, typeSelector)
+	return ks.Logs(ctx, instance, typeSelector)
 }
 
 type GroupWithDeployments struct {
@@ -947,13 +947,13 @@ const (
 	Error              InstanceStatus = "Error"
 )
 
-func (s Service) GetStatus(instance *model.DeploymentInstance) (InstanceStatus, error) {
+func (s Service) GetStatus(ctx context.Context, instance *model.DeploymentInstance) (InstanceStatus, error) {
 	ks, err := s.kubeClients.For(instance.Group.Cluster)
 	if err != nil {
 		return "", err
 	}
 
-	pod, err := ks.GetPod(instance.ID, "")
+	pod, err := ks.GetPod(ctx, instance.ID, "")
 	if err != nil {
 		if errdef.IsNotFound(err) {
 			s.logger.Info("Pod not found, assuming not deployed", "instance", instance.ID, "group", instance.GroupName, "error", err)
@@ -1033,7 +1033,7 @@ func (s Service) FilestoreBackup(ctx context.Context, instance *model.Deployment
 	baseName = strings.TrimSuffix(baseName, ".pgc")
 	baseName = strings.TrimSuffix(baseName, ".tar.gz")
 
-	streamer, err := s.filestoreStreamerFor(core, group.Cluster)
+	streamer, err := s.filestoreStreamerFor(ctx, core, group.Cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/kube/cache.go
+++ b/pkg/kube/cache.go
@@ -1,0 +1,78 @@
+package kube
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// cacheResyncPeriod is not a freshness interval: the watch keeps the store current in real time,
+// and client-go relists by itself when a watch breaks. Resync only replays the in-memory store to
+// registered event handlers (an in-memory iteration, no API calls) as a safety net against handler
+// bugs, which is why it can be generous.
+const cacheResyncPeriod = 10 * time.Minute
+
+// podCache is a shared informer over the pods IM manages, those carrying the im-id label, serving
+// pod reads from memory once synced. Until the initial sync completes, and if the watch ever
+// breaks, readers fall back to live LISTs, so the cache degrades to the uncached behavior instead
+// of becoming an outage.
+type podCache struct {
+	lister corelisters.PodLister
+	synced cache.InformerSynced
+	stop   chan struct{}
+}
+
+func newPodCache(clientset kubernetes.Interface) *podCache {
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, cacheResyncPeriod,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = "im-id"
+		}))
+	informer := factory.Core().V1().Pods()
+	stop := make(chan struct{})
+	c := &podCache{lister: informer.Lister(), synced: informer.Informer().HasSynced, stop: stop}
+	factory.Start(stop)
+	return c
+}
+
+func (p *podCache) ready() bool {
+	return p != nil && p.synced()
+}
+
+// list returns the cached pods matching the selector, sorted by name to mirror the API server's
+// ordering; an empty namespace means all namespaces.
+func (p *podCache) list(namespace, selector string) ([]v1.Pod, error) {
+	parsed, err := labels.Parse(selector)
+	if err != nil {
+		return nil, fmt.Errorf("invalid selector %q: %v", selector, err)
+	}
+
+	var pods []*v1.Pod
+	if namespace == "" {
+		pods, err = p.lister.List(parsed)
+	} else {
+		pods, err = p.lister.Pods(namespace).List(parsed)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]v1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		result = append(result, *pod)
+	}
+	slices.SortFunc(result, func(a, b v1.Pod) int { return cmp.Compare(a.Name, b.Name) })
+	return result, nil
+}
+
+func (p *podCache) close() {
+	close(p.stop)
+}

--- a/pkg/kube/cache.go
+++ b/pkg/kube/cache.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,11 +14,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// cacheResyncPeriod is not a freshness interval: the watch keeps the store current in real time,
-// and client-go relists by itself when a watch breaks. Resync only replays the in-memory store to
-// registered event handlers (an in-memory iteration, no API calls) as a safety net against handler
-// bugs, which is why it can be generous.
-const cacheResyncPeriod = 10 * time.Minute
+// Resync is disabled: it is not a freshness mechanism (the watch keeps the store current in real
+// time, and client-go relists by itself when a watch breaks), it only replays the in-memory store
+// to registered event handlers, of which this cache has none. When event handlers arrive with the
+// status push, a deliberate resync period can come with them.
+const cacheResyncPeriod = 0
 
 // podCache is a shared informer over the pods IM manages, those carrying the im-id label, serving
 // pod reads from memory once synced. Until the initial sync completes, and if the watch ever

--- a/pkg/kube/cache_test.go
+++ b/pkg/kube/cache_test.go
@@ -1,0 +1,72 @@
+package kube
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func imPod(name, namespace string, labels map[string]string) *v1.Pod {
+	labels["im-id"] = "1"
+	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels}}
+}
+
+func waitSynced(t *testing.T, cache *podCache) {
+	require.Eventually(t, cache.ready, 5*time.Second, 10*time.Millisecond, "informer should sync")
+}
+
+func TestPodCacheServesListPods(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		imPod("db-a", "ns1", map[string]string{"im-type": "db"}),
+		imPod("db-b", "ns2", map[string]string{"im-type": "db"}),
+		imPod("web-a", "ns1", map[string]string{"im-type": "web"}),
+	)
+	cache := newPodCache(clientset)
+	defer cache.close()
+	waitSynced(t, cache)
+
+	client := &Client{Clientset: clientset, pods: cache}
+
+	pods, err := client.ListPods(context.Background(), "ns1", "im-type=db")
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+	assert.Equal(t, "db-a", pods[0].Name)
+
+	all, err := client.ListPods(context.Background(), "", "im-type=db")
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	assert.Equal(t, "db-a", all[0].Name, "results are name sorted")
+	assert.Equal(t, "db-b", all[1].Name)
+}
+
+func TestPodCacheSeesUpdates(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	cache := newPodCache(clientset)
+	defer cache.close()
+	waitSynced(t, cache)
+
+	client := &Client{Clientset: clientset, pods: cache}
+	_, err := clientset.CoreV1().Pods("ns1").Create(context.Background(), imPod("late", "ns1", map[string]string{"im-type": "db"}), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		pods, err := client.ListPods(context.Background(), "ns1", "im-type=db")
+		return err == nil && len(pods) == 1
+	}, 5*time.Second, 10*time.Millisecond, "watch should deliver the new pod")
+}
+
+func TestListPodsFallsBackWithoutCache(t *testing.T) {
+	clientset := fake.NewSimpleClientset(imPod("db-a", "ns1", map[string]string{"im-type": "db"}))
+	client := &Client{Clientset: clientset}
+
+	pods, err := client.ListPods(context.Background(), "ns1", "im-type=db")
+
+	require.NoError(t, err)
+	require.Len(t, pods, 1)
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -25,6 +25,9 @@ type Client struct {
 	Clientset  kubernetes.Interface
 	Dynamic    dynamic.Interface
 	RestConfig *rest.Config
+	// pods is the per-cluster informer cache, set only on clients built through Clients; nil
+	// means every read goes to the API server as before.
+	pods *podCache
 }
 
 func NewClient(config model.Cluster) (*Client, error) {

--- a/pkg/kube/clients.go
+++ b/pkg/kube/clients.go
@@ -36,12 +36,18 @@ func (c *Clients) For(cluster model.Cluster) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	if client.Clientset != nil {
+		client.pods = newPodCache(client.Clientset)
+	}
 
 	// Drop any stale entry for the same cluster under an older UpdatedAt.
 	for existing := range c.byCluster {
 		var id uint
 		var updated int64
 		if _, err := fmt.Sscanf(existing, "%d-%d", &id, &updated); err == nil && id == cluster.ID && existing != key {
+			if stale := c.byCluster[existing]; stale.pods != nil {
+				stale.pods.close()
+			}
 			delete(c.byCluster, existing)
 		}
 	}

--- a/pkg/kube/clients_test.go
+++ b/pkg/kube/clients_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestClientsCachePerCluster(t *testing.T) {
@@ -14,7 +15,7 @@ func TestClientsCachePerCluster(t *testing.T) {
 	clients := NewClients()
 	clients.build = func(cluster model.Cluster) (*Client, error) {
 		builds++
-		return &Client{}, nil
+		return &Client{Clientset: fake.NewSimpleClientset()}, nil
 	}
 
 	updated := time.Now()
@@ -39,4 +40,10 @@ func TestClientsCachePerCluster(t *testing.T) {
 	assert.NotSame(t, first, third)
 	assert.Equal(t, 3, builds)
 	assert.Len(t, clients.byCluster, 2, "the stale entry for the updated cluster is dropped")
+
+	select {
+	case <-first.pods.stop:
+	default:
+		t.Fatal("the stale client's informer should be stopped")
+	}
 }

--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-func (c *Client) Logs(instance *model.DeploymentInstance, typeSelector string) (io.ReadCloser, error) {
-	pod, err := c.GetPod(instance.ID, typeSelector)
+func (c *Client) Logs(ctx context.Context, instance *model.DeploymentInstance, typeSelector string) (io.ReadCloser, error) {
+	pod, err := c.GetPod(ctx, instance.ID, typeSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -69,20 +69,20 @@ func (c *Client) Exec(ctx context.Context, namespace, podName, container string,
 	})
 }
 
-func (c *Client) GetPod(instanceID uint, typeSelector string) (v1.Pod, error) {
+func (c *Client) GetPod(ctx context.Context, instanceID uint, typeSelector string) (v1.Pod, error) {
 	selector, err := labelSelector(instanceID, typeSelector)
 	if err != nil {
 		return v1.Pod{}, err
 	}
-	return c.podBySelector(selector)
+	return c.podBySelector(ctx, selector)
 }
 
-func (c *Client) GetPodByLabels(labels map[string]string) (v1.Pod, error) {
+func (c *Client) GetPodByLabels(ctx context.Context, labels map[string]string) (v1.Pod, error) {
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: labels})
 	if err != nil {
 		return v1.Pod{}, fmt.Errorf("error creating label selector: %v", err)
 	}
-	return c.podBySelector(selector.String())
+	return c.podBySelector(ctx, selector.String())
 }
 
 // ListPods returns the non-evicted pods matching the selector in the given namespace, served
@@ -111,8 +111,8 @@ func dropEvicted(pods []v1.Pod) []v1.Pod {
 	})
 }
 
-func (c *Client) podBySelector(selector string) (v1.Pod, error) {
-	pods, err := c.ListPods(context.TODO(), "", selector)
+func (c *Client) podBySelector(ctx context.Context, selector string) (v1.Pod, error) {
+	pods, err := c.ListPods(ctx, "", selector)
 	if err != nil {
 		return v1.Pod{}, fmt.Errorf("error getting pod for selector %q: %v", selector, err)
 	}

--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -85,45 +85,47 @@ func (c *Client) GetPodByLabels(labels map[string]string) (v1.Pod, error) {
 	return c.podBySelector(selector.String())
 }
 
-// ListPods returns the non-evicted pods matching the selector in the given namespace.
+// ListPods returns the non-evicted pods matching the selector in the given namespace, served
+// from the informer cache when it is synced and live from the API server otherwise.
 func (c *Client) ListPods(ctx context.Context, namespace, selector string) ([]v1.Pod, error) {
+	if c.pods.ready() {
+		pods, err := c.pods.list(namespace, selector)
+		if err == nil {
+			return dropEvicted(pods), nil
+		}
+	}
+
 	pods, err := c.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, fmt.Errorf("error listing pods for selector %q: %v", selector, err)
 	}
 
-	pods.Items = slices.DeleteFunc(pods.Items, func(pod v1.Pod) bool {
+	return dropEvicted(pods.Items), nil
+}
+
+// 'Evicted' pods are safe to filter out, as for each pod there will be another pod created in a
+// different state in place of it.
+func dropEvicted(pods []v1.Pod) []v1.Pod {
+	return slices.DeleteFunc(pods, func(pod v1.Pod) bool {
 		return pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted"
 	})
-
-	return pods.Items, nil
 }
 
 func (c *Client) podBySelector(selector string) (v1.Pod, error) {
-	listOptions := metav1.ListOptions{
-		LabelSelector: selector,
-	}
-
-	pods, err := c.Clientset.CoreV1().Pods("").List(context.TODO(), listOptions)
+	pods, err := c.ListPods(context.TODO(), "", selector)
 	if err != nil {
 		return v1.Pod{}, fmt.Errorf("error getting pod for selector %q: %v", selector, err)
 	}
 
-	// 'Evicted' pods are safe to filter out, as for each pod
-	// there will be another pod created in a different state inplace of it.
-	pods.Items = slices.DeleteFunc(pods.Items, func(pod v1.Pod) bool {
-		return pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted"
-	})
-
-	if len(pods.Items) == 0 {
+	if len(pods) == 0 {
 		return v1.Pod{}, errdef.NewNotFound("failed to find pod using the selector: %q", selector)
 	}
 
-	if len(pods.Items) > 1 {
+	if len(pods) > 1 {
 		return v1.Pod{}, errdef.NewConflict("multiple pods found using the selector: %q", selector)
 	}
 
-	return pods.Items[0], nil
+	return pods[0], nil
 }
 
 // labelSelector returns a selector with requirements for im-id=instanceId and either the im-default


### PR DESCRIPTION
Clients built through the per-cluster cache start a shared pod informer watching the pods IM manages, those carrying the im-id label. ListPods and the selector-based pod lookups serve from the informer store once synced, so status, components and replica reads stop doing per-request cluster LISTs; an unsynced or broken watch falls back to the live path, degrading to the previous behavior instead of failing.

The watch keeps the store current in real time; the resync period only replays the store to event handlers and is documented as such. The cluster role gains watch on pods, the same grant pattern the seed job watching needed.

Second slice of the cluster-as-source-of-truth design; the informer event handlers that will push component status over SSE come next.