### PR TITLE
fix: stream events for every group a user can read

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -111,6 +111,13 @@ func run() (err error) {
 	enablePrettyPrint := exists && prettyPrint == "true"
 
 	options := log.PrettyJSONHandlerOptions{PrettyPrint: enablePrettyPrint}
+	if level, exists := os.LookupEnv("LOG_LEVEL"); exists {
+		var parsed slog.Level
+		if err := parsed.UnmarshalText([]byte(level)); err != nil {
+			return fmt.Errorf("invalid LOG_LEVEL %q: %v", level, err)
+		}
+		options.Level = parsed
+	}
 	logger := slog.New(log.New(log.NewPrettyJSONHandler(os.Stdout, &options)))
 
 	db, err := newDB(logger)
@@ -188,7 +195,7 @@ func run() (err error) {
 		return err
 	}
 
-	kubeClients := kube.NewClients()
+	kubeClients := kube.NewClients(logger)
 	instanceService, err := newInstanceService(logger, db, stackService, groupService, s3Client, kubeClients)
 	if err != nil {
 		return err

--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -234,7 +234,7 @@ func run() (err error) {
 		return err
 	}
 
-	eventHandler := event.NewHandler(logger, streamEnv, streamName)
+	eventHandler := event.NewHandler(logger, streamEnv, streamName, groupService)
 
 	_, err = createDefaultCluster(ctx, clusterService)
 	if err != nil {

--- a/pkg/event/event_integration_test.go
+++ b/pkg/event/event_integration_test.go
@@ -26,6 +26,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ownGroups scopes the stream to the groups the user belongs to, which is what these tests assert
+// on. The real group service widens that to every group for an administrator.
+type ownGroups struct{}
+
+func (ownGroups) FindAll(_ context.Context, user *model.User, _ bool) ([]model.Group, error) {
+	groups := append([]model.Group{}, user.Groups...)
+	return append(groups, user.AdminGroups...), nil
+}
+
 func TestEventHandler(t *testing.T) {
 	t.Parallel()
 
@@ -94,7 +103,7 @@ func TestEventHandler(t *testing.T) {
 		require.FailNow(t, "provide query param user=userID in the test")
 	}
 	client := inttest.SetupHTTPServer(t, func(engine *gin.Engine) {
-		eventHandler := event.NewHandler(logger, rabbitmq.Environment, streamName)
+		eventHandler := event.NewHandler(logger, rabbitmq.Environment, streamName, ownGroups{})
 		event.Routes(engine, authenticator, eventHandler)
 	})
 

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -22,18 +22,27 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func NewHandler(logger *slog.Logger, env *stream.Environment, streamName string) Handler {
+func NewHandler(logger *slog.Logger, env *stream.Environment, streamName string, groups groupService) Handler {
 	return Handler{
 		logger:     logger,
 		env:        env,
 		streamName: streamName,
+		groups:     groups,
 	}
+}
+
+// groupService resolves the groups a user may receive events for. FindAll already encodes the same
+// rule the deployment read authorization uses: every group for an administrator, and the user's own
+// plus group-administered ones for everybody else.
+type groupService interface {
+	FindAll(ctx context.Context, user *model.User, deployable bool) ([]model.Group, error)
 }
 
 type Handler struct {
 	logger     *slog.Logger
 	env        *stream.Environment
 	streamName string
+	groups     groupService
 }
 
 func (h Handler) StreamEvents(c *gin.Context) {
@@ -59,7 +68,12 @@ func (h Handler) StreamEvents(c *gin.Context) {
 		return
 	}
 
-	userGroups := mapUserGroups(user)
+	userGroups, err := h.streamableGroups(ctx, user)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "Failed to resolve the groups to stream events for", "error", err, "userId", user.ID)
+		_ = c.Error(err)
+		return
+	}
 	if len(userGroups) == 0 {
 		_ = c.Error(errdef.NewForbidden("you cannot stream events as you are not part of a group. Ask an administrator for help."))
 		return
@@ -77,7 +91,8 @@ func (h Handler) StreamEvents(c *gin.Context) {
 	logger := h.logger.
 		With("consumerName", consumerName).
 		With("consumerOffsetSpec", offsetSpec.String()).
-		With("sseRetry", retry)
+		With("sseRetry", retry).
+		With("groups", maps.Keys(userGroups))
 
 	filter := stream.NewConsumerFilter(maps.Keys(userGroups), false, postFilter(ctx, logger, user.ID, userGroups))
 	opts := stream.NewConsumerOptions().
@@ -153,12 +168,21 @@ func computeRetry() uint {
 	return base + rand.UintN(maxJitter) //nolint:gosec
 }
 
-func mapUserGroups(user *model.User) map[string]struct{} {
-	result := make(map[string]struct{}, len(user.Groups))
-	for _, group := range user.Groups {
+// streamableGroups returns the groups whose events the user may receive. It has to match what the
+// deployment endpoints let the user read, otherwise a user who can load a deployment and operate on
+// it never receives its events. That is what happens to an administrator, who is authorized for
+// every deployment but is a member of the administrators group only.
+func (h Handler) streamableGroups(ctx context.Context, user *model.User) (map[string]struct{}, error) {
+	groups, err := h.groups.FindAll(ctx, user, false)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
 		result[group.Name] = struct{}{}
 	}
-	return result
+	return result, nil
 }
 
 // postFilter is a RabbitMQ stream post filter that is applied client side. This is necessary as the

--- a/pkg/instance/componentStatusWatcher.go
+++ b/pkg/instance/componentStatusWatcher.go
@@ -97,6 +97,7 @@ func (w *ComponentStatusWatcher) publish(pod *v1.Pod, deleted bool) {
 	component := pod.Labels["im-type"]
 	instanceID, err := strconv.ParseUint(pod.Labels["im-id"], 10, strconv.IntSize)
 	if component == "" || err != nil {
+		w.logger.Debug("Skipping component status for pod without usable im labels", "pod", pod.Name, "imType", component, "imId", pod.Labels["im-id"])
 		return
 	}
 
@@ -115,4 +116,5 @@ func (w *ComponentStatusWatcher) publish(pod *v1.Pod, deleted bool) {
 		Replica:      kube.NewReplica(*pod),
 		Deleted:      deleted,
 	})
+	w.logger.DebugContext(ctx, "Published component status", "group", instance.GroupName, "deploymentId", instance.DeploymentID, "instanceId", instance.ID, "component", component, "pod", pod.Name, "deleted", deleted)
 }

--- a/pkg/instance/deployment_destroy_test.go
+++ b/pkg/instance/deployment_destroy_test.go
@@ -67,7 +67,7 @@ func TestDeleteDeploymentPreservesInstanceRecordWhenDestroyFails(t *testing.T) {
 	require.NoError(t, instanceRepo.SaveDeployment(context.Background(), deployment))
 
 	stackService := stack.NewService(stack.Stacks{"whoami-go": stack.WhoamiGo})
-	service := NewService(logger, instanceRepo, stubGroupService{group: &group}, stackService, failingDestroyHelmfile{failStack: "whoami-go"}, nil, "", kube.NewClients())
+	service := NewService(logger, instanceRepo, stubGroupService{group: &group}, stackService, failingDestroyHelmfile{failStack: "whoami-go"}, nil, "", kube.NewClients(slog.Default()))
 
 	err = service.DeleteDeployment(context.Background(), deployment)
 	require.Error(t, err)

--- a/pkg/instance/instance_integration_test.go
+++ b/pkg/instance/instance_integration_test.go
@@ -118,7 +118,7 @@ func TestInstanceHandler(t *testing.T) {
 	// blew through the previous 100 seconds.
 	tokenService, err := token.NewService(logger, tokenRepository, privateKey, 3600, 60, "secret", 3600, 3600)
 	require.NoError(t, err, "failed to create token service")
-	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, nil, "", kube.NewClients())
+	instanceService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, nil, "", kube.NewClients(slog.Default()))
 
 	s3Dir := t.TempDir()
 	s3Bucket := "database-bucket"
@@ -327,7 +327,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.NoError(t, db.Create(target).Error)
 
 		// The shared instanceService is wired with a nil S3 client; build one with the real client.
-		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients())
+		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients(slog.Default()))
 		// minio can briefly refuse connections right after its pod reports ready (the server
 		// restarts during first-run setup), so retry until it is serving. FilestoreBackup returns
 		// before recording anything when the mirror fails, so retries are side-effect free.
@@ -374,7 +374,7 @@ func TestInstanceHandler(t *testing.T) {
 		require.NoError(t, db.Create(target).Error)
 
 		// The shared instanceService is wired with a nil S3 client; build one with the real client.
-		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients())
+		fsService := instance.NewService(logger, instanceRepo, groupService, stackService, helmfileService, s3Client, s3Bucket, kube.NewClients(slog.Default()))
 		require.NoError(t, fsService.FilestoreBackup(context.Background(), &coreInstance, target.Name, target))
 
 		content := s3.GetObject(t, s3Bucket, "group-name/fsstore-backup-target-fs.tar.gz")

--- a/pkg/instance/service_test.go
+++ b/pkg/instance/service_test.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/dhis2-sre/im-manager/pkg/kube"
@@ -26,7 +27,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		instance := &model.DeploymentInstance{
 			StackName: "stack",
 			Parameters: map[string]model.DeploymentInstanceParameter{
@@ -51,7 +52,7 @@ func TestResolveParameters(t *testing.T) {
 			"name-a": s,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -89,7 +90,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-a": stackA,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -151,7 +152,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-b": stackB,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -190,7 +191,7 @@ func TestResolveParameters(t *testing.T) {
 			"stack-b": stackB,
 		}
 		stackService := stack.NewService(stacks)
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{
@@ -252,7 +253,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("ResolvedFromAnyProvidingStack", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
 				{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{"HOST": {ParameterName: "HOST", Value: "db.svc"}}},
@@ -269,7 +270,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("MissingProvider", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		instances := []*model.DeploymentInstance{
 			{StackName: "consumer", Parameters: map[string]model.DeploymentInstanceParameter{}},
 		}
@@ -281,7 +282,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 
 	t.Run("AmbiguousProviders", func(t *testing.T) {
 		stackService := stack.NewService(stack.Stacks{"consumer": consumer, "provider": provider, "other-provider": otherProvider})
-		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stackService, nil, nil, "", kube.NewClients(slog.Default()))
 		instances := []*model.DeploymentInstance{
 			{StackName: "provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
 			{StackName: "other-provider", Parameters: map[string]model.DeploymentInstanceParameter{}},
@@ -296,7 +297,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 	t.Run("PgAdminComposesWithDhis2V2", func(t *testing.T) {
 		stacks, err := stack.New(stack.All...)
 		require.NoError(t, err)
-		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients(slog.Default()))
 		group := &model.Group{Name: "group", Namespace: "namespace"}
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{
@@ -319,7 +320,7 @@ func TestProviderBasedRequirements(t *testing.T) {
 	t.Run("PgAdminComposesWithDhis2DB", func(t *testing.T) {
 		stacks, err := stack.New(stack.All...)
 		require.NoError(t, err)
-		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients())
+		service := NewService(nil, nil, nil, stack.NewService(stacks), nil, nil, "", kube.NewClients(slog.Default()))
 		group := &model.Group{Name: "group", Namespace: "namespace"}
 		deployment := &model.Deployment{
 			Instances: []*model.DeploymentInstance{

--- a/pkg/kube/cache.go
+++ b/pkg/kube/cache.go
@@ -2,7 +2,9 @@ package kube
 
 import (
 	"cmp"
+	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,22 +31,52 @@ type podCache struct {
 	lister   corelisters.PodLister
 	synced   cache.InformerSynced
 	stop     chan struct{}
+	logger   *slog.Logger
 }
 
-func newPodCache(clientset kubernetes.Interface) *podCache {
+func newPodCache(logger *slog.Logger, clientset kubernetes.Interface) *podCache {
 	factory := informers.NewSharedInformerFactoryWithOptions(clientset, cacheResyncPeriod,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = "im-id"
 		}))
 	informer := factory.Core().V1().Pods()
 	stop := make(chan struct{})
-	c := &podCache{informer: informer.Informer(), lister: informer.Lister(), synced: informer.Informer().HasSynced, stop: stop}
+	c := &podCache{informer: informer.Informer(), lister: informer.Lister(), synced: informer.Informer().HasSynced, stop: stop, logger: logger}
+
+	// Has to be installed before the informer runs. Without it a rejected or broken watch is only
+	// reported through klog, which this service does not wire into slog, so the cache would go
+	// quiet and readers would silently fall back to listing the API server.
+	if err := c.informer.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		logger.Error("Pod informer watch failed, component status pushes stop until it recovers", "error", err)
+	}); err != nil {
+		logger.Error("Failed to install the pod informer watch error handler", "error", err)
+	}
+
+	logger.Info("Starting pod informer cache")
 	factory.Start(stop)
+
+	go func() {
+		if !cache.WaitForCacheSync(stop, c.synced) {
+			logger.Warn("Pod informer cache stopped before it finished syncing")
+			return
+		}
+		logger.Info("Pod informer cache synced", "pods", len(c.informer.GetStore().List()))
+	}()
+
 	return c
 }
 
 func (p *podCache) ready() bool {
 	return p != nil && p.synced()
+}
+
+// logNotReady records that a read is going to the API server rather than the cache. A nil cache is
+// a client that was not built through Clients, which is the normal case in tests.
+func (p *podCache) logNotReady(ctx context.Context) {
+	if p == nil {
+		return
+	}
+	p.logger.DebugContext(ctx, "Pod cache is not synced, listing from the API server instead")
 }
 
 // list returns the cached pods matching the selector, sorted by name to mirror the API server's

--- a/pkg/kube/cache_test.go
+++ b/pkg/kube/cache_test.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestPodCacheServesListPods(t *testing.T) {
 		imPod("db-b", "ns2", map[string]string{"im-type": "db"}),
 		imPod("web-a", "ns1", map[string]string{"im-type": "web"}),
 	)
-	cache := newPodCache(clientset)
+	cache := newPodCache(slog.Default(), clientset)
 	defer cache.close()
 	waitSynced(t, cache)
 
@@ -47,7 +48,7 @@ func TestPodCacheServesListPods(t *testing.T) {
 
 func TestPodCacheSeesUpdates(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	cache := newPodCache(clientset)
+	cache := newPodCache(slog.Default(), clientset)
 	defer cache.close()
 	waitSynced(t, cache)
 

--- a/pkg/kube/clients.go
+++ b/pkg/kube/clients.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/dhis2-sre/im-manager/pkg/model"
@@ -14,6 +15,7 @@ import (
 // cached client without any explicit hook.
 type Clients struct {
 	mu          sync.Mutex
+	logger      *slog.Logger
 	byCluster   map[string]*Client
 	build       func(model.Cluster) (*Client, error)
 	podHandlers []cache.ResourceEventHandler
@@ -35,8 +37,8 @@ func (c *Clients) RegisterPodHandler(handler cache.ResourceEventHandler) {
 	}
 }
 
-func NewClients() *Clients {
-	return &Clients{byCluster: map[string]*Client{}, build: NewClient}
+func NewClients(logger *slog.Logger) *Clients {
+	return &Clients{logger: logger, byCluster: map[string]*Client{}, build: NewClient}
 }
 
 // For returns the cached client for the cluster, building it on first use.
@@ -55,7 +57,7 @@ func (c *Clients) For(cluster model.Cluster) (*Client, error) {
 		return nil, err
 	}
 	if client.Clientset != nil {
-		client.pods = newPodCache(client.Clientset)
+		client.pods = newPodCache(c.logger.With("clusterId", cluster.ID, "clusterName", cluster.Name, "clusterHost", restHost(client)), client.Clientset)
 		for _, handler := range c.podHandlers {
 			if err := client.pods.addHandler(handler); err != nil {
 				return nil, fmt.Errorf("failed to register pod event handler: %v", err)
@@ -76,5 +78,15 @@ func (c *Clients) For(cluster model.Cluster) (*Client, error) {
 	}
 
 	c.byCluster[key] = client
+	c.logger.Info("Built kube client", "clusterId", cluster.ID, "clusterName", cluster.Name, "clusterHost", restHost(client), "podHandlers", len(c.podHandlers))
 	return client, nil
+}
+
+// restHost identifies which API server a client and its cache belong to. A group can carry a
+// zero-value cluster, and then the id and name say nothing about where pods are really watched.
+func restHost(client *Client) string {
+	if client.RestConfig == nil {
+		return ""
+	}
+	return client.RestConfig.Host
 }

--- a/pkg/kube/clients_test.go
+++ b/pkg/kube/clients_test.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 
 func TestClientsCachePerCluster(t *testing.T) {
 	builds := 0
-	clients := NewClients()
+	clients := NewClients(slog.Default())
 	clients.build = func(cluster model.Cluster) (*Client, error) {
 		builds++
 		return &Client{Clientset: fake.NewSimpleClientset()}, nil

--- a/pkg/kube/pods.go
+++ b/pkg/kube/pods.go
@@ -93,6 +93,9 @@ func (c *Client) ListPods(ctx context.Context, namespace, selector string) ([]v1
 		if err == nil {
 			return dropEvicted(pods), nil
 		}
+		c.pods.logger.WarnContext(ctx, "Pod cache list failed, listing from the API server instead", "selector", selector, "error", err)
+	} else {
+		c.pods.logNotReady(ctx)
 	}
 
 	pods, err := c.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})


### PR DESCRIPTION
Restarting a component never updated the component list, only the manual refresh button did. Two causes, this is the second one, the first is the deduplication fix in #1683 which has to land for any of this to be visible.

The event stream built its group filter from user.Groups alone, while CanReadDeployment and CanWriteDeployment both have an administrator bypass. Resolving the groups through the group service instead reuses the rule the read authorization already applies. Effect per role: an administrator now receives events for every group instead of only the administrators group, a group administrator now receives events for the groups they administer instead of nothing, and an ordinary member is unchanged since user.Groups is what they already got. So an ordinary member was never affected by this particular bug, for them the missing updates were entirely #1683.

The call passes deployable false, which for component status makes no practical difference either way, since an instance can only be deployed into a deployable group and every seeded group is created deployable. It is passed false because event visibility should follow what a user can read rather than whether a group can host instances, which are different questions. It only shows up for a manually created non deployable group holding databases, as database-save and filestore-backup publish on the database's group and nothing outside the deploy path checks Deployable.

The non administrator path stays in memory off the already loaded user, so there is no extra query per connection, while an administrator costs one group query when the stream opens.

The second commit is the observability that made this findable. The pod informer cache had no logging, so a rejected watch was only visible through klog, which is not wired into slog, and readers quietly fell back to live LISTs while the endpoint kept returning correct data. It now logs cache start and sync, installs a watch error handler, and records which API server a client belongs to. LOG_LEVEL is honoured too, without it slog defaulted to info and every debug line in the service was dead code.

Verified on the version-3-0 feature environment. Before, an admin stream subscribed to groups administrators only and received nothing across a restart. After, it subscribes to administrators and whoami and a restart delivers the full sequence, Pending then Running then Running ready for the new replica plus Failed and deleted for the old one.