### PR TITLE
fix: retry a dump while postgres is mid-transition

### DIFF
--- a/pkg/database/dumpRetry_test.go
+++ b/pkg/database/dumpRetry_test.go
@@ -1,0 +1,68 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientPostgresState(t *testing.T) {
+	// The message Bitnami's initdb-script phase produces when it stops its temporary server, which
+	// is what a save issued moments after a deploy used to fail on.
+	shuttingDown := errors.New(`command terminated with exit code 1: pg_dump: error: connection to server at "localhost" (::1), port 5432 failed: FATAL:  the database system is shutting down`)
+	assert.True(t, isTransientPostgresState(shuttingDown))
+
+	assert.True(t, isTransientPostgresState(errors.New("FATAL: the database system is starting up")))
+	assert.True(t, isTransientPostgresState(errors.New("dial tcp 127.0.0.1:5432: connect: connection refused")))
+
+	// A real dump problem must not be retried, it will not fix itself.
+	assert.False(t, isTransientPostgresState(errors.New(`pg_dump: error: query failed: ERROR:  permission denied for table x`)))
+	assert.False(t, isTransientPostgresState(errors.New("no such pod")))
+}
+
+func TestDumpWithRetries(t *testing.T) {
+	service := Service{logger: slog.Default()}
+
+	t.Run("SucceedsOncePostgresFinishesRestarting", func(t *testing.T) {
+		attempts := 0
+		size, err := service.dumpWithRetries(context.Background(), func() (int64, error) {
+			attempts++
+			if attempts < 2 {
+				return 0, errors.New("FATAL: the database system is shutting down")
+			}
+			return 4096, nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, int64(4096), size)
+		assert.Equal(t, 2, attempts, "the first attempt hit the restart, the second succeeded")
+	})
+
+	t.Run("DoesNotRetryARealFailure", func(t *testing.T) {
+		attempts := 0
+		_, err := service.dumpWithRetries(context.Background(), func() (int64, error) {
+			attempts++
+			return 0, errors.New("pg_dump: error: permission denied for table dhis2_chart_seed_complete")
+		})
+
+		require.ErrorContains(t, err, "permission denied")
+		assert.Equal(t, 1, attempts, "a genuine dump error is reported immediately")
+	})
+
+	t.Run("StopsWhenTheContextIsCancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		attempts := 0
+		_, err := service.dumpWithRetries(ctx, func() (int64, error) {
+			attempts++
+			cancel()
+			return 0, errors.New("the database system is starting up")
+		})
+
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, attempts)
+	})
+}

--- a/pkg/database/service.go
+++ b/pkg/database/service.go
@@ -605,35 +605,44 @@ func (s Service) Dump(ctx context.Context, userId uint, database *model.Database
 	}
 	namespace := instance.Group.Namespace
 
-	pr, pw := io.Pipe()
-
 	key := fmt.Sprintf("%s/%s", group.Name, database.Name)
-
-	type uploadResult struct {
-		size int64
-		err  error
-	}
-	uploadDone := make(chan uploadResult, 1)
-	go func() {
-		defer pr.Close()
-		size, err := s.s3Client.StreamUpload(ctx, s.s3Bucket, key, "application/octet-stream", pr)
-		uploadDone <- uploadResult{size, err}
-	}()
 
 	s.logger.InfoContext(ctx, "starting pg_dump", "pod", podName, "container", container, "namespace", namespace, "command", strings.Join(redactPgPassword(command), " "))
 	publish("started", "", 0)
 
