### PR TITLE
test: bound how many heavy deployments run at once

### DIFF
--- a/pkg/instance/deployment_helper_test.go
+++ b/pkg/instance/deployment_helper_test.go
@@ -116,3 +116,19 @@ func updateDeployment(t *testing.T, client *inttest.HTTPClient, deploymentID uin
 
 	return updatedDeployment
 }
+
+/* heavyDeploys bounds how many subtests may hold a postgres or dhis2-core deployment at once. The
+ * runner cannot carry four postgres instances and two cores together: they schedule, then starve,
+ * fail their probes, restart, and every subtest waiting on readiness times out. Two runs of #1660
+ * failed that way with every postgres and core pod unready simultaneously while every lightweight
+ * pod stayed ready. FilestoreBackupFilesystemViaExec already opted out of the parallel batch for
+ * this reason; this bounds the rest instead of serialising them. */
+var heavyDeploys = make(chan struct{}, 2)
+
+// acquireHeavyDeploy blocks until this subtest may deploy postgres or dhis2-core, releasing the slot
+// once the subtest and its cleanup are done.
+func acquireHeavyDeploy(t *testing.T) {
+	t.Helper()
+	heavyDeploys <- struct{}{}
+	t.Cleanup(func() { <-heavyDeploys })
+}

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -260,6 +260,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("GetPublicDeployments", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 		privateDeployment := createDeployment(t, client, "private-deployment", tokens.AccessToken)
 		createDHIS2DBInstance(t, client, privateDeployment.ID, databaseID, tokens.AccessToken)
 		createDHIS2CoreInstance(t, client, privateDeployment.ID, tokens.AccessToken)
@@ -280,6 +281,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("DeploymentWithCompanionStack", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 		deployment := createDeployment(t, client, "companion-deployment", tokens.AccessToken, WithDescription("some description"))
 		deploymentInstance := createDHIS2DBInstance(t, client, deployment.ID, databaseID, tokens.AccessToken)
 		deploymentInstance = createMinioInstance(t, client, deployment.ID, tokens.AccessToken)
@@ -299,6 +301,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("FilestoreBackupMinioViaExec", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 
 		deployment := createDeployment(t, client, "fs-backup-deployment", tokens.AccessToken)
 		createDHIS2DBInstance(t, client, deployment.ID, databaseID, tokens.AccessToken)
@@ -390,6 +393,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("SaveAsDatabase", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 		deployment := createDeployment(t, client, "save-as-deployment", tokens.AccessToken)
 		dbInstance := createDHIS2DBInstance(t, client, deployment.ID, databaseID, tokens.AccessToken)
 
@@ -427,6 +431,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("SaveDatabase", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 
 		dbID := database.UploadTestDatabase(t, client, "save-test.sql.gz", "select now();", "group-name", inttest.WithAuthToken(tokens.AccessToken))
 
@@ -462,6 +467,7 @@ func TestInstanceHandler(t *testing.T) {
 
 	t.Run("UpdateDeploymentInstance", func(t *testing.T) {
 		t.Parallel()
+		acquireHeavyDeploy(t)
 		deployment := createDeployment(t, client, "test-deployment-instance-update", tokens.AccessToken, WithDescription("some description"))
 
 		createDHIS2DBInstance(t, client, deployment.ID, databaseID, tokens.AccessToken)


### PR DESCRIPTION
Three subtests fail together in CI, repeatedly and with the same signature: SaveDatabase, SaveAsDatabase and DeploymentWithCompanionStack time out waiting for a pod to become ready. The pod dump the assertion prints on timeout shows why. Every postgres and every dhis2-core pod is Running but not ready at the same moment, with postgres restart counts of two and three, while every lightweight pod, minio, coredns, traefik, metrics server, is ready. That is the runner out of headroom: the pods schedule, starve, fail their probes and restart.

DeploymentWithCompanionStack does not save anything, so this is not about the dump path, and no retry can rescue a pod that never becomes ready.

The suite runs thirteen subtests in parallel, four of which stand up postgres and two a dhis2-core that requests 1500Mi on its own. FilestoreBackupFilesystemViaExec already opted out of the parallel batch for exactly this reason; rather than serialising the rest, the six subtests that deploy postgres or core now take a slot from a semaphore of two, so peak load is bounded while the light subtests keep running freely. Suite wall time locally is unchanged at around five minutes.