### PR TITLE
fix: stop deduplicating notification stream events

### DIFF
--- a/pkg/notification/publisher.go
+++ b/pkg/notification/publisher.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
@@ -19,7 +18,6 @@ type Publisher struct {
 	logger     *slog.Logger
 	producer   *ha.ReliableProducer
 	repository *repository
-	counter    atomic.Int64
 }
 
 func NewPublisher(logger *slog.Logger, env *stream.Environment, streamName string, repo *repository) (*Publisher, error) {
@@ -29,8 +27,12 @@ func NewPublisher(logger *slog.Logger, env *stream.Environment, streamName strin
 	}
 
 	producerName := "notification-publisher"
+	// Deliberately not SetProducerName: a named producer is a deduplication reference, and RabbitMQ
+	// then silently drops (while still confirming) every message whose publishing id it has already
+	// seen for that name. Publishing ids come from a counter that restarts at zero with the process,
+	// so after a restart every event up to the stream's high water mark was discarded. This producer
+	// wants each event appended, not deduplicated. SetClientProvidedName only labels the connection.
 	opts := stream.NewProducerOptions().
-		SetProducerName(producerName).
 		SetClientProvidedName(producerName).
 		SetFilter(stream.NewProducerFilter(func(msg message.StreamMessage) string {
 			return fmt.Sprintf("%s", msg.GetApplicationProperties()["group"])
@@ -74,7 +76,6 @@ func (p *Publisher) Publish(ctx context.Context, userID uint, groupName, kind st
 	}
 
 	msg := amqp.NewMessage(data)
-	msg.SetPublishingId(p.counter.Add(1))
 	msg.ApplicationProperties = map[string]any{
 		"group": groupName,
 		"owner": strconv.FormatUint(uint64(userID), 10),


### PR DESCRIPTION
No SSE client received events after an im-manager restart. The stream producer was named via SetProducerName, which makes it a RabbitMQ stream deduplication reference, and it set publishing ids from an atomic counter that starts at zero with the process. RabbitMQ silently discards any message whose publishing id it has already seen for that reference, while still confirming it, so after every restart all events up to the stream's high water mark were thrown away.

Measured on the version-3-0 feature environment: rabbitmq-streams list_stream_publishers reported messages_published 5, messages_confirmed 5, messages_errored 0, while rabbitmqctl list_queues showed the stream stuck at 210 messages. After the fix the same test appended 5 messages and the events arrived live.

Dropping only SetPublishingId would not have been enough, the client's own producer.sequence also starts at zero and is never seeded from the broker. This producer wants every event appended rather than deduplicated, so the reference is gone. SetClientProvidedName is kept, it only labels the connection for observability.

Affects every event kind, database-save and filestore-backup included, so this is not specific to version-3.0.