### PR TITLE
fix: match the build workflow name in the im-vm deploy trigger

### DIFF
--- a/.github/workflows/deploy-im-vm.yaml
+++ b/.github/workflows/deploy-im-vm.yaml
@@ -18,7 +18,7 @@ name: Deploy to im-vm
 
 on:
   workflow_run:
-    workflows: [Build, test and deploy]
+    workflows: ["Build, test and deploy"]
     types: [completed]
 
 concurrency:


### PR DESCRIPTION
`workflows: [Build, test and deploy]` is a YAML flow sequence of two items, `Build` and `test and deploy`, so the trigger waited on two workflows that do not exist and never fired. Nothing has been deployed to the VM control plane by CI since #1646 merged.

Quoting it makes the list one name:

```
$ yq '.on.workflow_run.workflows | .[]' .github/workflows/deploy-im-vm.yaml
Build, test and deploy
```

Companion to dhis2-sre/im-web-client#890.