### PR TITLE
chore: stop deploying the EKS dev environment

### DIFF
--- a/helm/data/values/dev/values.yaml
+++ b/helm/data/values/dev/values.yaml
@@ -1,3 +1,8 @@
+# im-dev.dhis2.org is served from the VM control plane in dhis2-sre/dhis2-infrastructure
+# services/im-vm, and its database was migrated there. Running this one too would give the same
+# instances two owners, each inspecting its own copy of the rows and destroying what the other still
+# manages, so it stays at zero replicas while EKS is being retired. Set back to 1 to roll dev back.
+replicaCount: 0
 image:
   pullPolicy: Always
 sameSiteMode: none


### PR DESCRIPTION
`im-dev.dhis2.org` now resolves to the VM control plane in dhis2-sre/dhis2-infrastructure#284, and dev's database was migrated there today. The EKS deployment is still deployed by every push to master, and the chart's `replicaCount: 1` would scale it back up, leaving two IMs against two diverging copies of the same rows with both inspectors destroying instances the other still manages.

`replicaCount: 0` keeps CI from doing that without removing the environment, so rolling dev back during the soak is setting it to 1 again.

Verified that the rendered environment file the VM runs from is byte-identical with and without this change, since it comes from the same values file.