### PR TITLE
feat: push component status over the event stream

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -215,6 +215,8 @@ func run() (err error) {
 
 	deploymentService := deployment.NewService(logger, instanceService, databaseService, tokenService, publisher)
 
+	kubeClients.RegisterPodHandler(instance.NewComponentStatusWatcher(logger, instanceService, publisher))
+
 	databaseHandler := database.NewHandler(logger, databaseService, groupService, instanceService, stackService, deploymentService)
 
 	instanceHandler, err := newInstanceHandler(stackService, groupService, instanceService, deploymentService)

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/dhis2-sre/im-manager/internal/errdef"
 	"github.com/dhis2-sre/im-manager/internal/handler"
@@ -102,11 +103,21 @@ func (h Handler) StreamEvents(c *gin.Context) {
 	c.Writer.Flush()
 	logger.InfoContext(ctx, "Connection established for sending SSE events")
 
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			logger.InfoContext(ctx, "Request canceled, returning from /events handler")
 			return
+		case <-heartbeat.C:
+			// A comment frame keeps idle connections alive through proxies; browsers ignore it.
+			if _, err := c.Writer.WriteString(": heartbeat\n\n"); err != nil {
+				logger.InfoContext(ctx, "Failed to write SSE heartbeat, client likely gone", "error", err)
+				return
+			}
+			c.Writer.Flush()
 		case sseEvent := <-sseEvents:
 			c.Render(-1, sseEvent)
 			c.Writer.Flush()

--- a/pkg/instance/componentStatusWatcher.go
+++ b/pkg/instance/componentStatusWatcher.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strconv"
 
@@ -47,37 +48,52 @@ func NewComponentStatusWatcher(logger *slog.Logger, instances instanceLookup, pu
 
 var _ cache.ResourceEventHandler = &ComponentStatusWatcher{}
 
-func (w *ComponentStatusWatcher) OnAdd(obj interface{}, isInInitialList bool) {
+func (w *ComponentStatusWatcher) OnAdd(obj any, isInInitialList bool) {
 	// The initial list is the informer syncing what already runs; clients load that state through
 	// the components endpoint, so only genuine additions are pushed.
 	if isInInitialList {
 		return
 	}
-	w.publish(obj, false)
-}
-
-func (w *ComponentStatusWatcher) OnUpdate(oldObj, newObj interface{}) {
-	oldPod, okOld := oldObj.(*v1.Pod)
-	newPod, okNew := newObj.(*v1.Pod)
-	if okOld && okNew && kube.NewReplica(*oldPod) == kube.NewReplica(*newPod) {
-		return
+	if pod, ok := w.podFrom(obj); ok {
+		w.publish(pod, false)
 	}
-	w.publish(newObj, false)
 }
 
-func (w *ComponentStatusWatcher) OnDelete(obj interface{}) {
-	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = unknown.Obj
-	}
-	w.publish(obj, true)
-}
-
-func (w *ComponentStatusWatcher) publish(obj interface{}, deleted bool) {
-	pod, ok := obj.(*v1.Pod)
+func (w *ComponentStatusWatcher) OnUpdate(oldObj, newObj any) {
+	newPod, ok := w.podFrom(newObj)
 	if !ok {
 		return
 	}
+	// Writes that leave the replica view untouched, e.g. an unrelated annotation, are not worth an
+	// event. Without the previous pod there is nothing to compare, so the event goes out.
+	if oldPod, ok := w.podFrom(oldObj); ok && kube.NewReplica(*oldPod) == kube.NewReplica(*newPod) {
+		return
+	}
+	w.publish(newPod, false)
+}
 
+func (w *ComponentStatusWatcher) OnDelete(obj any) {
+	if pod, ok := w.podFrom(obj); ok {
+		w.publish(pod, true)
+	}
+}
+
+// podFrom recovers the pod from an informer event payload, unwrapping the tombstone the informer
+// delivers when a delete went unobserved. Anything else is logged rather than dropped in silence,
+// since that would leave clients stale with nothing pointing at why.
+func (w *ComponentStatusWatcher) podFrom(obj any) (*v1.Pod, bool) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		w.logger.Warn("Ignoring pod informer event of unexpected type", "type", fmt.Sprintf("%T", obj))
+		return nil, false
+	}
+	return pod, true
+}
+
+func (w *ComponentStatusWatcher) publish(pod *v1.Pod, deleted bool) {
 	component := pod.Labels["im-type"]
 	instanceID, err := strconv.ParseUint(pod.Labels["im-id"], 10, 64)
 	if component == "" || err != nil {

--- a/pkg/instance/componentStatusWatcher.go
+++ b/pkg/instance/componentStatusWatcher.go
@@ -1,0 +1,102 @@
+package instance
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+
+	"github.com/dhis2-sre/im-manager/pkg/kube"
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+const kindComponentStatus = "component-status"
+
+// componentStatusEvent is the transient wire event for a single replica transition. The frontend
+// merges it into the component view it loaded from the components endpoint; Deleted removes the
+// replica.
+type componentStatusEvent struct {
+	DeploymentID uint         `json:"deploymentId"`
+	InstanceID   uint         `json:"instanceId"`
+	Component    string       `json:"component"`
+	Replica      kube.Replica `json:"replica"`
+	Deleted      bool         `json:"deleted,omitempty"`
+}
+
+type transientPublisher interface {
+	PublishTransient(ctx context.Context, groupName, kind string, payload any)
+}
+
+type instanceLookup interface {
+	FindDeploymentInstanceById(ctx context.Context, id uint) (*model.DeploymentInstance, error)
+}
+
+// ComponentStatusWatcher turns pod informer events into transient component-status events on the
+// notification stream, scoped to the owning instance's group. It implements
+// cache.ResourceEventHandler and is registered on every cluster's pod informer.
+type ComponentStatusWatcher struct {
+	logger    *slog.Logger
+	instances instanceLookup
+	publisher transientPublisher
+}
+
+func NewComponentStatusWatcher(logger *slog.Logger, instances instanceLookup, publisher transientPublisher) *ComponentStatusWatcher {
+	return &ComponentStatusWatcher{logger: logger, instances: instances, publisher: publisher}
+}
+
+var _ cache.ResourceEventHandler = &ComponentStatusWatcher{}
+
+func (w *ComponentStatusWatcher) OnAdd(obj interface{}, isInInitialList bool) {
+	// The initial list is the informer syncing what already runs; clients load that state through
+	// the components endpoint, so only genuine additions are pushed.
+	if isInInitialList {
+		return
+	}
+	w.publish(obj, false)
+}
+
+func (w *ComponentStatusWatcher) OnUpdate(oldObj, newObj interface{}) {
+	oldPod, okOld := oldObj.(*v1.Pod)
+	newPod, okNew := newObj.(*v1.Pod)
+	if okOld && okNew && kube.NewReplica(*oldPod) == kube.NewReplica(*newPod) {
+		return
+	}
+	w.publish(newObj, false)
+}
+
+func (w *ComponentStatusWatcher) OnDelete(obj interface{}) {
+	if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = unknown.Obj
+	}
+	w.publish(obj, true)
+}
+
+func (w *ComponentStatusWatcher) publish(obj interface{}, deleted bool) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		return
+	}
+
+	component := pod.Labels["im-type"]
+	instanceID, err := strconv.ParseUint(pod.Labels["im-id"], 10, 64)
+	if component == "" || err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	instance, err := w.instances.FindDeploymentInstanceById(ctx, uint(instanceID))
+	if err != nil {
+		// Pods of instances IM no longer knows, e.g. lingering after a delete, are not an error.
+		w.logger.DebugContext(ctx, "Skipping component status for unknown instance", "instanceId", instanceID, "pod", pod.Name)
+		return
+	}
+
+	w.publisher.PublishTransient(ctx, instance.GroupName, kindComponentStatus, componentStatusEvent{
+		DeploymentID: instance.DeploymentID,
+		InstanceID:   instance.ID,
+		Component:    component,
+		Replica:      kube.NewReplica(*pod),
+		Deleted:      deleted,
+	})
+}

--- a/pkg/instance/componentStatusWatcher_test.go
+++ b/pkg/instance/componentStatusWatcher_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 type recordedEvent struct {
@@ -119,4 +120,25 @@ func TestComponentStatusWatcher(t *testing.T) {
 
 		assert.Empty(t, publisher.events)
 	})
+}
+
+func TestComponentStatusWatcherIgnoresUnexpectedTypes(t *testing.T) {
+	publisher := &recordingPublisher{}
+	instance := &model.DeploymentInstance{ID: 42, DeploymentID: 7, GroupName: "whoami"}
+	watcher := NewComponentStatusWatcher(slog.Default(), stubLookup{instance: instance}, publisher)
+
+	// Nothing here is a pod, so none of it may panic or publish.
+	watcher.OnAdd("not a pod", false)
+	watcher.OnUpdate(42, "still not a pod")
+	watcher.OnDelete(nil)
+	assert.Empty(t, publisher.events)
+
+	// A tombstone wrapping a real pod is a genuine delete.
+	watcher.OnDelete(cache.DeletedFinalStateUnknown{Key: "ns/db-0", Obj: watcherPod(v1.PodRunning, true)})
+	require.Len(t, publisher.events, 1)
+	assert.True(t, publisher.events[0].payload.(componentStatusEvent).Deleted)
+
+	// An update whose previous object is not a pod still publishes, there is nothing to compare to.
+	watcher.OnUpdate("not a pod", watcherPod(v1.PodRunning, true))
+	assert.Len(t, publisher.events, 2)
 }

--- a/pkg/instance/componentStatusWatcher_test.go
+++ b/pkg/instance/componentStatusWatcher_test.go
@@ -1,0 +1,122 @@
+package instance
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/dhis2-sre/im-manager/internal/errdef"
+	"github.com/dhis2-sre/im-manager/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type recordedEvent struct {
+	group   string
+	kind    string
+	payload any
+}
+
+type recordingPublisher struct {
+	events []recordedEvent
+}
+
+func (r *recordingPublisher) PublishTransient(ctx context.Context, groupName, kind string, payload any) {
+	r.events = append(r.events, recordedEvent{groupName, kind, payload})
+}
+
+type stubLookup struct {
+	instance *model.DeploymentInstance
+}
+
+func (s stubLookup) FindDeploymentInstanceById(ctx context.Context, id uint) (*model.DeploymentInstance, error) {
+	if s.instance == nil {
+		return nil, errdef.NewNotFound("instance not found")
+	}
+	return s.instance, nil
+}
+
+func watcherPod(phase v1.PodPhase, ready bool) *v1.Pod {
+	readyStatus := v1.ConditionFalse
+	if ready {
+		readyStatus = v1.ConditionTrue
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "db-0",
+			Labels: map[string]string{"im-id": "42", "im-type": "db"},
+		},
+		Status: v1.PodStatus{
+			Phase:      phase,
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: readyStatus}},
+		},
+	}
+}
+
+func TestComponentStatusWatcher(t *testing.T) {
+	logger := slog.Default()
+	instance := &model.DeploymentInstance{ID: 42, DeploymentID: 7, GroupName: "whoami"}
+
+	t.Run("PublishesOnMeaningfulUpdate", func(t *testing.T) {
+		publisher := &recordingPublisher{}
+		watcher := NewComponentStatusWatcher(logger, stubLookup{instance: instance}, publisher)
+
+		watcher.OnUpdate(watcherPod(v1.PodPending, false), watcherPod(v1.PodRunning, true))
+
+		require.Len(t, publisher.events, 1)
+		assert.Equal(t, "whoami", publisher.events[0].group)
+		assert.Equal(t, "component-status", publisher.events[0].kind)
+		event := publisher.events[0].payload.(componentStatusEvent)
+		assert.Equal(t, uint(7), event.DeploymentID)
+		assert.Equal(t, uint(42), event.InstanceID)
+		assert.Equal(t, "db", event.Component)
+		assert.Equal(t, "Running", event.Replica.Phase)
+		assert.True(t, event.Replica.Ready)
+		assert.False(t, event.Deleted)
+	})
+
+	t.Run("SkipsNoopUpdate", func(t *testing.T) {
+		publisher := &recordingPublisher{}
+		watcher := NewComponentStatusWatcher(logger, stubLookup{instance: instance}, publisher)
+
+		watcher.OnUpdate(watcherPod(v1.PodRunning, true), watcherPod(v1.PodRunning, true))
+
+		assert.Empty(t, publisher.events)
+	})
+
+	t.Run("SkipsInitialListAdds", func(t *testing.T) {
+		publisher := &recordingPublisher{}
+		watcher := NewComponentStatusWatcher(logger, stubLookup{instance: instance}, publisher)
+
+		watcher.OnAdd(watcherPod(v1.PodRunning, true), true)
+		assert.Empty(t, publisher.events)
+
+		watcher.OnAdd(watcherPod(v1.PodPending, false), false)
+		assert.Len(t, publisher.events, 1)
+	})
+
+	t.Run("DeleteCarriesDeletedFlag", func(t *testing.T) {
+		publisher := &recordingPublisher{}
+		watcher := NewComponentStatusWatcher(logger, stubLookup{instance: instance}, publisher)
+
+		watcher.OnDelete(watcherPod(v1.PodRunning, true))
+
+		require.Len(t, publisher.events, 1)
+		assert.True(t, publisher.events[0].payload.(componentStatusEvent).Deleted)
+	})
+
+	t.Run("SkipsUnknownInstanceAndUnlabelledPods", func(t *testing.T) {
+		publisher := &recordingPublisher{}
+		watcher := NewComponentStatusWatcher(logger, stubLookup{}, publisher)
+		watcher.OnAdd(watcherPod(v1.PodRunning, true), false)
+
+		unlabelled := watcherPod(v1.PodRunning, true)
+		unlabelled.Labels = map[string]string{}
+		known := NewComponentStatusWatcher(logger, stubLookup{instance: instance}, publisher)
+		known.OnAdd(unlabelled, false)
+
+		assert.Empty(t, publisher.events)
+	})
+}

