### PR TITLE
test: bound the heap of every core the integration tests deploy

### DIFF
--- a/pkg/instance/instance_helper_test.go
+++ b/pkg/instance/instance_helper_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -124,8 +125,45 @@ func createMinioInstance(t *testing.T, client *inttest.HTTPClient, deploymentID 
 	return createInstance(t, client, deploymentID, "minio", authToken, opts...)
 }
 
+// A core with no -Xmx finds no cgroup limit, since the chart sets a memory request and no limit, and
+// takes a quarter of whatever /proc/meminfo reports, which inside the k3s container is the runner.
+const (
+	testCoreJavaOpts = "-Xmx1g"
+	// The same bound in bytes, as the JVM reports MaxHeapSize.
+	testCoreMaxHeapSize = int64(1) << 30
+)
+
 func createDHIS2CoreInstance(t *testing.T, client *inttest.HTTPClient, deploymentID uint, authToken string, opts ...InstanceOption) model.DeploymentInstance {
+	// Prepended, so a caller that wants a different heap can still override it.
+	opts = append([]InstanceOption{WithParameter("JAVA_OPTS", testCoreJavaOpts)}, opts...)
 	return createInstance(t, client, deploymentID, "dhis2-core", authToken, opts...)
+}
+
+// podExecer is the part of the kubernetes service these helpers need.
+type podExecer interface {
+	Exec(ctx context.Context, namespace, podName, container string, command []string, stdout, stderr io.Writer) error
+}
+
+// assertCoreHeapBounded reads the ceiling a throwaway JVM in the core container is given. The chart
+// appends javaOpts to JAVA_TOOL_OPTIONS, which every JVM there honours and none shows on its command
+// line, so this is the readable surface; {command line} rather than {ergonomic} is what distinguishes
+// a bound that was set from one the JVM derived from the node.
+func assertCoreHeapBounded(t *testing.T, executor podExecer, namespace, pod, container string, expected int64) {
+	t.Helper()
+
+	var flags, stderr strings.Builder
+	require.NoError(t, executor.Exec(context.Background(), namespace, pod, container,
+		[]string{"sh", "-c", `java -XX:+PrintFlagsFinal -version 2>/dev/null | grep MaxHeapSize`}, &flags, &stderr),
+		"reading the core's heap ceiling failed: %s", stderr.String())
+
+	line := strings.TrimSpace(flags.String())
+	fields := strings.Fields(line)
+	require.GreaterOrEqual(t, len(fields), 4, "unexpected MaxHeapSize line: %q", line)
+	actual, err := strconv.ParseInt(fields[3], 10, 64)
+	require.NoError(t, err, "unexpected MaxHeapSize line: %q", line)
+
+	assert.Equal(t, expected, actual, "the core's heap is not bounded to %s: %q", testCoreJavaOpts, line)
+	assert.Contains(t, line, "{command line}", "the core's heap ceiling came from the node, not from %s: %q", testCoreJavaOpts, line)
 }
 
 // minioPodName returns the name of the deployment's single minio pod.

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -304,6 +304,9 @@ func TestInstanceHandler(t *testing.T) {
 		ks, err := instance.NewKubernetesService(group.Cluster)
 		require.NoError(t, err)
 		corePod, coreContainer := waitForCorePodRunning(t, k8sClient, coreInstance.Group.Namespace, coreInstance.ID, 120*time.Second)
+
+		assertCoreHeapBounded(t, ks, coreInstance.Group.Namespace, corePod, coreContainer, testCoreMaxHeapSize)
+
 		seedScript := `mkdir -p /opt/dhis2/files/seeded && printf 'hello-filestore' > /opt/dhis2/files/seeded/marker.txt`
 		var seedOut, seedErr strings.Builder
 		require.NoError(t, ks.Exec(context.Background(), coreInstance.Group.Namespace, corePod, coreContainer, []string{"sh", "-c", seedScript}, &seedOut, &seedErr), "seed failed: %s", seedErr.String())


### PR DESCRIPTION
`TestInstanceHandler` loses processes to the OOM killer, and the symptom lands wherever it likes: `FilestoreBackupMinioViaExec` failed with `backup failed: command terminated with exit code 137` while backing up a single 15-byte object, and an earlier run failed two unrelated `UpdateDeploymentInstance*` subtests in 0.03s each.

Nothing in a deployed core bounds its memory. The stack's `JAVA_OPTS` default is a single space, so no `-Xmx` is ever passed, and the chart sets `resources.requests.memory` with no limit. The JVM therefore finds no cgroup limit and applies `MaxRAMPercentage`, a quarter of whatever `/proc/meminfo` reports, which inside the gnomock k3s container is the whole runner. On a live core pod, where the same absence of limits applies, that is:

```
MaxHeapSize = 8216641536   # 7.65 GiB, 25% of a ~30 GB node
```

`createDHIS2CoreInstance` now passes `-Xmx1g`, prepended so a caller can still override it, which bounds every core the suite deploys in one place.

The bound is asserted rather than assumed, and the first run of this PR earned that: the assertion originally read `/proc/1/cmdline`, on the assumption that catalina expands `JAVA_OPTS` onto the java command line. It failed, while reporting a 1 GiB ceiling sourced from `{command line}` on the very next line. The chart appends `javaOpts` to `JAVA_TOOL_OPTIONS`:

```
- name: JAVA_TOOL_OPTIONS
  value: >-
    -Djava.io.tmpdir=/tmp/dhis ... -Xmx1g
```

Every JVM in the container honours that, and none of them shows it on argv, so a throwaway JVM's flags are the readable surface. The assertion now checks both the value and that it came from `{command line}` rather than `{ergonomic}`, which is what separates a bound that was set from one derived from the node.

It runs in `FilestoreBackupFilesystemViaExec`, which already has a running core pod, so it costs one exec rather than another deploy.

Whether it clears the flake is for CI to say, since the failure rate is roughly one run in three.

#1676 should land first: five of the last seven master failures were the Deploy step, not the tests.