### PR TITLE
fix: resolve and record the file store saved with a database

### DIFF
--- a/pkg/database/database_integration_test.go
+++ b/pkg/database/database_integration_test.go
@@ -421,3 +421,32 @@ func (ss stackService) Find(name string) (*stack.Stack, error) {
 type noopPublisher struct{}
 
 func (noopPublisher) Publish(context.Context, uint, string, string, any) {}
+
+// TestFilestoreAssociationResolvesThroughFilestoreID guards the self-referential association: the
+// foreign key has to be FilestoreID, since resolving it through ID silently returns the database
+// itself as its own file store.
+func TestFilestoreAssociationResolvesThroughFilestoreID(t *testing.T) {
+	t.Parallel()
+
+	db := inttest.SetupDB(t)
+	repository := database.NewRepository(db)
+	ctx := context.Background()
+	user, _ := userpkg.CreateUserWithGroup(t, db, "packages", "some", "", "filestore-user@dhis2.org")
+
+	filestore := &model.Database{Name: "saved-fs.tar.gz", GroupName: "packages", Slug: "packages/saved-fs", Type: "fs", Size: 4096, UserID: user.ID}
+	require.NoError(t, db.Create(filestore).Error)
+
+	saved := &model.Database{Name: "saved.pgc", GroupName: "packages", Slug: "packages/saved", Type: "database", FilestoreID: filestore.ID, UserID: user.ID}
+	require.NoError(t, db.Create(saved).Error)
+
+	found, err := repository.FindById(ctx, saved.ID)
+	require.NoError(t, err)
+	require.NotNil(t, found.Filestore, "the file store should be loaded, not left nil")
+	assert.Equal(t, filestore.ID, found.Filestore.ID)
+	assert.Equal(t, "saved-fs.tar.gz", found.Filestore.Name, "resolving through ID would return the database itself")
+	assert.Equal(t, int64(4096), found.Filestore.Size)
+
+	withoutFilestore, err := repository.FindById(ctx, filestore.ID)
+	require.NoError(t, err)
+	assert.Nil(t, withoutFilestore.Filestore, "a file store row has no file store of its own")
+}

--- a/pkg/database/repository.go
+++ b/pkg/database/repository.go
@@ -60,6 +60,7 @@ func (r repository) FindById(ctx context.Context, id uint) (*model.Database, err
 	err := r.db.
 		WithContext(ctx).
 		Preload("Lock").
+		Preload("Filestore").
 		Joins("User").
 		First(&d, id).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -82,6 +83,7 @@ func (r repository) FindBySlug(ctx context.Context, slug string) (*model.Databas
 	err := r.db.
 		WithContext(ctx).
 		Preload("Lock").
+		Preload("Filestore").
 		Where("slug = ?", slug).
 		First(&d).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/instance/backupService.go
+++ b/pkg/instance/backupService.go
@@ -37,8 +37,9 @@ type BackupService struct {
 	uploader *storage.S3Client
 }
 
-// PerformBackup uploads the streamer's output to key in s3Bucket.
-func (s *BackupService) PerformBackup(ctx context.Context, streamer filestoreStreamer, s3Bucket, key string) error {
+// PerformBackup uploads the streamer's output to key in s3Bucket and returns the number of bytes
+// written, which the caller records on the file store so its size is known.
+func (s *BackupService) PerformBackup(ctx context.Context, streamer filestoreStreamer, s3Bucket, key string) (int64, error) {
 	start := time.Now()
 	pr, pw := io.Pipe()
 
@@ -57,10 +58,9 @@ func (s *BackupService) PerformBackup(ctx context.Context, streamer filestoreStr
 	})
 
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("backup failed: %v", err)
+		return 0, fmt.Errorf("backup failed: %v", err)
 	}
 
-	s.logger.InfoContext(ctx, "Filestore backup completed", "key", key, "duration", time.Since(start))
-	s.logger.DebugContext(ctx, "Filestore backup stats", "key", key, "bytesUploaded", uploaded)
-	return nil
+	s.logger.InfoContext(ctx, "Filestore backup completed", "key", key, "duration", time.Since(start), "bytesUploaded", uploaded)
+	return uploaded, nil
 }

--- a/pkg/instance/backupService_test.go
+++ b/pkg/instance/backupService_test.go
@@ -55,9 +55,11 @@ func TestBackupServiceIntegration(t *testing.T) {
 	backupService := NewBackupService(logger, storage.NewS3Client(logger, s3Test.Client, nil))
 
 	s3Key := "group/save-name-fs.tar.gz"
-	require.NoError(t, backupService.PerformBackup(ctx, s3APISource{source}, s3Bucket, s3Key))
+	uploaded, err := backupService.PerformBackup(ctx, s3APISource{source}, s3Bucket, s3Key)
+	require.NoError(t, err)
 
 	tarContent := s3Test.GetObject(t, s3Bucket, s3Key)
+	assert.Equal(t, int64(len(tarContent)), uploaded, "the reported size is what landed in S3, so it can be recorded on the file store")
 	entries := extractTarGz(t, tarContent)
 
 	var paths []string

--- a/pkg/instance/service.go
+++ b/pkg/instance/service.go
@@ -1040,12 +1040,13 @@ func (s Service) FilestoreBackup(ctx context.Context, instance *model.Deployment
 
 	key := fmt.Sprintf("%s/%s-%s.tar.gz", instance.GroupName, baseName, "fs")
 	backupService := NewBackupService(s.logger, s.s3Client)
-	if err := backupService.PerformBackup(ctx, streamer, s.s3Bucket, key); err != nil {
+	size, err := backupService.PerformBackup(ctx, streamer, s.s3Bucket, key)
+	if err != nil {
 		return err
 	}
 
 	s3Uri := fmt.Sprintf("s3://%s/%s", s.s3Bucket, key)
-	filestore, err := s.recordBackup(ctx, instance.GroupName, s3Uri, baseName+"-fs.tar.gz", database.UserID)
+	filestore, err := s.recordBackup(ctx, instance.GroupName, s3Uri, baseName+"-fs.tar.gz", database.UserID, size)
 	if err != nil {
 		return err
 	}
@@ -1055,13 +1056,14 @@ func (s Service) FilestoreBackup(ctx context.Context, instance *model.Deployment
 	return s.instanceRepository.SaveDatabase(ctx, database)
 }
 
-func (s Service) recordBackup(ctx context.Context, groupName, s3uri, name string, userID uint) (*model.Database, error) {
+func (s Service) recordBackup(ctx context.Context, groupName, s3uri, name string, userID uint, size int64) (*model.Database, error) {
 	database := &model.Database{
 		Name:      name,
 		GroupName: groupName,
 		Url:       s3uri,
 		Type:      "fs",
 		UserID:    userID,
+		Size:      size,
 	}
 	err := s.instanceRepository.RecordBackup(ctx, database)
 	if err != nil {

--- a/pkg/model/database.go
+++ b/pkg/model/database.go
@@ -20,10 +20,15 @@ type Database struct {
 	Slug              string             `json:"slug" gorm:"uniqueIndex"`
 	Type              string             `json:"type"` // TODO: Strictly sql or fs?
 	FilestoreID       uint               `json:"filestoreId"`
-	Filestore         *Database          `json:"filestore" gorm:"foreignKey:ID"`
-	UserID            uint               `json:"userId"`
-	User              User               `json:"user"`
-	Size              int64              `json:"size"`
+	// Filestore is the file store saved alongside this database, resolved through FilestoreID.
+	// Naming the foreign key explicitly matters here: the association points at another row of this
+	// same table, and pointing it at ID instead resolves a database to itself. It is excluded from
+	// migration on purpose: FilestoreID is a plain uint where 0 means "no file store", so an
+	// enforced constraint would reject every database saved without one.
+	Filestore *Database `json:"filestore" gorm:"foreignKey:FilestoreID;-:migration"`
+	UserID    uint      `json:"userId"`
+	User      User      `json:"user"`
+	Size      int64     `json:"size"`
 }
 
 // swagger:model


### PR DESCRIPTION
The details view showed a bare numeric id where the file store name belongs, which turned out to be three separate defects.

The association was declared with the foreign key pointing at ID, so it resolved a database to itself rather than through FilestoreID. Preloading it without fixing that would have quietly returned the wrong row. It is now resolved through FilestoreID and preloaded by the single database finders.

The association also has to be excluded from migration: FilestoreID is a plain uint where zero means no file store, so an enforced constraint rejects every database saved without one. AutoMigrate runs on startup, so this would have failed against existing rows on deploy rather than only in tests. The new test is what caught it.

Finally the file store size was never recorded, so every file store reported zero bytes: PerformBackup counted the uploaded bytes and discarded them. It now returns the count and the record carries it, which is also what makes showing a size in the interface possible at all.