--- a/pkg/kube/cache.go
+++ b/pkg/kube/cache.go
@@ -25,9 +25,10 @@ const cacheResyncPeriod = 0
 // breaks, readers fall back to live LISTs, so the cache degrades to the uncached behavior instead
 // of becoming an outage.
 type podCache struct {
-	lister corelisters.PodLister
-	synced cache.InformerSynced
-	stop   chan struct{}
+	informer cache.SharedIndexInformer
+	lister   corelisters.PodLister
+	synced   cache.InformerSynced
+	stop     chan struct{}
 }
 
 func newPodCache(clientset kubernetes.Interface) *podCache {
@@ -37,7 +38,7 @@ func newPodCache(clientset kubernetes.Interface) *podCache {
 		}))
 	informer := factory.Core().V1().Pods()
 	stop := make(chan struct{})
-	c := &podCache{lister: informer.Lister(), synced: informer.Informer().HasSynced, stop: stop}
+	c := &podCache{informer: informer.Informer(), lister: informer.Lister(), synced: informer.Informer().HasSynced, stop: stop}
 	factory.Start(stop)
 	return c
 }
@@ -70,6 +71,11 @@ func (p *podCache) list(namespace, selector string) ([]v1.Pod, error) {
 	}
 	slices.SortFunc(result, func(a, b v1.Pod) int { return cmp.Compare(a.Name, b.Name) })
 	return result, nil
