### PR TITLE
fix: derive test user emails from an atomic counter increment

### DIFF
--- a/pkg/user/user_integration_test.go
+++ b/pkg/user/user_integration_test.go
@@ -607,9 +607,12 @@ type userCounter struct {
 	count atomic.Uint32
 }
 
-func (uc *userCounter) Increment() {
+// Increment reserves the next user number and returns it. The number has to come out of the same
+// atomic operation that produced it, because parallel subtests otherwise increment and then read
+// separately, and two of them can read the same count and derive the same email address.
+func (uc *userCounter) Increment() int {
 	uc.wg.Add(1)
-	uc.count.Add(1)
+	return int(uc.count.Add(1))
 }
 
 func (uc *userCounter) Done() {
@@ -627,9 +630,9 @@ func (uc *userCounter) Value() int {
 func createUser(t *testing.T, client *inttest.HTTPClient, userService *user.Service) (uint, string, string) {
 	t.Helper()
 
-	userCount.Increment()
+	number := userCount.Increment()
 	defer userCount.Done()
-	email := fmt.Sprintf("user%d@dhis2.org", userCount.Value())
+	email := fmt.Sprintf("user%d@dhis2.org", number)
 	password := uuid.NewString()
 	requestBody := jsonBody(`{"email": "%s", "password": "%s"}`, email, password)
 


### PR DESCRIPTION
`createUser` called `userCount.Increment()` and then `userCount.Value()` as two separate operations. Parallel subtests could each increment and then read the same count, build the same `user%d@dhis2.org` address, and the second `POST /users` would come back 409. The exact user count assertion in `AsAdmin` then failed too, because the user had been counted but never created.

`atomic.Uint32.Add` already returns the new value, so `Increment` now returns it and the caller uses that value rather than re-reading.

The race dates to #778 (2024-06-05) and only shows up under particular scheduling, which is why it has passed for over a year. It surfaced while working on #1660, where `pkg/user` failed on two consecutive runs having passed on the last five master runs.

Verified with 11 local runs of `TestUserHandler` under `-race`: no email collisions. Some local runs failed on `failed to start DB`, which is testcontainer startup on a saturated Docker daemon rather than this race.