-	if err := execPgDump(ctx, client, namespace, podName, container, command, pw, format, database.Name); err != nil {
+	// One attempt of the whole pipeline: pg_dump in the pod writing into a pipe that is streamed to
+	// S3. Retried as a unit, since a failed attempt leaves a partial object behind that the next
+	// upload to the same key replaces.
+	attempt := func() (int64, error) {
+		pr, pw := io.Pipe()
+
+		type uploadResult struct {
+			size int64
+			err  error
+		}
+		uploadDone := make(chan uploadResult, 1)
+		go func() {
+			defer pr.Close()
+			size, err := s.s3Client.StreamUpload(ctx, s.s3Bucket, key, "application/octet-stream", pr)
+			uploadDone <- uploadResult{size, err}
+		}()
+
+		if err := execPgDump(ctx, client, namespace, podName, container, command, pw, format, database.Name); err != nil {
+			<-uploadDone
+			return 0, err
+		}
+
+		upload := <-uploadDone
+		return upload.size, upload.err
+	}
+
+	size, err := s.dumpWithRetries(ctx, attempt)
+	if err != nil {
 		s.logger.ErrorContext(ctx, "failed to exec pg_dump", "error", err)
-		<-uploadDone
 		publish("error", err.Error(), 0)
 		return nil, err
 	}
-
-	result := <-uploadDone
-	if result.err != nil {
-		return fail(result.err)
-	}
+	result := uploadOutcome{size: size}
 
 	saved, err := s.repository.FindById(ctx, database.ID)
 	if err != nil {
@@ -673,6 +682,58 @@ func execPgDump(ctx context.Context, executor PodExecutor, namespace, podName, c
 	}
 	pw.Close()
 	return nil
+}
+
+type uploadOutcome struct {
+	size int64
+}
+
+// transientPostgresStates are the messages postgres returns while it is not accepting connections
+// yet or no longer is. Bitnami's chart runs a temporary server to execute the initdb scripts, which
+// seeding uses, and stops it once they finish; a dump that lands in that transition sees one of
+// these. They say nothing about the database being unusable, only that it is mid-transition, so a
+// backup should wait rather than fail.
+var transientPostgresStates = []string{
+	"the database system is shutting down",
+	"the database system is starting up",
+	"the database system is in recovery mode",
+	"connection refused",
+}
+
+func isTransientPostgresState(err error) bool {
+	message := strings.ToLower(err.Error())
+	return slices.ContainsFunc(transientPostgresStates, func(state string) bool {
+		return strings.Contains(message, state)
+	})
+}
+
+const (
+	dumpRetryBudget   = 2 * time.Minute
+	dumpRetryInterval = 5 * time.Second
+)
+
+// dumpWithRetries retries the dump while postgres reports a transient state, so a save issued
+// moments after a deploy waits for seeding to finish instead of failing with the server's
+// mid-restart message. Any other error fails immediately: retrying a genuine dump error would only
+// delay the report.
+func (s Service) dumpWithRetries(ctx context.Context, attempt func() (int64, error)) (int64, error) {
+	deadline := time.Now().Add(dumpRetryBudget)
+	for {
+		size, err := attempt()
+		if err == nil {
+			return size, nil
+		}
+		if !isTransientPostgresState(err) || time.Now().After(deadline) {
+			return 0, err
+		}
+
+		s.logger.InfoContext(ctx, "postgres is mid-transition, retrying the dump", "error", err, "retryIn", dumpRetryInterval)
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(dumpRetryInterval):
+		}
+	}
 }
 
 func (s Service) logError(ctx context.Context, err error) {


### PR DESCRIPTION
SaveDatabase fails in CI regularly, and not because it is slow: the dump fails a third of a second after starting with pg_dump reporting that the database system is shutting down, after which the assertion waits out its whole window for an object that is never coming and reports only that a condition was never satisfied.

The reason is the seeding mechanism. seed.sh is mounted as the Bitnami chart initdb scripts, so on a fresh volume postgres is started temporarily to run them and stopped again once they finish. The readiness probe is pg_isready, which the temporary server answers, so the pod reports ready while it is still seeding. A dump landing in the stop and restart transition sees the message above. How wide that window is depends on how long seeding takes, which is why it fails often rather than always.

This is not only a test problem: a user who deploys, sees the instance go green and saves immediately hits the same window and gets the same cryptic failure. So the dump now retries while postgres reports a transient state, shutting down, starting up, in recovery or refusing connections, for up to two minutes, and fails immediately on anything else since a real dump error will not fix itself by waiting. The pipeline is retried as a unit because a failed attempt leaves a partial object that the next upload to the same key replaces.

Raising the timeout was the wrong instinct, and I already did that once in #1651.