+}
+
+func (p *podCache) addHandler(handler cache.ResourceEventHandler) error {
+	_, err := p.informer.AddEventHandler(handler)
+	return err
 }
 
 func (p *podCache) close() {

--- a/pkg/kube/clients.go
+++ b/pkg/kube/clients.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
+	"k8s.io/client-go/tools/cache"
 )
 
 // Clients caches one Client per cluster so the SOPS kubeconfig decrypt, REST config and client
@@ -12,9 +13,26 @@ import (
 // id and UpdatedAt, so saving a cluster (e.g. rotating its kubeconfig) naturally invalidates the
 // cached client without any explicit hook.
 type Clients struct {
-	mu        sync.Mutex
-	byCluster map[string]*Client
-	build     func(model.Cluster) (*Client, error)
+	mu          sync.Mutex
+	byCluster   map[string]*Client
+	build       func(model.Cluster) (*Client, error)
+	podHandlers []cache.ResourceEventHandler
+}
+
+// RegisterPodHandler attaches the handler to every cluster's pod informer, present and future.
+// Handlers registered after a cache started still receive adds for everything already in the
+// store, so registration order and cache construction order do not matter.
+func (c *Clients) RegisterPodHandler(handler cache.ResourceEventHandler) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.podHandlers = append(c.podHandlers, handler)
+	for _, client := range c.byCluster {
+		if client.pods != nil {
+			if err := client.pods.addHandler(handler); err != nil {
+				panic(fmt.Sprintf("failed to register pod event handler on a running cache: %v", err))
+			}
+		}
+	}
 }
 
 func NewClients() *Clients {
@@ -38,6 +56,11 @@ func (c *Clients) For(cluster model.Cluster) (*Client, error) {
 	}
 	if client.Clientset != nil {
 		client.pods = newPodCache(client.Clientset)
+		for _, handler := range c.podHandlers {
+			if err := client.pods.addHandler(handler); err != nil {
+				return nil, fmt.Errorf("failed to register pod event handler: %v", err)
+			}
+		}
 	}
 
 	// Drop any stale entry for the same cluster under an older UpdatedAt.

--- a/pkg/kube/component.go
+++ b/pkg/kube/component.go
@@ -142,6 +142,11 @@ func (b BaseComponent) pods(ctx context.Context, client *Client, instance *model
 	return client.ListPods(ctx, instance.Group.Namespace, selector)
 }
 
+// NewReplica derives the replica view of a pod, shared by the cache event handlers.
+func NewReplica(pod v1.Pod) Replica {
+	return newReplica(pod)
+}
+
 func newReplica(pod v1.Pod) Replica {
 	var restarts int32
 	for _, status := range pod.Status.ContainerStatuses {

--- a/pkg/notification/publisher.go
+++ b/pkg/notification/publisher.go
@@ -85,3 +85,25 @@ func (p *Publisher) Publish(ctx context.Context, userID uint, groupName, kind st
 		p.logger.ErrorContext(ctx, "Failed to send notification to RabbitMQ", "kind", kind, "error", err)
 	}
 }
+
+// PublishTransient streams an event to the group without persisting a notification and without an
+// owner, so every group member's live connection receives it and it never appears in the
+// notification bell. Meant for high-frequency ephemeral state like component status.
+func (p *Publisher) PublishTransient(ctx context.Context, groupName, kind string, payload any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		p.logger.ErrorContext(ctx, "Failed to marshal transient event payload", "kind", kind, "error", err)
+		return
+	}
+
+	msg := amqp.NewMessage(data)
+	msg.SetPublishingId(p.counter.Add(1))
+	msg.ApplicationProperties = map[string]any{
+		"group": groupName,
+		"kind":  kind,
+	}
+
+	if err := p.producer.Send(msg); err != nil {
+		p.logger.ErrorContext(ctx, "Failed to send transient event to RabbitMQ", "kind", kind, "error", err)
+	}
+}


### PR DESCRIPTION
Pod informer events become transient component-status events on the existing notification stream, scoped to the owning instance group: one event per meaningful replica transition (phase, readiness, restarts), with a deleted flag on removals. The initial informer sync and no-op updates are filtered out, and pods of instances IM no longer knows are skipped.

PublishTransient streams without persisting a notification and without an owner, so component status reaches every group member live but never appears in the notification bell. The SSE endpoint also gains a 30 second heartbeat comment frame so idle connections survive proxies.

Stacked on #1652, merge that first. The frontend listener that consumes these events and retires the Refresh button follows separately.